### PR TITLE
INF-131/132/134: optimize attendance query paths

### DIFF
--- a/src/controllers/discipline.controller.js
+++ b/src/controllers/discipline.controller.js
@@ -191,9 +191,31 @@ export const getAllDisciplineIndices = async (req, res, next) => {
     const startDate = new Date();
     startDate.setMonth(startDate.getMonth() - parseInt(months));
 
+    const userIds = users.map((user) => user.id_users);
+
+    const attendances = userIds.length
+      ? await Attendance.findAll({
+          where: {
+            user_id: { [Op.in]: userIds },
+            attendance_date: {
+              [Op.between]: [
+                startDate.toISOString().split('T')[0],
+                endDate.toISOString().split('T')[0]
+              ]
+            }
+          }
+        })
+      : [];
+
+    const attendancesByUser = groupAttendancesByUser(attendances);
+
     for (const user of users) {
       try {
-        const userMetrics = await aggregateUserMetrics(user.id_users, startDate, endDate);
+        const userMetrics = aggregateMetricsFromAttendances(
+          attendancesByUser[user.id_users] || [],
+          startDate,
+          endDate
+        );
         const disciplineResult = await fuzzyEngine.calculateDisciplineIndex(
           userMetrics,
           ahpWeights
@@ -321,6 +343,96 @@ export const getDisciplineConfig = async (req, res, next) => {
 // ==========================================
 
 /**
+ * Group attendances by user id
+ * @param {Array} attendances - Attendance records
+ * @returns {Object} Attendances grouped by user id
+ */
+function groupAttendancesByUser(attendances) {
+  return attendances.reduce((grouped, attendance) => {
+    const key = attendance.user_id;
+    if (!grouped[key]) grouped[key] = [];
+    grouped[key].push(attendance);
+    return grouped;
+  }, {});
+}
+
+/**
+ * Aggregate metrics from attendance records for discipline calculation
+ * @param {Array} attendances - Attendance records
+ * @param {Date} startDate - Start date for analysis
+ * @param {Date} endDate - End date for analysis
+ * @returns {Object} Aggregated metrics
+ */
+function aggregateMetricsFromAttendances(attendances, startDate, endDate) {
+  // Calculate total working days in period (excluding weekends)
+  const totalWorkingDays = calculateWorkingDays(startDate, endDate);
+
+  // Calculate metrics
+  const totalAttendances = attendances.length;
+  const lateAttendances = attendances.filter((att) => {
+    if (!att.time_in) return false;
+    const timeIn = new Date(att.time_in);
+    const hour = timeIn.getHours();
+    const minute = timeIn.getMinutes();
+    return hour > 9 || (hour === 9 && minute > 0); // After 09:00 considered late
+  }).length;
+
+  const overtimeAttendances = attendances.filter((att) => {
+    return att.work_hour && parseFloat(att.work_hour) > 8.0;
+  }).length;
+
+  const alphaAttendances = attendances.filter((att) => {
+    return att.status_id === 3; // Alpha status
+  }).length;
+
+  // Calculate rates (as percentages)
+  const lateness_rate = totalWorkingDays > 0 ? (lateAttendances / totalWorkingDays) * 100 : 0;
+  const absenteeism_rate = totalWorkingDays > 0 ? (alphaAttendances / totalWorkingDays) * 100 : 0;
+  const overtime_frequency =
+    totalAttendances > 0 ? (overtimeAttendances / totalAttendances) * 100 : 0;
+
+  // Calculate consistency (attendance rate)
+  const attendance_consistency =
+    totalWorkingDays > 0 ? (totalAttendances / totalWorkingDays) * 100 : 0;
+
+  // Lateness frequency over the last 1 month window (relative to endDate)
+  const lfStartDate = new Date(endDate);
+  lfStartDate.setMonth(lfStartDate.getMonth() - 1);
+
+  const workingDaysLastMonth = calculateWorkingDays(lfStartDate, endDate);
+
+  const lateAttendancesLastMonth = attendances.filter((att) => {
+    // Ensure attendance falls within the last 1 month window
+    const attDate = att.attendance_date ? new Date(att.attendance_date) : null;
+    if (!attDate || attDate < lfStartDate || attDate > endDate) return false;
+    if (!att.time_in) return false;
+    const timeIn = new Date(att.time_in);
+    const hour = timeIn.getHours();
+    const minute = timeIn.getMinutes();
+    return hour > 9 || (hour === 9 && minute > 0);
+  }).length;
+
+  const lateness_frequency =
+    workingDaysLastMonth > 0 ? (lateAttendancesLastMonth / workingDaysLastMonth) * 100 : 0;
+
+  return {
+    lateness_rate: Math.round(lateness_rate * 100) / 100,
+    absenteeism_rate: Math.round(absenteeism_rate * 100) / 100,
+    overtime_frequency: Math.round(overtime_frequency * 100) / 100,
+    attendance_consistency: Math.min(100, Math.round(attendance_consistency * 100) / 100),
+    // Added for FAHP engine compatibility (1-month period)
+    lateness_frequency: Math.round(lateness_frequency * 100) / 100,
+
+    // Additional details
+    total_working_days: totalWorkingDays,
+    total_attendances: totalAttendances,
+    late_days: lateAttendances,
+    overtime_days: overtimeAttendances,
+    alpha_days: alphaAttendances
+  };
+}
+
+/**
  * Aggregate user metrics for discipline calculation
  * @param {number} userId - User ID
  * @param {Date} startDate - Start date for analysis
@@ -339,72 +451,7 @@ async function aggregateUserMetrics(userId, startDate, endDate) {
       }
     });
 
-    // Calculate total working days in period (excluding weekends)
-    const totalWorkingDays = calculateWorkingDays(startDate, endDate);
-
-    // Calculate metrics
-    const totalAttendances = attendances.length;
-    const lateAttendances = attendances.filter((att) => {
-      if (!att.time_in) return false;
-      const timeIn = new Date(att.time_in);
-      const hour = timeIn.getHours();
-      const minute = timeIn.getMinutes();
-      return hour > 9 || (hour === 9 && minute > 0); // After 09:00 considered late
-    }).length;
-
-    const overtimeAttendances = attendances.filter((att) => {
-      return att.work_hour && parseFloat(att.work_hour) > 8.0;
-    }).length;
-
-    const alphaAttendances = attendances.filter((att) => {
-      return att.status_id === 3; // Alpha status
-    }).length;
-
-    // Calculate rates (as percentages)
-    const lateness_rate = totalWorkingDays > 0 ? (lateAttendances / totalWorkingDays) * 100 : 0;
-    const absenteeism_rate = totalWorkingDays > 0 ? (alphaAttendances / totalWorkingDays) * 100 : 0;
-    const overtime_frequency =
-      totalAttendances > 0 ? (overtimeAttendances / totalAttendances) * 100 : 0;
-
-    // Calculate consistency (attendance rate)
-    const attendance_consistency =
-      totalWorkingDays > 0 ? (totalAttendances / totalWorkingDays) * 100 : 0;
-
-    // Lateness frequency over the last 1 month window (relative to endDate)
-    const lfStartDate = new Date(endDate);
-    lfStartDate.setMonth(lfStartDate.getMonth() - 1);
-
-    const workingDaysLastMonth = calculateWorkingDays(lfStartDate, endDate);
-
-    const lateAttendancesLastMonth = attendances.filter((att) => {
-      // Ensure attendance falls within the last 1 month window
-      const attDate = att.attendance_date ? new Date(att.attendance_date) : null;
-      if (!attDate || attDate < lfStartDate || attDate > endDate) return false;
-      if (!att.time_in) return false;
-      const timeIn = new Date(att.time_in);
-      const hour = timeIn.getHours();
-      const minute = timeIn.getMinutes();
-      return hour > 9 || (hour === 9 && minute > 0);
-    }).length;
-
-    const lateness_frequency =
-      workingDaysLastMonth > 0 ? (lateAttendancesLastMonth / workingDaysLastMonth) * 100 : 0;
-
-    return {
-      lateness_rate: Math.round(lateness_rate * 100) / 100,
-      absenteeism_rate: Math.round(absenteeism_rate * 100) / 100,
-      overtime_frequency: Math.round(overtime_frequency * 100) / 100,
-      attendance_consistency: Math.min(100, Math.round(attendance_consistency * 100) / 100),
-      // Added for FAHP engine compatibility (1-month period)
-      lateness_frequency: Math.round(lateness_frequency * 100) / 100,
-
-      // Additional details
-      total_working_days: totalWorkingDays,
-      total_attendances: totalAttendances,
-      late_days: lateAttendances,
-      overtime_days: overtimeAttendances,
-      alpha_days: alphaAttendances
-    };
+    return aggregateMetricsFromAttendances(attendances, startDate, endDate);
   } catch (error) {
     logger.error(`Error aggregating metrics for user ${userId}:`, error);
     throw error;

--- a/src/controllers/summary.controller.js
+++ b/src/controllers/summary.controller.js
@@ -382,18 +382,22 @@ export const getSummaryReport = async (req, res, next) => {
       }
     });
 
-    const settings = await Settings.findAll({
-      where: {
-        setting_key: {
-          [Op.in]: ['checkin.start_time']
-        }
-      }
-    });
-
     const settingsMap = {};
-    settings.forEach((setting) => {
-      settingsMap[setting.setting_key] = setting.setting_value;
-    });
+    try {
+      const settings = await Settings.findAll({
+        where: {
+          setting_key: {
+            [Op.in]: ['checkin.start_time']
+          }
+        }
+      });
+
+      settings.forEach((setting) => {
+        settingsMap[setting.setting_key] = setting.setting_value;
+      });
+    } catch (error) {
+      logger.error('Error preloading summary settings:', error);
+    }
 
     // Calculate discipline index for each user
     const userDisciplineMap = {};

--- a/src/controllers/summary.controller.js
+++ b/src/controllers/summary.controller.js
@@ -21,21 +21,10 @@ import fuzzyAhpEngine from '../utils/fuzzyAhpEngine.js';
  * @param {Date} endDate - End date for calculation
  * @returns {Object} User metrics object
  */
-const calculateUserMetrics = async (userId, startDate, endDate) => {
+const calculateUserMetrics = async (userId, startDate, endDate, settingsMap = null) => {
   try {
-    // Load required attendance settings (use DB-configured values; fallback defaults)
-    const settings = await Settings.findAll({
-      where: {
-        setting_key: {
-          [Op.in]: ['checkin.start_time']
-        }
-      }
-    });
-    const settingsMap = {};
-    settings.forEach((s) => {
-      settingsMap[s.setting_key] = s.setting_value;
-    });
-    const checkinStartTime = settingsMap['checkin.start_time'] || '08:00:00';
+    const effectiveSettingsMap = settingsMap || {};
+    const checkinStartTime = effectiveSettingsMap['checkin.start_time'] || '08:00:00';
 
     const startParts = checkinStartTime.split(':').map((v) => parseInt(v, 10) || 0);
     const startMinutes = (startParts[0] || 0) * 60 + (startParts[1] || 0);
@@ -393,11 +382,24 @@ export const getSummaryReport = async (req, res, next) => {
       }
     });
 
+    const settings = await Settings.findAll({
+      where: {
+        setting_key: {
+          [Op.in]: ['checkin.start_time']
+        }
+      }
+    });
+
+    const settingsMap = {};
+    settings.forEach((setting) => {
+      settingsMap[setting.setting_key] = setting.setting_value;
+    });
+
     // Calculate discipline index for each user
     const userDisciplineMap = {};
     const disciplineCalculationPromises = Object.keys(uniqueUsers).map(async (userId) => {
       try {
-        const userMetrics = await calculateUserMetrics(parseInt(userId), startDate, endDate);
+        const userMetrics = await calculateUserMetrics(parseInt(userId, 10), startDate, endDate, settingsMap);
         const disciplineResult = await fuzzyAhpEngine.calculateDisciplineIndex(userMetrics);
 
         userDisciplineMap[userId] = {

--- a/src/models/migrations/20260423010000-add-attendance-date-index.js
+++ b/src/models/migrations/20260423010000-add-attendance-date-index.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const indexExists = async (queryInterface, tableName, indexName, transaction) => {
+  const [rows] = await queryInterface.sequelize.query(`SHOW INDEX FROM \`${tableName}\``, {
+    transaction
+  });
+
+  return rows.some((row) => row.Key_name === indexName);
+};
+
+/** @type {import('sequelize-cli').Migration} */
+const migration = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      if (!(await indexExists(queryInterface, 'attendance', 'idx_attendance_date', transaction))) {
+        await queryInterface.addIndex('attendance', ['attendance_date'], {
+          name: 'idx_attendance_date',
+          transaction
+        });
+      }
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeIndex('attendance', 'idx_attendance_date');
+  }
+};
+
+export default migration;
+
+if (typeof module !== 'undefined') {
+  module.exports = migration;
+}

--- a/tests/attendanceDateIndexMigration.test.js
+++ b/tests/attendanceDateIndexMigration.test.js
@@ -1,0 +1,57 @@
+import { jest } from '@jest/globals';
+
+const mockAddIndex = jest.fn();
+const mockRemoveIndex = jest.fn();
+const mockQuery = jest.fn();
+const mockTransaction = jest.fn(async (cb) => cb('tx'));
+
+const queryInterface = {
+  addIndex: mockAddIndex,
+  removeIndex: mockRemoveIndex,
+  sequelize: {
+    query: mockQuery,
+    transaction: mockTransaction
+  }
+};
+
+describe('attendance date index migration', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    mockAddIndex.mockReset();
+    mockRemoveIndex.mockReset();
+    mockQuery.mockReset();
+    mockTransaction.mockClear();
+  });
+
+  test('adds idx_attendance_date when the index is missing', async () => {
+    mockQuery.mockResolvedValueOnce([[{ Key_name: 'uq_attendance_user_date' }]]);
+
+    const migration = await import('../src/models/migrations/20260423010000-add-attendance-date-index.js');
+    await migration.default.up(queryInterface);
+
+    expect(mockAddIndex).toHaveBeenCalledWith(
+      'attendance',
+      ['attendance_date'],
+      expect.objectContaining({
+        name: 'idx_attendance_date',
+        transaction: 'tx'
+      })
+    );
+  });
+
+  test('does not add idx_attendance_date when the index already exists', async () => {
+    mockQuery.mockResolvedValueOnce([[{ Key_name: 'idx_attendance_date' }]]);
+
+    const migration = await import('../src/models/migrations/20260423010000-add-attendance-date-index.js');
+    await migration.default.up(queryInterface);
+
+    expect(mockAddIndex).not.toHaveBeenCalled();
+  });
+
+  test('removes idx_attendance_date on rollback', async () => {
+    const migration = await import('../src/models/migrations/20260423010000-add-attendance-date-index.js');
+    await migration.default.down(queryInterface);
+
+    expect(mockRemoveIndex).toHaveBeenCalledWith('attendance', 'idx_attendance_date');
+  });
+});

--- a/tests/disciplineAllQueryPlan.test.js
+++ b/tests/disciplineAllQueryPlan.test.js
@@ -1,0 +1,94 @@
+import { jest } from '@jest/globals';
+
+const mockUserFindAll = jest.fn();
+const mockAttendanceFindAll = jest.fn();
+const mockGetDisciplineAhpWeights = jest.fn(() => ({ lateness: 0.25 }));
+const mockCalculateDisciplineIndex = jest.fn(async () => ({
+  score: 82,
+  label: 'Tinggi'
+}));
+
+jest.unstable_mockModule('../src/models/index.js', () => ({
+  Attendance: { findAll: mockAttendanceFindAll },
+  User: { findAll: mockUserFindAll },
+  Role: {}
+}));
+
+jest.unstable_mockModule('../src/utils/fuzzyAhpEngine.js', () => ({
+  default: {
+    getDisciplineAhpWeights: mockGetDisciplineAhpWeights,
+    calculateDisciplineIndex: mockCalculateDisciplineIndex
+  }
+}));
+
+jest.unstable_mockModule('../src/utils/logger.js', () => ({
+  default: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }
+}));
+
+const buildRes = () => ({
+  status: jest.fn().mockReturnThis(),
+  json: jest.fn().mockReturnThis()
+});
+
+describe('discipline all query plan', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    mockUserFindAll.mockReset();
+    mockAttendanceFindAll.mockReset();
+    mockGetDisciplineAhpWeights.mockClear();
+    mockCalculateDisciplineIndex.mockClear();
+  });
+
+  test('loads attendance once for all users instead of once per user', async () => {
+    mockUserFindAll.mockResolvedValue([
+      {
+        id_users: 7,
+        full_name: 'Febri',
+        nip_nim: '001',
+        email: 'f@example.com',
+        role: { role_name: 'User' }
+      },
+      {
+        id_users: 8,
+        full_name: 'Diana',
+        nip_nim: '002',
+        email: 'd@example.com',
+        role: { role_name: 'User' }
+      }
+    ]);
+
+    mockAttendanceFindAll.mockResolvedValue([
+      {
+        user_id: 7,
+        attendance_date: '2026-04-01',
+        time_in: new Date('2026-04-01T08:10:00+07:00'),
+        work_hour: 8,
+        status_id: 1
+      },
+      {
+        user_id: 8,
+        attendance_date: '2026-04-01',
+        time_in: new Date('2026-04-01T09:10:00+07:00'),
+        work_hour: 7.5,
+        status_id: 2
+      }
+    ]);
+
+    const { getAllDisciplineIndices } = await import('../src/controllers/discipline.controller.js');
+
+    const req = {
+      user: { id: 1, role_name: 'Admin' },
+      query: { months: '1', page: '1', limit: '20', sort: 'score_desc' }
+    };
+    const res = buildRes();
+    const next = jest.fn();
+
+    await getAllDisciplineIndices(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(mockUserFindAll).toHaveBeenCalledTimes(1);
+    expect(mockAttendanceFindAll).toHaveBeenCalledTimes(1);
+    expect(mockCalculateDisciplineIndex).toHaveBeenCalledTimes(2);
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+});

--- a/tests/summarySettingsCache.test.js
+++ b/tests/summarySettingsCache.test.js
@@ -50,6 +50,65 @@ const buildRes = () => ({
   json: jest.fn().mockReturnThis()
 });
 
+const buildSummaryRows = () => [
+  {
+    id_attendance: 101,
+    attendance_date: '2026-04-23',
+    time_in: new Date('2026-04-23T01:15:00.000Z'),
+    time_out: new Date('2026-04-23T10:00:00.000Z'),
+    work_hour: 8,
+    notes: '',
+    user: {
+      id_users: 7,
+      full_name: 'Febri',
+      email: 'f@example.com',
+      nip_nim: '001',
+      role: { role_name: 'User' }
+    },
+    location: null,
+    attendance_category: { category_name: 'WFO' },
+    status: { attendance_status_name: 'Tepat Waktu' }
+  },
+  {
+    id_attendance: 102,
+    attendance_date: '2026-04-23',
+    time_in: new Date('2026-04-23T01:20:00.000Z'),
+    time_out: new Date('2026-04-23T10:00:00.000Z'),
+    work_hour: 8,
+    notes: '',
+    user: {
+      id_users: 8,
+      full_name: 'Diana',
+      email: 'd@example.com',
+      nip_nim: '002',
+      role: { role_name: 'User' }
+    },
+    location: null,
+    attendance_category: { category_name: 'WFH' },
+    status: { attendance_status_name: 'Terlambat' }
+  }
+];
+
+const arrangeAttendanceFindAllForSummary = () => {
+  mockAttendanceFindAll
+    .mockResolvedValueOnce([])
+    .mockResolvedValueOnce([])
+    .mockResolvedValueOnce([
+      {
+        time_in: new Date('2026-04-23T01:15:00.000Z'),
+        work_hour: 8,
+        status: { attendance_status_name: 'Tepat Waktu' }
+      }
+    ])
+    .mockResolvedValueOnce([
+      {
+        time_in: new Date('2026-04-23T01:20:00.000Z'),
+        work_hour: 8,
+        status: { attendance_status_name: 'Terlambat' }
+      }
+    ]);
+};
+
 describe('summary settings cache', () => {
   beforeEach(() => {
     jest.resetModules();
@@ -66,63 +125,10 @@ describe('summary settings cache', () => {
 
     mockAttendanceFindAndCountAll.mockResolvedValue({
       count: 2,
-      rows: [
-        {
-          id_attendance: 101,
-          attendance_date: '2026-04-23',
-          time_in: new Date('2026-04-23T01:15:00.000Z'),
-          time_out: new Date('2026-04-23T10:00:00.000Z'),
-          work_hour: 8,
-          notes: '',
-          user: {
-            id_users: 7,
-            full_name: 'Febri',
-            email: 'f@example.com',
-            nip_nim: '001',
-            role: { role_name: 'User' }
-          },
-          location: null,
-          attendance_category: { category_name: 'WFO' },
-          status: { attendance_status_name: 'Tepat Waktu' }
-        },
-        {
-          id_attendance: 102,
-          attendance_date: '2026-04-23',
-          time_in: new Date('2026-04-23T01:20:00.000Z'),
-          time_out: new Date('2026-04-23T10:00:00.000Z'),
-          work_hour: 8,
-          notes: '',
-          user: {
-            id_users: 8,
-            full_name: 'Diana',
-            email: 'd@example.com',
-            nip_nim: '002',
-            role: { role_name: 'User' }
-          },
-          location: null,
-          attendance_category: { category_name: 'WFH' },
-          status: { attendance_status_name: 'Terlambat' }
-        }
-      ]
+      rows: buildSummaryRows()
     });
 
-    mockAttendanceFindAll
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([
-        {
-          time_in: new Date('2026-04-23T01:15:00.000Z'),
-          work_hour: 8,
-          status: { attendance_status_name: 'Tepat Waktu' }
-        }
-      ])
-      .mockResolvedValueOnce([
-        {
-          time_in: new Date('2026-04-23T01:20:00.000Z'),
-          work_hour: 8,
-          status: { attendance_status_name: 'Terlambat' }
-        }
-      ]);
+    arrangeAttendanceFindAllForSummary();
 
     const { getSummaryReport } = await import('../src/controllers/summary.controller.js');
 
@@ -135,5 +141,28 @@ describe('summary settings cache', () => {
     expect(next).not.toHaveBeenCalled();
     expect(mockSettingsFindAll).toHaveBeenCalledTimes(1);
     expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  test('continues summary generation when settings preload fails', async () => {
+    mockSettingsFindAll.mockRejectedValueOnce(new Error('settings unavailable'));
+
+    mockAttendanceFindAndCountAll.mockResolvedValue({
+      count: 2,
+      rows: buildSummaryRows()
+    });
+
+    arrangeAttendanceFindAllForSummary();
+
+    const { getSummaryReport } = await import('../src/controllers/summary.controller.js');
+
+    const req = { query: { period: 'daily', page: '1', limit: '10' } };
+    const res = buildRes();
+    const next = jest.fn();
+
+    await getSummaryReport(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(mockFuzzyCalculate).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/summarySettingsCache.test.js
+++ b/tests/summarySettingsCache.test.js
@@ -1,0 +1,139 @@
+import { jest } from '@jest/globals';
+
+const mockSettingsFindAll = jest.fn();
+const mockAttendanceFindAll = jest.fn();
+const mockAttendanceFindAndCountAll = jest.fn();
+const mockFuzzyCalculate = jest.fn(async () => ({
+  score: 88,
+  label: 'Sangat Tinggi',
+  breakdown: {}
+}));
+
+jest.unstable_mockModule('../src/config/database.js', () => ({
+  default: { fn: jest.fn(), col: jest.fn() }
+}));
+
+jest.unstable_mockModule('../src/models/index.js', () => ({
+  Attendance: {
+    findAll: mockAttendanceFindAll,
+    findAndCountAll: mockAttendanceFindAndCountAll
+  },
+  User: {},
+  Role: {},
+  Location: {},
+  AttendanceCategory: {},
+  AttendanceStatus: {},
+  Settings: {
+    findAll: mockSettingsFindAll
+  }
+}));
+
+jest.unstable_mockModule('../src/utils/logger.js', () => ({
+  default: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }
+}));
+
+jest.unstable_mockModule('../src/utils/workHourFormatter.js', () => ({
+  formatWorkHour: jest.fn(() => '8h 0m'),
+  formatTimeOnly: jest.fn(() => '08:15'),
+  calculateWorkHour: jest.fn(() => 8)
+}));
+
+jest.unstable_mockModule('../src/utils/fuzzyAhpEngine.js', () => ({
+  default: {
+    calculateDisciplineIndex: mockFuzzyCalculate,
+    getDisciplineLabel: jest.fn(() => 'Sedang')
+  }
+}));
+
+const buildRes = () => ({
+  status: jest.fn().mockReturnThis(),
+  json: jest.fn().mockReturnThis()
+});
+
+describe('summary settings cache', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    mockSettingsFindAll.mockReset();
+    mockAttendanceFindAll.mockReset();
+    mockAttendanceFindAndCountAll.mockReset();
+    mockFuzzyCalculate.mockClear();
+  });
+
+  test('loads checkin.start_time once for a summary request with multiple unique users', async () => {
+    mockSettingsFindAll.mockResolvedValue([
+      { setting_key: 'checkin.start_time', setting_value: '08:00:00' }
+    ]);
+
+    mockAttendanceFindAndCountAll.mockResolvedValue({
+      count: 2,
+      rows: [
+        {
+          id_attendance: 101,
+          attendance_date: '2026-04-23',
+          time_in: new Date('2026-04-23T01:15:00.000Z'),
+          time_out: new Date('2026-04-23T10:00:00.000Z'),
+          work_hour: 8,
+          notes: '',
+          user: {
+            id_users: 7,
+            full_name: 'Febri',
+            email: 'f@example.com',
+            nip_nim: '001',
+            role: { role_name: 'User' }
+          },
+          location: null,
+          attendance_category: { category_name: 'WFO' },
+          status: { attendance_status_name: 'Tepat Waktu' }
+        },
+        {
+          id_attendance: 102,
+          attendance_date: '2026-04-23',
+          time_in: new Date('2026-04-23T01:20:00.000Z'),
+          time_out: new Date('2026-04-23T10:00:00.000Z'),
+          work_hour: 8,
+          notes: '',
+          user: {
+            id_users: 8,
+            full_name: 'Diana',
+            email: 'd@example.com',
+            nip_nim: '002',
+            role: { role_name: 'User' }
+          },
+          location: null,
+          attendance_category: { category_name: 'WFH' },
+          status: { attendance_status_name: 'Terlambat' }
+        }
+      ]
+    });
+
+    mockAttendanceFindAll
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          time_in: new Date('2026-04-23T01:15:00.000Z'),
+          work_hour: 8,
+          status: { attendance_status_name: 'Tepat Waktu' }
+        }
+      ])
+      .mockResolvedValueOnce([
+        {
+          time_in: new Date('2026-04-23T01:20:00.000Z'),
+          work_hour: 8,
+          status: { attendance_status_name: 'Terlambat' }
+        }
+      ]);
+
+    const { getSummaryReport } = await import('../src/controllers/summary.controller.js');
+
+    const req = { query: { period: 'daily', page: '1', limit: '10' } };
+    const res = buildRes();
+    const next = jest.fn();
+
+    await getSummaryReport(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(mockSettingsFindAll).toHaveBeenCalledTimes(1);
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated `attendance_date` index migration for attendance queries that do not lead with `user_id`
- preload summary settings once per request while preserving the `08:00:00` fallback when settings lookup fails
- batch-load attendance rows for `getAllDisciplineIndices` to remove the per-user N+1 query pattern without changing scoring formulas

## Test Plan
- [x] `npm test -- tests/attendanceDateIndexMigration.test.js tests/summarySettingsCache.test.js tests/disciplineAllQueryPlan.test.js tests/discipline.test.js tests/configContract.test.js`
- [x] `./node_modules/.bin/eslint --resolve-plugins-relative-to . --no-ignore src/controllers/summary.controller.js src/controllers/discipline.controller.js src/models/migrations/20260423010000-add-attendance-date-index.js tests/attendanceDateIndexMigration.test.js tests/summarySettingsCache.test.js tests/disciplineAllQueryPlan.test.js`
- [ ] Run migration verification against a real MySQL environment (`migrate:status` / apply rollback) because local DB credentials were unavailable during branch work
- [ ] Verify `getAllDisciplineIndices` query count / behavior on representative data volume in a real environment