### PR TITLE
Fix master deploy workflow signals

### DIFF
--- a/.do/README.md
+++ b/.do/README.md
@@ -1,8 +1,16 @@
-# DigitalOcean App Platform Deployment
+# DigitalOcean App Platform Deployment (Historical Reference)
 
 ## 📋 Overview
 
-Konfigurasi ini mendukung deployment otomatis aplikasi Infinit Track Backend ke DigitalOcean App Platform menggunakan GitOps-style deployment.
+Dokumen ini menyimpan referensi historis untuk backend DigitalOcean App Platform, bukan deployment truth aktif.
+
+Active backend deployment truth saat ini adalah:
+
+- `.github/workflows/ci.yml` untuk validation gate
+- `.github/workflows/docker-deploy.yml` untuk publish image ke DOCR
+- Droplet + Docker Compose sebagai runtime aktif
+
+Gunakan dokumen ini hanya jika jalur App Platform memang sengaja diaktifkan kembali.
 
 ## 🚀 Deployment Methods
 
@@ -74,20 +82,15 @@ Konfigurasi ini mendukung deployment otomatis aplikasi Infinit Track Backend ke 
    - Click "Create Resources"
    - Tunggu hingga deployment selesai (~5-10 menit)
 
-### Method 2: Via GitHub Actions (Automated CD)
+### Method 2: Historical GitHub Actions path
 
-Lihat file `.github/workflows/deploy-staging.yml` untuk workflow otomatis.
+The old `.github/workflows/deploy-staging.yml` App Platform deployment path is retained only as a manual historical marker.
 
-**Prerequisites:**
+Active backend release flow now uses:
 
-1. Set GitHub Secrets:
-
-   - `DIGITALOCEAN_ACCESS_TOKEN` - Token API dari DO
-   - Environment-specific secrets di GitHub Environments
-
-2. Workflow akan otomatis trigger saat:
-   - Push ke branch `master`
-   - Atau manual trigger via GitHub Actions tab
+1. `.github/workflows/ci.yml` for lint/test validation.
+2. `.github/workflows/docker-deploy.yml` to publish the backend image to DOCR.
+3. Droplet + Docker Compose runtime pull using an explicit `BACKEND_IMAGE_TAG`.
 
 ## 🔒 Environment Variables Security
 
@@ -102,12 +105,10 @@ Lihat file `.github/workflows/deploy-staging.yml` untuk workflow otomatis.
 
 ## 🏥 Health Check
 
-App Platform akan melakukan health check ke endpoint `/health` setiap 10 detik:
+Jika App Platform diaktifkan kembali, gunakan endpoint `/health` sebagai health check target:
 
 - **Success Response:** `{"status":"OK","timestamp":"..."}`
 - **HTTP Status:** 200
-
-Jika health check gagal 3x berturut-turut, container akan di-restart otomatis.
 
 ## 📊 Monitoring & Logs
 
@@ -128,18 +129,6 @@ Jika health check gagal 3x berturut-turut, container akan di-restart otomatis.
    - Monitor CPU, Memory, Request rate
 
 ## 🔄 Update Deployment
-
-### Auto Deploy (Recommended)
-
-Push perubahan ke branch `master`:
-
-```bash
-git add .
-git commit -m "Update feature XYZ"
-git push origin master
-```
-
-DO App Platform akan otomatis detect dan deploy.
 
 ### Manual Deploy via Dashboard
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,142 +1,23 @@
-name: Deploy to Staging
+name: Historical App Platform Deploy
 
 on:
-  push:
-    branches:
-      - master # Trigger on push to master branch
-  pull_request:
-    branches:
-      - master # Also run on PR to master (for testing)
-  workflow_dispatch: # Allow manual trigger from GitHub Actions tab
-
-env:
-  NODE_VERSION: '18' # Match your Node.js version
+  workflow_dispatch:
 
 jobs:
-  # Job 1: Lint and Test
-  test:
-    name: Lint & Test
+  disabled:
+    name: Historical path disabled
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run linter
-        run: npm run lint
-        continue-on-error: true # Don't fail build on lint warnings
-
-      - name: Run tests
-        run: npm test
-        env:
-          NODE_ENV: test
-          DB_HOST: localhost
-          DB_NAME: test_db
-          DB_USER: test_user
-          DB_PASS: test_pass
-          JWT_SECRET: test_secret_for_ci_only
-          CLOUDINARY_CLOUD_NAME: test_cloud
-          CLOUDINARY_API_KEY: test_key
-          CLOUDINARY_API_SECRET: test_secret
-        continue-on-error: false # Fail build on test failures
-
-  # Job 2: Deploy to DigitalOcean App Platform (Staging)
-  deploy-staging:
-    name: Deploy to Staging
-    runs-on: ubuntu-latest
-    needs: test # Run only after tests pass
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-
-    environment:
-      name: staging
-      url: https://infinit-track-staging.ondigitalocean.app
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install doctl
-        uses: digitalocean/action-doctl@v2
-        with:
-          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
-
-      - name: Deploy to DigitalOcean App Platform
+      - name: Explain active backend deployment path
         run: |
-          # Get app ID (you need to set this after creating the app)
-          APP_ID="${{ secrets.DO_APP_ID_STAGING }}"
-
-          if [ -z "$APP_ID" ]; then
-            echo "❌ DO_APP_ID_STAGING secret is not set!"
-            echo "Please set it in GitHub Secrets after creating the app on DigitalOcean"
-            exit 1
-          fi
-
-          echo "🚀 Triggering deployment for App ID: $APP_ID"
-
-          # Trigger deployment
-          doctl apps create-deployment $APP_ID --wait
-
-          echo "✅ Deployment triggered successfully!"
-
-      - name: Wait for deployment to complete
-        run: |
-          echo "⏳ Waiting for deployment to be live..."
-          sleep 30  # Give it time to start
-
-      - name: Get deployment status
-        run: |
-          APP_ID="${{ secrets.DO_APP_ID_STAGING }}"
-          doctl apps get $APP_ID --format ID,Tier,Phase,ActiveDeployment.Phase
-
-      - name: Run smoke tests
-        run: |
-          npm run smoke-test https://infinit-track-staging.ondigitalocean.app
-        continue-on-error: true
-
-      - name: Deployment summary
-        run: |
-          echo "## 🚀 Staging Deployment Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "✅ Deployment triggered successfully" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**App URL:** https://infinit-track-staging.ondigitalocean.app" >> $GITHUB_STEP_SUMMARY
-          echo "**Health Check:** https://infinit-track-staging.ondigitalocean.app/health" >> $GITHUB_STEP_SUMMARY
-          echo "**API Docs:** https://infinit-track-staging.ondigitalocean.app/docs" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Smoke Tests:** See step above for results" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Next Steps:**" >> $GITHUB_STEP_SUMMARY
-          echo "1. Verify smoke tests passed ✅" >> $GITHUB_STEP_SUMMARY
-          echo "2. Check database connection in logs" >> $GITHUB_STEP_SUMMARY
-          echo "3. Test critical user flows" >> $GITHUB_STEP_SUMMARY
-          echo "4. Monitor error logs for 15 minutes" >> $GITHUB_STEP_SUMMARY
-
-  # Job 3: Notify on failure
-  notify-failure:
-    name: Notify on Failure
-    runs-on: ubuntu-latest
-    needs: [test, deploy-staging]
-    if: failure()
-
-    steps:
-      - name: Deployment failed
-        run: |
-          echo "## ❌ Deployment Failed" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "The staging deployment has failed. Please check the logs above for details." >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Common Issues:**" >> $GITHUB_STEP_SUMMARY
-          echo "- Tests failed" >> $GITHUB_STEP_SUMMARY
-          echo "- Linting errors" >> $GITHUB_STEP_SUMMARY
-          echo "- DO_APP_ID_STAGING secret not set" >> $GITHUB_STEP_SUMMARY
-          echo "- DIGITALOCEAN_ACCESS_TOKEN invalid" >> $GITHUB_STEP_SUMMARY
-          echo "- Migration errors" >> $GITHUB_STEP_SUMMARY
+          echo "## Historical App Platform Deploy" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "This workflow is retained only as a historical marker." >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Active backend deployment truth:" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Validate code with .github/workflows/ci.yml" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Publish Docker image with .github/workflows/docker-deploy.yml" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Run backend runtime on Droplet + Docker Compose" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "No App Platform deployment was attempted." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -27,6 +27,15 @@ jobs:
             exit 1
           fi
 
+      - name: Validate DigitalOcean token secret
+        env:
+          DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+        run: |
+          if [ -z "$DIGITALOCEAN_ACCESS_TOKEN" ]; then
+            echo "DIGITALOCEAN_ACCESS_TOKEN repository secret is required to publish the backend image to DOCR." >&2
+            exit 1
+          fi
+
       - name: Checkout code
         uses: actions/checkout@v4
 
@@ -54,15 +63,6 @@ jobs:
           CLOUDINARY_CLOUD_NAME: test_cloud
           CLOUDINARY_API_KEY: test_key
           CLOUDINARY_API_SECRET: test_secret
-
-      - name: Validate DigitalOcean token secret
-        env:
-          DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
-        run: |
-          if [ -z "$DIGITALOCEAN_ACCESS_TOKEN" ]; then
-            echo "DIGITALOCEAN_ACCESS_TOKEN repository secret is required to publish the backend image to DOCR." >&2
-            exit 1
-          fi
 
       - name: Install doctl
         uses: digitalocean/action-doctl@v2

--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -55,6 +55,15 @@ jobs:
           CLOUDINARY_API_KEY: test_key
           CLOUDINARY_API_SECRET: test_secret
 
+      - name: Validate DigitalOcean token secret
+        env:
+          DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+        run: |
+          if [ -z "$DIGITALOCEAN_ACCESS_TOKEN" ]; then
+            echo "DIGITALOCEAN_ACCESS_TOKEN repository secret is required to publish the backend image to DOCR." >&2
+            exit 1
+          fi
+
       - name: Install doctl
         uses: digitalocean/action-doctl@v2
         with:

--- a/docs/GITHUB_ACTIONS_SETUP.md
+++ b/docs/GITHUB_ACTIONS_SETUP.md
@@ -6,6 +6,7 @@ Guide untuk setup GitHub Actions backend sesuai source of truth saat ini:
 
 - `.github/workflows/ci.yml` = validation gate (lint + test)
 - `.github/workflows/docker-deploy.yml` = build and publish Docker image ke **DigitalOcean Container Registry (DOCR)**
+- `.github/workflows/deploy-staging.yml` = manual-only historical marker, no active deploy
 - active backend runtime target = **Droplet + Docker Compose**
 - App Platform = **historical / obsolete path**
 - Kubernetes = **optional / non-active path**
@@ -22,6 +23,12 @@ Guide untuk setup GitHub Actions backend sesuai source of truth saat ini:
 - **Purpose:** build backend Docker image and push it to DOCR
 - **Output:** image tags in `registry.digitalocean.com/infinit-track/infinit-track-backend`
 - **Guardrail:** manual dispatch is still enforced to publish only from branch `master`
+- **Required secret:** `DIGITALOCEAN_ACCESS_TOKEN`; the workflow fails fast with an explicit message when it is missing
+
+### 3. Historical App Platform marker (`deploy-staging.yml`)
+- **Trigger:** manual dispatch only
+- **Purpose:** document that App Platform deployment is not the active backend path
+- **Output:** summary only; no `doctl apps create-deployment` call is made
 
 ### Current non-goals
 - GitHub Actions does **not** deploy backend runtime directly to the droplet yet.

--- a/docs/PRODUCTION_DEPLOYMENT.md
+++ b/docs/PRODUCTION_DEPLOYMENT.md
@@ -72,6 +72,7 @@ They are not part of the supported active backend deploy path and should be trea
 - [ ] DOCR workflow pushes `latest` successfully
 - [ ] image appears in `registry.digitalocean.com/infinit-track/infinit-track-backend`
 - [ ] no runtime deployment is implied by the publish workflow summary
+- [ ] historical App Platform workflow remains manual-only and does not trigger from `master`
 
 ### Minimum verification for runtime pull phase
 - [ ] droplet can authenticate to the registry

--- a/tests/configContract.test.js
+++ b/tests/configContract.test.js
@@ -199,5 +199,8 @@ describe('backend runtime config contract', () => {
     expect(workflow).toContain('DIGITALOCEAN_ACCESS_TOKEN repository secret is required');
     expect(workflow).toContain('digitalocean/action-doctl@v2');
     expect(workflow).toContain('docker/build-push-action@v5');
+    expect(workflow.indexOf('Validate DigitalOcean token secret')).toBeLessThan(
+      workflow.indexOf('Checkout code')
+    );
   });
 });

--- a/tests/configContract.test.js
+++ b/tests/configContract.test.js
@@ -23,6 +23,10 @@ function readDockerCompose() {
   return fs.readFileSync(path.resolve(repoRoot, 'docker-compose.yml'), 'utf8');
 }
 
+function readWorkflow(name) {
+  return fs.readFileSync(path.resolve(repoRoot, '.github/workflows', name), 'utf8');
+}
+
 function loadCliConfig() {
   const require = createRequire(import.meta.url);
   const configPath = path.resolve(repoRoot, 'src/config/database-cli.cjs');
@@ -177,5 +181,23 @@ describe('backend runtime config contract', () => {
 
     expect(`${appSpec}\n${productionAppSpec}\n${appReadme}`).toContain('GEOAPIFY_API_KEY');
     expect(`${appSpec}\n${productionAppSpec}\n${appReadme}`).not.toContain('GEOAPIFY_KEY');
+  });
+
+  test('keeps historical App Platform deploy manual-only and non-deploying', () => {
+    const workflow = readWorkflow('deploy-staging.yml');
+
+    expect(workflow).toContain('workflow_dispatch:');
+    expect(workflow).not.toContain('branches:');
+    expect(workflow).not.toContain('doctl apps create-deployment');
+    expect(workflow).toContain('No App Platform deployment was attempted.');
+  });
+
+  test('requires a DigitalOcean token before publishing backend image to DOCR', () => {
+    const workflow = readWorkflow('docker-deploy.yml');
+
+    expect(workflow).toContain('Validate DigitalOcean token secret');
+    expect(workflow).toContain('DIGITALOCEAN_ACCESS_TOKEN repository secret is required');
+    expect(workflow).toContain('digitalocean/action-doctl@v2');
+    expect(workflow).toContain('docker/build-push-action@v5');
   });
 });


### PR DESCRIPTION
## Summary
- disable the obsolete App Platform workflow from auto-running on `master` by turning it into a manual-only historical marker
- add an explicit `DIGITALOCEAN_ACCESS_TOKEN` preflight to the DOCR publish workflow so missing credentials fail clearly
- align workflow contract tests and deployment docs with the active DOCR + Droplet runtime path

## Test plan
- [x] `npm test -- --runTestsByPath tests/configContract.test.js`
- [x] `npm test`

## Impact
- `master` no longer shows a false-red deploy failure from a historical App Platform path
- the real DOCR publish workflow still fails when credentials are missing, but now does so with a direct actionable message

## Risk
- low code-path risk because only workflow/docs/test contract files changed
- moderate operational importance because these files shape release and deployment signals

## Verification evidence
- local targeted contract test passed
- full Jest suite passed locally

## Docs/ADR update required
- docs updated in this branch; no ADR added

🤖 Generated with [Claude Code](https://claude.com/claude-code)