### PR TITLE
INF-131/132: close verification gaps for migration and discipline batching

### DIFF
--- a/src/config/database-cli.cjs
+++ b/src/config/database-cli.cjs
@@ -7,6 +7,7 @@ module.exports = {
     database: process.env.DB_NAME,
     host: process.env.DB_HOST,
     dialect: 'mysql',
+    migrationStorageTableName: 'sequelizemeta',
     dialectOptions: {
       charset: 'utf8mb4'
     }

--- a/src/controllers/discipline.controller.js
+++ b/src/controllers/discipline.controller.js
@@ -209,6 +209,8 @@ export const getAllDisciplineIndices = async (req, res, next) => {
 
     const attendancesByUser = groupAttendancesByUser(attendances);
 
+    logger.info(`Fetched ${attendances.length} attendance records in 1 query`);
+
     for (const user of users) {
       try {
         const userMetrics = aggregateMetricsFromAttendances(

--- a/src/models/migrations/20240525120000-create-user.cjs
+++ b/src/models/migrations/20240525120000-create-user.cjs
@@ -1,13 +1,12 @@
-// 'use strict';
+'use strict';
 
-// /** @type {import('sequelize-cli').Migration} */
-// module.exports = {
-//   async up(queryInterface, Sequelize) {
-//     // This is a stub migration - tables already exist
-//     // No action needed
-//   },
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up() {
+    // Historical alignment stub: the users table already exists in the baseline schema.
+  },
 
-//   async down(queryInterface, Sequelize) {
-//     // This is a stub migration - no rollback needed
-//   }
-// };
+  async down() {
+    // No rollback needed for historical alignment stub.
+  }
+};

--- a/src/models/migrations/20240619000000-update-photos-for-cloudinary.cjs
+++ b/src/models/migrations/20240619000000-update-photos-for-cloudinary.cjs
@@ -1,24 +1,12 @@
-// 'use strict';
+'use strict';
 
-// /** @type {import('sequelize-cli').Migration} */
-// module.exports = {
-//   async up(queryInterface, Sequelize) {
-//     // Add public_id column
-//     await queryInterface.addColumn('photos', 'public_id', {
-//       type: Sequelize.STRING(255),
-//       allowNull: true,
-//       after: 'file_path'
-//     });
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up() {
+    // Historical alignment stub: baseline schema already uses photo_url and public_id.
+  },
 
-//     // Rename file_path to photo_url
-//     await queryInterface.renameColumn('photos', 'file_path', 'photo_url');
-//   },
-
-//   async down(queryInterface, Sequelize) {
-//     // Rename photo_url back to file_path
-//     await queryInterface.renameColumn('photos', 'photo_url', 'file_path');
-    
-//     // Remove public_id column
-//     await queryInterface.removeColumn('photos', 'public_id');
-//   }
-// };
+  async down() {
+    // No rollback needed for historical alignment stub.
+  }
+};

--- a/src/models/migrations/20240619000000-update-photos-for-cloudinary.js
+++ b/src/models/migrations/20240619000000-update-photos-for-cloudinary.js
@@ -1,24 +1,18 @@
-// 'use strict';
+'use strict';
 
-// /** @type {import('sequelize-cli').Migration} */
-// module.exports = {
-//   async up(queryInterface, Sequelize) {
-//     // Add public_id column
-//     await queryInterface.addColumn('photos', 'public_id', {
-//       type: Sequelize.STRING(255),
-//       allowNull: true,
-//       after: 'file_path'
-//     });
+/** @type {import('sequelize-cli').Migration} */
+const migration = {
+  async up() {
+    // Historical alignment stub: baseline schema already uses photo_url and public_id.
+  },
 
-//     // Rename file_path to photo_url
-//     await queryInterface.renameColumn('photos', 'file_path', 'photo_url');
-//   },
+  async down() {
+    // No rollback needed for historical alignment stub.
+  }
+};
 
-//   async down(queryInterface, Sequelize) {
-//     // Rename photo_url back to file_path
-//     await queryInterface.renameColumn('photos', 'photo_url', 'file_path');
+export default migration;
 
-//     // Remove public_id column
-//     await queryInterface.removeColumn('photos', 'public_id');
-//   }
-// };
+if (typeof module !== 'undefined') {
+  module.exports = migration;
+}

--- a/src/models/migrations/20260403000000-add-unique-constraint-attendance.js
+++ b/src/models/migrations/20260403000000-add-unique-constraint-attendance.js
@@ -9,7 +9,7 @@ const indexExists = async (queryInterface, tableName, indexName, transaction) =>
 };
 
 /** @type {import('sequelize-cli').Migration} */
-module.exports = {
+const migration = {
   async up(queryInterface) {
     await queryInterface.sequelize.transaction(async (transaction) => {
       // Step 1: Check and clean duplicate attendance records
@@ -68,3 +68,9 @@ module.exports = {
     await queryInterface.removeIndex('bookings', 'idx_bookings_user_schedule');
   }
 };
+
+export default migration;
+
+if (typeof module !== 'undefined') {
+  module.exports = migration;
+}

--- a/src/models/migrations/20260422000000-add-photo-storage-metadata.js
+++ b/src/models/migrations/20260422000000-add-photo-storage-metadata.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /** @type {import('sequelize-cli').Migration} */
-module.exports = {
+const migration = {
   async up(queryInterface, Sequelize) {
     await queryInterface.addColumn('photos', 'storage_provider', {
       type: Sequelize.STRING(32),
@@ -21,3 +21,9 @@ module.exports = {
     await queryInterface.removeColumn('photos', 'storage_provider');
   }
 };
+
+export default migration;
+
+if (typeof module !== 'undefined') {
+  module.exports = migration;
+}

--- a/tests/disciplineAllQueryPlan.test.js
+++ b/tests/disciplineAllQueryPlan.test.js
@@ -7,6 +7,7 @@ const mockCalculateDisciplineIndex = jest.fn(async () => ({
   score: 82,
   label: 'Tinggi'
 }));
+const mockLoggerInfo = jest.fn();
 
 jest.unstable_mockModule('../src/models/index.js', () => ({
   Attendance: { findAll: mockAttendanceFindAll },
@@ -22,7 +23,7 @@ jest.unstable_mockModule('../src/utils/fuzzyAhpEngine.js', () => ({
 }));
 
 jest.unstable_mockModule('../src/utils/logger.js', () => ({
-  default: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }
+  default: { info: mockLoggerInfo, warn: jest.fn(), error: jest.fn(), debug: jest.fn() }
 }));
 
 const buildRes = () => ({
@@ -37,6 +38,7 @@ describe('discipline all query plan', () => {
     mockAttendanceFindAll.mockReset();
     mockGetDisciplineAhpWeights.mockClear();
     mockCalculateDisciplineIndex.mockClear();
+    mockLoggerInfo.mockClear();
   });
 
   test('loads attendance once for all users instead of once per user', async () => {
@@ -88,6 +90,7 @@ describe('discipline all query plan', () => {
     expect(next).not.toHaveBeenCalled();
     expect(mockUserFindAll).toHaveBeenCalledTimes(1);
     expect(mockAttendanceFindAll).toHaveBeenCalledTimes(1);
+    expect(mockLoggerInfo).toHaveBeenCalledWith('Fetched 2 attendance records in 1 query');
     expect(mockCalculateDisciplineIndex).toHaveBeenCalledTimes(2);
     expect(res.status).toHaveBeenCalledWith(200);
   });

--- a/tests/migrationChainContract.test.js
+++ b/tests/migrationChainContract.test.js
@@ -1,0 +1,60 @@
+import fs from 'fs';
+import path from 'path';
+import { jest } from '@jest/globals';
+
+const migrationsDir = path.resolve(process.cwd(), 'src/models/migrations');
+const readFile = (name) => fs.readFileSync(path.join(migrationsDir, name), 'utf8');
+
+describe('migration chain contract', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  test('database-cli targets the lower-case sequelizemeta table used by the local DB snapshot', async () => {
+    const config = await import('../src/config/database-cli.cjs');
+
+    expect(config.default?.development?.migrationStorageTableName || config.development?.migrationStorageTableName).toBe('sequelizemeta');
+  });
+
+  test('legacy create-user migration exports callable up/down methods', async () => {
+    const migration = await import('../src/models/migrations/20240525120000-create-user.cjs');
+
+    expect(typeof migration.default?.up || typeof migration.up).toBe('function');
+    expect(typeof migration.default?.down || typeof migration.down).toBe('function');
+  });
+
+  test('legacy cloudinary migrations export callable up/down methods', async () => {
+    const migrationCjs = await import('../src/models/migrations/20240619000000-update-photos-for-cloudinary.cjs');
+    const migrationJs = await import('../src/models/migrations/20240619000000-update-photos-for-cloudinary.js');
+
+    expect(typeof migrationCjs.default?.up || typeof migrationCjs.up).toBe('function');
+    expect(typeof migrationCjs.default?.down || typeof migrationCjs.down).toBe('function');
+    expect(typeof migrationJs.default?.up || typeof migrationJs.up).toBe('function');
+    expect(typeof migrationJs.default?.down || typeof migrationJs.down).toBe('function');
+  });
+
+  test('legacy create-user migration is documented as a no-op stub rather than an empty commented file', () => {
+    const source = readFile('20240525120000-create-user.cjs');
+
+    expect(source).toContain('module.exports');
+    expect(source).toContain('async up');
+    expect(source).toContain('async down');
+  });
+
+  test('legacy cloudinary JS migration keeps the guarded ESM/CommonJS export pattern', () => {
+    const source = readFile('20240619000000-update-photos-for-cloudinary.js');
+
+    expect(source).toContain('export default migration');
+    expect(source).toContain("typeof module !== 'undefined'");
+  });
+
+  test('modern JS migrations keep the guarded ESM/CommonJS export pattern', () => {
+    const uniqueAttendance = readFile('20260403000000-add-unique-constraint-attendance.js');
+    const photoMetadata = readFile('20260422000000-add-photo-storage-metadata.js');
+
+    expect(uniqueAttendance).toContain('export default migration');
+    expect(uniqueAttendance).toContain("typeof module !== 'undefined'");
+    expect(photoMetadata).toContain('export default migration');
+    expect(photoMetadata).toContain("typeof module !== 'undefined'");
+  });
+});


### PR DESCRIPTION
## Summary
- repair the local Sequelize migration chain so mixed legacy and modern migration files can be evaluated and applied under the repo's ESM setup
- close INF-131 verification by confirming the `attendance_date` migration is applied, the index exists, and `EXPLAIN` uses `idx_attendance_date`
- close INF-132 verification by adding the explicit `Fetched X attendance records in 1 query` log and asserting it in focused regression coverage

## Test Plan
- [x] `node --experimental-vm-modules ./node_modules/jest/bin/jest.js --config ./jest.config.json --testPathIgnorePatterns /node_modules/ /.claude/worktrees/ --runTestsByPath ./tests/migrationChainContract.test.js ./tests/disciplineAllQueryPlan.test.js ./tests/discipline.test.js`
- [x] `./node_modules/.bin/eslint --resolve-plugins-relative-to . --no-ignore src/config/database-cli.cjs src/models/migrations/20240525120000-create-user.cjs src/models/migrations/20240619000000-update-photos-for-cloudinary.cjs src/models/migrations/20240619000000-update-photos-for-cloudinary.js src/models/migrations/20260403000000-add-unique-constraint-attendance.js src/models/migrations/20260422000000-add-photo-storage-metadata.js tests/migrationChainContract.test.js src/controllers/discipline.controller.js tests/disciplineAllQueryPlan.test.js`
- [x] `npm run migrate:status`
- [x] Verified `SHOW INDEX FROM attendance WHERE Key_name = 'idx_attendance_date'`
- [x] Verified `EXPLAIN SELECT * FROM attendance WHERE attendance_date = '2026-04-10'` uses `idx_attendance_date`