### PR TITLE
INF-139: switch droplet runtime to DOCR image

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,10 @@ CLOUDINARY_CLOUD_NAME=your_cloudinary_cloud_name
 CLOUDINARY_API_KEY=your_cloudinary_api_key
 CLOUDINARY_API_SECRET=your_cloudinary_api_secret
 
+# Runtime image contract
+# Compose runtime should pin an explicit SHA on the droplet; latest is convenience only.
+BACKEND_IMAGE_TAG=latest
+
 # Geoapify API Configuration (canonical runtime key)
 # Active runtime reads GEOAPIFY_API_KEY; historical GEOAPIFY_KEY references are not the current backend contract.
 GEOAPIFY_API_KEY=your_geoapify_api_key_here

--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 env:
-  DOCKER_IMAGE: ${{ secrets.DOCKERHUB_USERNAME }}/infinit-track-backend
+  DOCKER_IMAGE: registry.digitalocean.com/infinit-track/infinit-track-backend
 
 jobs:
   test:
@@ -38,12 +38,14 @@ jobs:
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: registry.digitalocean.com
+          username: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+          password: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
       - uses: docker/build-push-action@v5
         with:
           context: .
           push: true
+          # Publish both immutable SHA tags and latest; droplet runtime should pin SHA explicitly.
           tags: |
             ${{ env.DOCKER_IMAGE }}:latest
             ${{ env.DOCKER_IMAGE }}:${{ github.sha }}

--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -36,11 +36,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: digitalocean/action-doctl@v2
         with:
-          registry: registry.digitalocean.com
-          username: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
-          password: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+      - name: Login to DOCR
+        run: doctl registry login --expiry-seconds 1200
       - uses: docker/build-push-action@v5
         with:
           context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,9 +21,7 @@ services:
       start_period: 30s
 
   app:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: registry.digitalocean.com/infinit-track/infinit-track-backend:${BACKEND_IMAGE_TAG:-latest}
     container_name: infinit-track-app
     restart: unless-stopped
     ports:
@@ -34,6 +32,7 @@ services:
     environment:
       NODE_ENV: development
       PORT: 3000
+      BACKEND_IMAGE_TAG: ${BACKEND_IMAGE_TAG:-latest}
       DB_HOST: ${DB_HOST:-db}
       DB_USER: ${DB_USER:-trackuser}
       DB_PASS: ${DB_PASS:-trackpassword}

--- a/docs/droplet-docr-runtime.md
+++ b/docs/droplet-docr-runtime.md
@@ -14,6 +14,17 @@ The staging droplet runs the backend from a DOCR image, not from a local compose
    export BACKEND_IMAGE_TAG=<git-sha>
    ```
 2. Authenticate Docker to DOCR on the droplet.
+   - If `registry.digitalocean.com/infinit-track/infinit-track-backend` is private, authenticate before pulling.
+   - Prerequisite: a DigitalOcean personal access token with Container Registry read access.
+   - Direct Docker login:
+     ```bash
+     export DOCR_TOKEN=<digitalocean-pat-with-registry-read-access>
+     echo "$DOCR_TOKEN" | docker login registry.digitalocean.com -u doctl --password-stdin
+     ```
+   - Or, if `doctl` is installed and already authenticated:
+     ```bash
+     doctl registry login
+     ```
 3. Pull the selected image:
    ```bash
    docker compose pull app

--- a/docs/droplet-docr-runtime.md
+++ b/docs/droplet-docr-runtime.md
@@ -1,0 +1,42 @@
+# Droplet DOCR Runtime Procedure
+
+## Runtime source of truth
+The staging droplet runs the backend from a DOCR image, not from a local compose build.
+
+## Image contract
+- Repository: `registry.digitalocean.com/infinit-track/infinit-track-backend`
+- Runtime tag source: `BACKEND_IMAGE_TAG`
+- `latest` is convenience only; the runtime should pin a SHA tag for actual deploys.
+
+## Deploy procedure
+1. Set the runtime tag:
+   ```bash
+   export BACKEND_IMAGE_TAG=<git-sha>
+   ```
+2. Authenticate Docker to DOCR on the droplet.
+3. Pull the selected image:
+   ```bash
+   docker compose pull app
+   ```
+4. Restart the app service:
+   ```bash
+   docker compose up -d app
+   ```
+5. Verify:
+   ```bash
+   docker compose ps
+   curl -fsS http://localhost:3000/health
+   docker compose logs --tail=100 app
+   ```
+
+## Rollback procedure
+1. Set `BACKEND_IMAGE_TAG` back to the last known good SHA.
+2. Pull that image:
+   ```bash
+   docker compose pull app
+   ```
+3. Restart the app service:
+   ```bash
+   docker compose up -d app
+   ```
+4. Re-run health and log checks.

--- a/tests/configContract.test.js
+++ b/tests/configContract.test.js
@@ -60,8 +60,12 @@ describe('backend runtime config contract', () => {
     expect(config.jwt.refreshInactivityWindowSeconds).toBe(172800);
   });
 
-  test('declares explicit DB_HOST, DB_SSL, and refresh-token app env in docker compose', () => {
+  test('declares image-based runtime with explicit BACKEND_IMAGE_TAG in docker compose', () => {
     const compose = readDockerCompose();
+
+    expect(compose).toContain('image: registry.digitalocean.com/infinit-track/infinit-track-backend:${BACKEND_IMAGE_TAG:-latest}');
+    expect(compose).toContain('BACKEND_IMAGE_TAG: ${BACKEND_IMAGE_TAG:-latest}');
+    expect(compose).not.toContain('build:');
 
     expect(compose).toContain('DB_HOST: ${DB_HOST:-db}');
     expect(compose).toContain('DB_SSL: ${DB_SSL:-false}');

--- a/tests/configContract.test.js
+++ b/tests/configContract.test.js
@@ -75,4 +75,10 @@ describe('backend runtime config contract', () => {
     expect(compose).toContain('JWT_REFRESH_TTL_SECONDS: ${JWT_REFRESH_TTL_SECONDS:-2592000}');
     expect(compose).toContain('JWT_REFRESH_INACTIVITY_WINDOW_SECONDS: ${JWT_REFRESH_INACTIVITY_WINDOW_SECONDS:-172800}');
   });
+
+  test('documents BACKEND_IMAGE_TAG in env example for operators', () => {
+    const envExample = fs.readFileSync(path.resolve(process.cwd(), '.env.example'), 'utf8');
+
+    expect(envExample).toContain('BACKEND_IMAGE_TAG=latest');
+  });
 });


### PR DESCRIPTION
## Summary
- switch compose app runtime from build-on-host to a DOCR image contract
- keep runtime pinned to an explicit SHA tag while still publishing `latest`
- add droplet operator procedure for pull, restart, and rollback

## Test plan
- [x] npm test -- --runInBand --runTestsByPath tests/configContract.test.js
- [x] npm run lint