### PR TITLE
Wire DOCR publish flow and align deploy docs

### DIFF
--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -1,0 +1,100 @@
+name: Publish Docker Image to DOCR
+
+on:
+  push:
+    branches: [deploy]
+  workflow_dispatch:
+
+env:
+  REGISTRY: registry.digitalocean.com/infinit-track
+  IMAGE_NAME: infinit-track-backend
+
+concurrency:
+  group: docker-deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    name: Lint, Test, Build, and Push
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Enforce deploy branch for manual runs
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if [ "${GITHUB_REF_NAME}" != "deploy" ]; then
+            echo "This workflow may only publish from the deploy branch."
+            exit 1
+          fi
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run linter
+        run: npm run lint
+
+      - name: Run tests
+        run: npm test
+        env:
+          NODE_ENV: test
+          JWT_SECRET: test_secret_ci
+          DB_HOST: localhost
+          DB_NAME: test_db
+          DB_USER: test_user
+          DB_PASS: test_pass
+
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - name: Log in to DOCR
+        run: doctl registries login --expiry-seconds 1200
+
+      - name: Set image tags
+        id: meta
+        run: |
+          echo "sha_tag=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+          echo "latest_tag=deploy-latest" >> "$GITHUB_OUTPUT"
+          echo "image_uri=${REGISTRY}/${IMAGE_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ steps.meta.outputs.image_uri }}:${{ steps.meta.outputs.sha_tag }}
+            ${{ steps.meta.outputs.image_uri }}:${{ steps.meta.outputs.latest_tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Verify repository tags
+        run: doctl registry repository list-tags infinit-track infinit-track-backend
+
+      - name: Publish summary
+        run: |
+          echo "## DOCR Publish Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Registry: infinit-track" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Repository: infinit-track-backend" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Branch: ${GITHUB_REF_NAME}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- SHA tag: ${GITHUB_SHA}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Rolling tag: deploy-latest" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Image URI: registry.digitalocean.com/infinit-track/infinit-track-backend" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Non-goals:" >> "$GITHUB_STEP_SUMMARY"
+          echo "- No Droplet deploy performed" >> "$GITHUB_STEP_SUMMARY"
+          echo "- docker-compose.yml still uses build-based runtime" >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,10 @@ coverage/
 # Temporary files
 *.tmp
 *.temp
-docs/
+docs/*
+!docs/openapi.yaml
+!docs/GITHUB_ACTIONS_SETUP.md
+!docs/PRODUCTION_DEPLOYMENT.md
 .blackboxrules
 
 /memory-bank

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,7 @@ WORKDIR /app
 
 COPY package.json package-lock.json ./
 RUN npm ci --only=production && \
-    cp -R node_modules /prod_modules && \
-    npm ci
+    cp -R node_modules /prod_modules
 
 # Stage 2: Production image
 FROM node:18-alpine AS production

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+# Stage 1: Install dependencies
+FROM node:18-alpine AS deps
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci --only=production && \
+    cp -R node_modules /prod_modules && \
+    npm ci
+
+# Stage 2: Production image
+FROM node:18-alpine AS production
+
+RUN apk add --no-cache dumb-init tzdata && \
+    cp /usr/share/zoneinfo/Asia/Jakarta /etc/localtime && \
+    echo "Asia/Jakarta" > /etc/timezone && \
+    apk del tzdata
+
+ENV NODE_ENV=production \
+    TZ=Asia/Jakarta \
+    PORT=3000
+
+WORKDIR /app
+
+COPY --from=deps /prod_modules ./node_modules
+COPY package.json .sequelizerc ./
+COPY src/ ./src/
+COPY scripts/ ./scripts/
+COPY docs/openapi.yaml ./docs/openapi.yaml
+
+RUN mkdir -p logs && chown -R node:node /app
+
+USER node
+
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+    CMD wget --no-verbose --tries=1 --spider http://localhost:3000/health || exit 1
+
+ENTRYPOINT ["dumb-init", "node", "src/server.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,52 @@
+services:
+  db:
+    image: mysql:8.0
+    container_name: infinit-track-db
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${DB_NAME}
+      MYSQL_USER: ${DB_USER}
+      MYSQL_PASSWORD: ${DB_PASS}
+      TZ: Asia/Jakarta
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: infinit-track-app
+    restart: unless-stopped
+    ports:
+      - "${PORT:-3000}:3000"
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      NODE_ENV: production
+      PORT: 3000
+      DB_HOST: db
+      DB_USER: ${DB_USER}
+      DB_PASS: ${DB_PASS}
+      DB_NAME: ${DB_NAME}
+      JWT_SECRET: ${JWT_SECRET}
+      TZ: Asia/Jakarta
+      CLOUDINARY_CLOUD_NAME: ${CLOUDINARY_CLOUD_NAME:-}
+      CLOUDINARY_API_KEY: ${CLOUDINARY_API_KEY:-}
+      CLOUDINARY_API_SECRET: ${CLOUDINARY_API_SECRET:-}
+      GEOAPIFY_API_KEY: ${GEOAPIFY_API_KEY:-}
+    volumes:
+      - app_logs:/app/logs
+
+volumes:
+  mysql_data:
+  app_logs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     container_name: infinit-track-db
     restart: unless-stopped
     environment:
-      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
+      MYSQL_ROOT_PASSWORD: ${DB_PASS}
       MYSQL_DATABASE: ${DB_NAME}
       MYSQL_USER: ${DB_USER}
       MYSQL_PASSWORD: ${DB_PASS}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,6 @@ services:
       MYSQL_USER: ${DB_USER}
       MYSQL_PASSWORD: ${DB_PASS}
       TZ: Asia/Jakarta
-    ports:
-      - "3306:3306"
     volumes:
       - mysql_data:/var/lib/mysql
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     volumes:
       - mysql_data:/var/lib/mysql
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      test: ["CMD-SHELL", "mysqladmin ping -h localhost -u root -p\"$$MYSQL_ROOT_PASSWORD\""]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docs/GITHUB_ACTIONS_SETUP.md
+++ b/docs/GITHUB_ACTIONS_SETUP.md
@@ -1,0 +1,53 @@
+# 🔄 GitHub Actions Setup Guide
+
+## Overview
+
+Guide untuk setup GitHub Actions backend sesuai source of truth saat ini:
+
+- `.github/workflows/ci.yml` = validation gate (lint + test)
+- `.github/workflows/docker-deploy.yml` = build and publish Docker image ke **DigitalOcean Container Registry (DOCR)**
+- active backend runtime target = **Droplet + Docker Compose**
+- App Platform = **historical / obsolete path**
+- Kubernetes = **optional / non-active path**
+
+## 🎯 Workflow Overview
+
+### 1. CI Validation (`ci.yml`)
+- **Trigger:** push + pull_request
+- **Purpose:** lint and test backend code
+- **Output:** verification signal only
+
+### 2. DOCR Publish (`docker-deploy.yml`)
+- **Trigger:** push to `deploy` branch + manual dispatch
+- **Purpose:** build backend Docker image and push it to DOCR
+- **Output:** image tags in `registry.digitalocean.com/infinit-track/infinit-track-backend`
+- **Guardrail:** manual dispatch is still enforced to publish only from branch `deploy`
+
+### Current non-goals
+- GitHub Actions does **not** deploy backend runtime directly to the droplet yet.
+- Docker Compose on the droplet still uses the current build-based path until runtime contract is switched intentionally.
+
+## Required Secrets
+
+### Repository Secrets
+
+1. `DIGITALOCEAN_ACCESS_TOKEN`
+   - Used by: DOCR publish workflow
+   - Needed for: `doctl registries login`
+
+### No longer active for backend deploy truth
+These may still exist historically, but are not part of the active backend image publication path:
+
+- `DO_APP_ID_STAGING`
+- `DO_APP_ID_PRODUCTION`
+- `DOCKERHUB_USERNAME`
+- `DOCKERHUB_TOKEN`
+- `KUBECONFIG`
+
+## Branch Contract
+
+- `develop`: normal integration work
+- `master`: final release-ready branch
+- `deploy`: image publication branch for DOCR review/testing
+
+Current image publication workflow is intentionally bound to `deploy` so release artifacts can be reviewed without coupling normal development pushes to image publication.

--- a/docs/PRODUCTION_DEPLOYMENT.md
+++ b/docs/PRODUCTION_DEPLOYMENT.md
@@ -1,0 +1,85 @@
+# 🚀 Production Deployment Guide
+
+## Overview
+
+Panduan deployment backend untuk fase saat ini, dengan source of truth yang selaras ke target runtime aktif.
+
+## Current Deployment Truth
+
+Backend deployment truth for the current phase is:
+
+- active runtime target = **Droplet + Docker Compose**
+- image publication path = **DigitalOcean Container Registry (DOCR)**
+- App Platform = **obsolete / historical path**
+- Kubernetes = **optional / non-active path**
+
+This document should not be used to justify new App Platform deployment work unless that direction is intentionally reactivated later.
+
+## Current Deployment Model
+
+### Phase 1: Publish image to DOCR
+- GitHub Actions publishes backend image from branch `deploy`
+- Registry: `registry.digitalocean.com/infinit-track`
+- Repository: `infinit-track-backend`
+
+### Phase 2: Runtime remains on Droplet + Docker Compose
+- Current runtime path is still droplet-based
+- Docker Compose runtime has not yet been switched from `build:` to `image:` in this phase
+- Any future move to image-pull runtime should be treated as a separate tracked change
+
+## Obsolete Historical Guidance
+
+Any older references in this repository to:
+- DigitalOcean App Platform app IDs
+- `.do/app.yaml`
+- `.do/app-production.yaml`
+- `doctl apps create-deployment`
+
+should be interpreted as historical artifacts unless explicitly reactivated.
+They are not part of the supported active backend deploy path and should be treated as retained-for-history material or future cleanup candidates, not runtime instructions.
+
+## Phase Boundaries
+
+### What this document covers now
+- image publication truth
+- active runtime target truth
+- boundary between artifact publishing and runtime deployment
+
+### What this document does not claim
+- that GitHub Actions already deploys the runtime to the droplet
+- that Docker Compose runtime already pulls prebuilt images from DOCR
+- that Kubernetes is an active deployment path
+
+## Deployment Readiness Checklist
+
+### Before image publication
+- [ ] CI validation is passing
+- [ ] branch `deploy` contains the reviewed release artifact candidate
+- [ ] Dockerfile still builds the backend correctly
+- [ ] runtime contract changes are reviewed separately from image publication changes
+
+### Before runtime deployment on Droplet
+- [ ] droplet access is available
+- [ ] Docker Compose configuration on the droplet is verified
+- [ ] required runtime secrets are present on the droplet
+- [ ] image tag to be deployed is explicitly chosen
+- [ ] rollback path is known
+
+## Verification Expectations
+
+### Minimum verification for publish-only phase
+- [ ] DOCR workflow pushes SHA tag successfully
+- [ ] DOCR workflow pushes `deploy-latest` successfully
+- [ ] image appears in `registry.digitalocean.com/infinit-track/infinit-track-backend`
+- [ ] no runtime deployment is implied by the publish workflow summary
+
+### Minimum verification for future runtime pull phase
+- [ ] droplet can authenticate to the registry
+- [ ] Docker Compose can pull the selected image tag
+- [ ] backend health endpoint returns success after compose restart
+- [ ] logs confirm backend boot + DB connectivity
+
+## Notes for future follow-up
+- If runtime later moves from `build:` to `image:`, update this document again instead of silently reusing old assumptions.
+- If Kubernetes is intentionally reactivated, document that as a separate deployment truth decision.
+- If any App Platform material is retained elsewhere, it should be marked historical to avoid misleading future operators.


### PR DESCRIPTION
## Summary
- add a publish-only GitHub Actions workflow that builds and pushes backend images to DOCR from the `deploy` branch
- bring Docker/Compose deploy artifacts into the tracked branch and tighten compose runtime env handling for active deploy truth
- update tracked deployment docs to treat Droplet + Docker Compose as the active runtime path and App Platform as historical

## Test Plan
- [x] Run `npm --prefix \"E:/test/Infinit_Track_BE/.claude/worktrees/task2-docr-publish-docs\" test`
- [x] Verify DOCR workflow contains deploy-branch guard, concurrency guard, and DOCR publish tags
- [x] Verify `docker-compose.yml` app service remains `build:`-based and uses `NODE_ENV: production`
- [x] Verify deployment docs are now tracked and aligned with the current runtime truth

🤖 Generated with [Claude Code](https://claude.com/claude-code)