### PR TITLE
INF-159 finalize dashboard analytics aggregation contract

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1601,45 +1601,64 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
 
-  /api/summary:
-    get:
+  /api/wfa/test-ahp:
+    post:
       tags:
-        - Reports & Analytics
-      summary: Get summary report (Admin/Management only)
-      description: Get comprehensive attendance and performance summary report
-      parameters:
-        - in: query
-          name: start_date
-          schema:
-            type: string
-            format: date
-          description: Start date for report period (YYYY-MM-DD)
-        - in: query
-          name: end_date
-          schema:
-            type: string
-            format: date
-          description: End date for report period (YYYY-MM-DD)
-        - in: query
-          name: division_id
-          schema:
-            type: integer
-          description: Filter by specific division
-        - in: query
-          name: user_id
-          schema:
-            type: integer
-          description: Filter by specific user
-        - in: query
-          name: report_type
-          schema:
-            type: string
-            enum: [attendance, discipline, wfa, overview]
-            default: overview
-          description: Type of summary report to generate
+        - WFA System
+      summary: Test Fuzzy AHP algorithm (Admin only)
+      description: Test the Fuzzy AHP algorithm with custom values
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                test_locations:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                        example: 'Test Cafe'
+                      wifi_quality:
+                        type: number
+                        format: float
+                        example: 4.5
+                      noise_level:
+                        type: number
+                        format: float
+                        example: 3.0
+                      amenities:
+                        type: integer
+                        example: 8
+                      distance:
+                        type: number
+                        format: float
+                        example: 500.0
+                custom_weights:
+                  type: object
+                  properties:
+                    wifi_quality:
+                      type: number
+                      format: float
+                      example: 0.4
+                    noise_level:
+                      type: number
+                      format: float
+                      example: 0.3
+                    amenities:
+                      type: number
+                      format: float
+                      example: 0.2
+                    distance:
+                      type: number
+                      format: float
+                      example: 0.1
       responses:
         '200':
-          description: Summary report generated successfully
+          description: AHP test completed successfully
           content:
             application/json:
               schema:
@@ -1651,78 +1670,410 @@ paths:
                   data:
                     type: object
                     properties:
-                      period:
+                      test_results:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            location:
+                              type: string
+                              example: 'Test Cafe'
+                            score:
+                              type: number
+                              format: float
+                              example: 0.87
+                            ranking:
+                              type: integer
+                              example: 1
+                      algorithm_details:
+                        type: object
+                        description: Detailed algorithm computation results
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  # Job Management Endpoints
+  /api/jobs/status:
+    get:
+      tags:
+        - Job Management
+      summary: Get jobs status (Admin only)
+      description: Get status and information about all cron jobs
+      responses:
+        '200':
+          description: Jobs status retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: object
+                    properties:
+                      jobs:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/JobStatus'
+                      server_info:
                         type: object
                         properties:
-                          start_date:
+                          uptime:
                             type: string
-                            format: date
-                            example: '2025-07-01'
-                          end_date:
+                            example: '2 hours, 15 minutes'
+                          timezone:
                             type: string
-                            format: date
-                            example: '2025-07-31'
-                      overview:
+                            example: 'Asia/Jakarta'
+                          current_time:
+                            type: string
+                            example: '2025-07-05 15:30:00 WIB'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /api/jobs/trigger/general-alpha:
+    post:
+      tags:
+        - Job Management
+      summary: Trigger General Alpha job (Admin only)
+      description: Manually trigger the general alpha generation job
+      responses:
+        '200':
+          description: General Alpha job triggered successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  message:
+                    type: string
+                    example: 'General Alpha job triggered successfully'
+                  data:
+                    type: object
+                    properties:
+                      job_id:
+                        type: string
+                        example: 'general-alpha-20250705-153000'
+                      execution_time:
+                        type: string
+                        example: '2025-07-05 15:30:00 WIB'
+                      records_processed:
+                        type: integer
+                        example: 25
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /api/jobs/trigger/wfa-bookings:
+    post:
+      tags:
+        - Job Management
+      summary: Trigger WFA bookings job (Admin only)
+      description: Manually trigger the WFA bookings resolution job
+      responses:
+        '200':
+          description: WFA bookings job triggered successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  message:
+                    type: string
+                    example: 'WFA bookings job triggered successfully'
+                  data:
+                    type: object
+                    properties:
+                      job_id:
+                        type: string
+                        example: 'wfa-bookings-20250705-153000'
+                      execution_time:
+                        type: string
+                        example: '2025-07-05 15:30:00 WIB'
+                      bookings_processed:
+                        type: integer
+                        example: 5
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /api/jobs/trigger/auto-checkout:
+    post:
+      tags:
+        - Job Management
+      summary: Trigger auto checkout job (Admin only)
+      description: Manually trigger the smart auto checkout job
+      responses:
+        '200':
+          description: Auto checkout job triggered successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  message:
+                    type: string
+                    example: 'Auto checkout job triggered successfully'
+                  data:
+                    type: object
+                    properties:
+                      job_id:
+                        type: string
+                        example: 'auto-checkout-20250705-153000'
+                      execution_time:
+                        type: string
+                        example: '2025-07-05 15:30:00 WIB'
+                      users_processed:
+                        type: integer
+                        example: 12
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /api/jobs/trigger/all:
+    post:
+      tags:
+        - Job Management
+      summary: Trigger all jobs (Admin only)
+      description: Manually trigger all available jobs in sequence
+      responses:
+        '200':
+          description: All jobs triggered successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  message:
+                    type: string
+                    example: 'All jobs triggered successfully'
+                  data:
+                    type: object
+                    properties:
+                      jobs_executed:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            job_name:
+                              type: string
+                              example: 'general-alpha'
+                            status:
+                              type: string
+                              example: 'completed'
+                            execution_time:
+                              type: string
+                              example: '2025-07-05 15:30:00 WIB'
+                            records_processed:
+                              type: integer
+                              example: 25
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  # Summary & Reports Endpoints
+  /api/summary/dashboard-analytics:
+    get:
+      tags:
+        - Reports & Analytics
+      summary: Get dashboard analytics aggregation
+      description: Retrieve dashboard-ready aggregated attendance, mode mix, today locations, and lightweight Fuzzy AHP snapshots for Admin or Management users.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: period
+          schema:
+            type: string
+            enum: [30d, current_month, custom]
+            default: 30d
+          description: Historical aggregation window. Use `custom` together with `from` and `to`.
+        - in: query
+          name: from
+          schema:
+            type: string
+            format: date
+            example: '2026-04-01'
+          description: Custom range start date in `YYYY-MM-DD` format. Required when `period=custom`.
+        - in: query
+          name: to
+          schema:
+            type: string
+            format: date
+            example: '2026-04-30'
+          description: Custom range end date in `YYYY-MM-DD` format. Required when `period=custom`.
+      responses:
+        '200':
+          description: Dashboard analytics retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: object
+                    properties:
+                      meta:
                         type: object
                         properties:
-                          total_employees:
-                            type: integer
-                            example: 45
-                          total_attendances:
-                            type: integer
-                            example: 950
-                          average_attendance_rate:
-                            type: number
-                            format: float
-                            example: 92.5
-                          total_wfa_bookings:
-                            type: integer
-                            example: 25
-                          on_time_percentage:
-                            type: number
-                            format: float
-                            example: 87.3
-                      attendance_summary:
-                        type: object
-                        properties:
-                          present_days:
-                            type: integer
-                            example: 880
-                          late_days:
-                            type: integer
-                            example: 70
-                          alpha_days:
-                            type: integer
-                            example: 15
-                          wfa_days:
-                            type: integer
-                            example: 25
-                      discipline_summary:
-                        type: object
-                        properties:
-                          average_discipline_index:
-                            type: number
-                            format: float
-                            example: 8.7
-                          top_performers:
+                          generated_at:
+                            type: string
+                            format: date-time
+                            nullable: true
+                            example: null
+                          timezone:
+                            type: string
+                            example: Asia/Jakarta
+                          requested_window:
+                            type: object
+                            description: Raw window sesuai query client. Untuk period default seperti 30d, from/to dapat bernilai null.
+                            properties:
+                              period:
+                                type: string
+                                example: custom
+                              from:
+                                type: string
+                                format: date
+                                nullable: true
+                                example: '2026-04-01'
+                              to:
+                                type: string
+                                format: date
+                                nullable: true
+                                example: '2026-04-30'
+                          section_windows:
+                            type: object
+                            description: Window efektif yang benar-benar dipakai untuk agregasi historis dan snapshot fuzzy AHP.
+                            properties:
+                              executive_kpis:
+                                type: object
+                                properties:
+                                  from:
+                                    type: string
+                                    format: date
+                                    nullable: true
+                                    example: '2026-04-01'
+                                  to:
+                                    type: string
+                                    format: date
+                                    nullable: true
+                                    example: '2026-04-30'
+                              historical_trend:
+                                type: object
+                                properties:
+                                  from:
+                                    type: string
+                                    format: date
+                                    nullable: true
+                                    example: '2026-04-01'
+                                  to:
+                                    type: string
+                                    format: date
+                                    nullable: true
+                                    example: '2026-04-30'
+                              mode_mix:
+                                type: object
+                                properties:
+                                  from:
+                                    type: string
+                                    format: date
+                                    nullable: true
+                                    example: '2026-04-01'
+                                  to:
+                                    type: string
+                                    format: date
+                                    nullable: true
+                                    example: '2026-04-30'
+                              fuzzy_ahp_snapshot:
+                                type: object
+                                properties:
+                                  from:
+                                    type: string
+                                    format: date
+                                    nullable: true
+                                    example: '2026-04-01'
+                                  to:
+                                    type: string
+                                    format: date
+                                    nullable: true
+                                    example: '2026-04-30'
+                              today_locations:
+                                type: object
+                                properties:
+                                  mode:
+                                    type: string
+                                    example: jakarta_today
+                          sources:
                             type: array
                             items:
-                              type: object
-                              properties:
-                                user_id:
-                                  type: integer
-                                  example: 5
-                                full_name:
-                                  type: string
-                                  example: 'John Doe'
-                                discipline_index:
-                                  type: number
-                                  format: float
-                                  example: 9.8
-                      charts_data:
+                              type: string
+                            example: [Attendance, AttendanceCategory, AttendanceStatus, Location, User]
+                      executive_kpis:
                         type: object
                         properties:
-                          daily_attendance:
+                          total_attendance_records:
+                            type: integer
+                            example: 3
+                          total_present:
+                            type: integer
+                            example: 2
+                          total_alpha:
+                            type: integer
+                            example: 1
+                          total_wfo:
+                            type: integer
+                            example: 1
+                          total_wfh:
+                            type: integer
+                            example: 1
+                          total_wfa:
+                            type: integer
+                            example: 1
+                          discipline_average:
+                            type: number
+                            format: float
+                            nullable: true
+                            example: 82
+                          discipline_users_analyzed:
+                            type: integer
+                            example: 2
+                      historical_trend:
+                        type: object
+                        properties:
+                          points:
                             type: array
                             items:
                               type: object
@@ -1730,32 +2081,544 @@ paths:
                                 date:
                                   type: string
                                   format: date
-                                  example: '2025-07-05'
+                                  example: '2026-04-01'
                                 present:
                                   type: integer
-                                  example: 42
-                                late:
-                                  type: integer
-                                  example: 3
+                                  example: 1
                                 alpha:
                                   type: integer
                                   example: 0
-                          division_performance:
+                                wfo:
+                                  type: integer
+                                  example: 1
+                                wfh:
+                                  type: integer
+                                  example: 0
+                                wfa:
+                                  type: integer
+                                  example: 0
+                      mode_mix:
+                        type: object
+                        properties:
+                          totals:
+                            type: object
+                            properties:
+                              wfo:
+                                type: integer
+                                example: 1
+                              wfh:
+                                type: integer
+                                example: 1
+                              wfa:
+                                type: integer
+                                example: 1
+                          percentages:
+                            type: object
+                            properties:
+                              wfo:
+                                type: number
+                                format: float
+                                example: 33.3333333333
+                              wfh:
+                                type: number
+                                format: float
+                                example: 33.3333333333
+                              wfa:
+                                type: number
+                                format: float
+                                example: 33.3333333333
+                      today_locations:
+                        type: object
+                        properties:
+                          date:
+                            type: string
+                            format: date
+                            example: '2026-05-03'
+                          timezone:
+                            type: string
+                            example: Asia/Jakarta
+                          total_users:
+                            type: integer
+                            example: 2
+                          locations:
                             type: array
                             items:
                               type: object
                               properties:
-                                division_name:
+                                user_id:
+                                  type: integer
+                                  example: 7
+                                full_name:
                                   type: string
-                                  example: 'Engineering'
-                                attendance_rate:
+                                  example: Febri
+                                photo:
+                                  type: string
+                                  nullable: true
+                                  example: null
+                                status:
+                                  type: string
+                                  example: WFO
+                                check_in_time:
+                                  type: string
+                                  example: '08:15'
+                                latitude:
                                   type: number
                                   format: float
-                                  example: 95.2
-                                average_discipline:
+                                  example: -0.8917
+                                longitude:
                                   type: number
                                   format: float
-                                  example: 9.1
+                                  example: 119.8707
+                      fuzzy_ahp_snapshot:
+                        type: object
+                        properties:
+                          discipline:
+                            type: object
+                            properties:
+                              generated_at:
+                                type: string
+                                format: date-time
+                                nullable: true
+                                example: null
+                              window:
+                                type: object
+                                properties:
+                                  from:
+                                    type: string
+                                    format: date
+                                    nullable: true
+                                    example: '2026-04-01'
+                                  to:
+                                    type: string
+                                    format: date
+                                    nullable: true
+                                    example: '2026-04-30'
+                              weights:
+                                type: object
+                                additionalProperties:
+                                  type: number
+                                  format: float
+                                example:
+                                  alpha_rate: 0.6
+                                  lateness_severity: 0.4
+                              consistency:
+                                type: object
+                                nullable: true
+                                properties:
+                                  CR:
+                                    type: number
+                                    format: float
+                                    example: 0.021
+                                  threshold:
+                                    type: number
+                                    format: float
+                                    example: 0.1
+                                  is_consistent:
+                                    type: boolean
+                                    example: true
+                              top_rank:
+                                type: object
+                                nullable: true
+                                properties:
+                                  id:
+                                    type: integer
+                                    example: 7
+                                  name:
+                                    type: string
+                                    example: Febri
+                                  score:
+                                    type: number
+                                    format: float
+                                    example: 84
+                                  label:
+                                    type: string
+                                    example: Tinggi
+                              distribution:
+                                type: object
+                                additionalProperties:
+                                  type: integer
+                                example:
+                                  Tinggi: 1
+                                  Sedang: 1
+                          wfa:
+                            type: object
+                            properties:
+                              generated_at:
+                                type: string
+                                format: date-time
+                                nullable: true
+                                example: null
+                              window:
+                                type: object
+                                properties:
+                                  from:
+                                    type: string
+                                    format: date
+                                    nullable: true
+                                    example: '2026-04-01'
+                                  to:
+                                    type: string
+                                    format: date
+                                    nullable: true
+                                    example: '2026-04-30'
+                              weights:
+                                type: object
+                                additionalProperties:
+                                  type: number
+                                  format: float
+                                example:
+                                  location_type: 0.55
+                                  distance_factor: 0.45
+                              consistency:
+                                type: object
+                                nullable: true
+                                properties:
+                                  CR:
+                                    type: number
+                                    format: float
+                                    example: 0.018
+                                  threshold:
+                                    type: number
+                                    format: float
+                                    example: 0.1
+                                  is_consistent:
+                                    type: boolean
+                                    example: true
+                              top_rank:
+                                type: object
+                                nullable: true
+                                properties:
+                                  id:
+                                    type: integer
+                                    example: 31
+                                  name:
+                                    type: string
+                                    example: Cafe Satu
+                                  score:
+                                    type: number
+                                    format: float
+                                    example: 90
+                                  label:
+                                    type: string
+                                    example: Sangat Tinggi
+                              distribution:
+                                type: object
+                                additionalProperties:
+                                  type: integer
+                                example:
+                                  Sangat Tinggi: 1
+                                  Tinggi: 1
+                          smart_ac:
+                            type: object
+                            properties:
+                              generated_at:
+                                type: string
+                                format: date-time
+                                nullable: true
+                                example: null
+                              window:
+                                type: object
+                                properties:
+                                  from:
+                                    type: string
+                                    format: date
+                                    nullable: true
+                                    example: '2026-04-01'
+                                  to:
+                                    type: string
+                                    format: date
+                                    nullable: true
+                                    example: '2026-04-30'
+                              weights:
+                                type: object
+                                additionalProperties:
+                                  type: number
+                                  format: float
+                                example:
+                                  history: 0.4
+                                  context: 0.6
+                              consistency:
+                                type: object
+                                nullable: true
+                                properties:
+                                  CR:
+                                    type: number
+                                    format: float
+                                    example: 0
+                                  threshold:
+                                    type: number
+                                    format: float
+                                    example: 0.1
+                                  is_consistent:
+                                    type: boolean
+                                    example: true
+                              top_rank:
+                                type: object
+                                nullable: true
+                                properties:
+                                  id:
+                                    type: integer
+                                    example: 8
+                                  name:
+                                    type: string
+                                    example: Diana
+                                  score:
+                                    type: number
+                                    format: float
+                                    example: 72
+                                  label:
+                                    type: string
+                                    example: Tinggi
+                              distribution:
+                                type: object
+                                additionalProperties:
+                                  type: integer
+                                example:
+                                  Tinggi: 1
+                                  Sedang: 1
+                      insights:
+                        type: object
+                        properties:
+                          items:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                type:
+                                  type: string
+                                  example: alpha_spike
+                                title:
+                                  type: string
+                                  example: Alpha rate elevated
+                                message:
+                                  type: string
+                                  example: Alpha reached 33.3% of attendance records in the selected window.
+                                severity:
+                                  type: string
+                                  example: high
+                  message:
+                    type: string
+                    example: Dashboard analytics retrieved successfully
+        '400':
+          description: Invalid dashboard analytics query parameters
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  code:
+                    type: string
+                    example: E_VALIDATION
+                  message:
+                    type: string
+                    example: Rentang tanggal custom maksimal 31 hari
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /api/summary:
+    get:
+      tags:
+        - Reports & Analytics
+      summary: Get summary report (Admin/Management only)
+      description: Retrieve legacy summary aggregates, attendance report rows, and discipline-analysis overview for Admin or Management users.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: period
+          schema:
+            type: string
+            enum: [daily, weekly, monthly, all]
+            default: daily
+          description: Summary window preset used by the backend.
+        - in: query
+          name: page
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+          description: Report pagination page number.
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+            default: 10
+          description: Number of attendance rows returned in the report section.
+      responses:
+        '200':
+          description: Summary report with discipline analysis generated successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  summary:
+                    type: object
+                    properties:
+                      total_ontime:
+                        type: integer
+                        example: 14
+                      total_late:
+                        type: integer
+                        example: 3
+                      total_alpha:
+                        type: integer
+                        example: 1
+                      total_wfo:
+                        type: integer
+                        example: 10
+                      total_wfh:
+                        type: integer
+                        example: 5
+                      total_wfa:
+                        type: integer
+                        example: 3
+                  report:
+                    type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            id_attendance:
+                              type: integer
+                              example: 101
+                            attendance_date:
+                              type: string
+                              format: date
+                              example: '2026-05-04'
+                            time_in:
+                              type: string
+                              nullable: true
+                              example: '08:03'
+                            time_out:
+                              type: string
+                              nullable: true
+                              example: '17:01'
+                            work_hour:
+                              type: string
+                              nullable: true
+                              example: '08:58'
+                            user:
+                              type: object
+                              properties:
+                                id_users:
+                                  type: integer
+                                  example: 7
+                                full_name:
+                                  type: string
+                                  example: Febri
+                            role:
+                              type: object
+                              nullable: true
+                              properties:
+                                role_name:
+                                  type: string
+                                  example: User
+                            location:
+                              type: object
+                              nullable: true
+                              properties:
+                                description:
+                                  type: string
+                                  example: Kantor Pusat
+                            attendance_category:
+                              type: object
+                              nullable: true
+                              properties:
+                                category_name:
+                                  type: string
+                                  example: Work From Office
+                            status:
+                              type: object
+                              nullable: true
+                              properties:
+                                attendance_status_name:
+                                  type: string
+                                  example: Ontime
+                      pagination:
+                        type: object
+                        properties:
+                          current_page:
+                            type: integer
+                            example: 1
+                          total_pages:
+                            type: integer
+                            example: 2
+                          total_items:
+                            type: integer
+                            example: 15
+                          items_per_page:
+                            type: integer
+                            example: 10
+                          has_next_page:
+                            type: boolean
+                            example: true
+                          has_prev_page:
+                            type: boolean
+                            example: false
+                  analytics:
+                    type: object
+                    properties:
+                      discipline_analysis:
+                        type: object
+                        properties:
+                          users_analyzed:
+                            type: integer
+                            example: 12
+                          average_discipline_score:
+                            type: number
+                            format: float
+                            example: 74.25
+                          methodology:
+                            type: string
+                            example: Fuzzy AHP Engine
+                          criteria:
+                            type: array
+                            items:
+                              type: string
+                            example: [Alpha Rate, Lateness Severity, Lateness Frequency, Work Focus]
+                  period:
+                    type: string
+                    example: monthly
+                  date_range:
+                    type: object
+                    properties:
+                      start_date:
+                        type: string
+                        example: '2026-05-01'
+                      end_date:
+                        type: string
+                        example: '2026-05-31'
+                  message:
+                    type: string
+                    example: Summary report with discipline analysis generated successfully
+        '400':
+          description: Invalid summary period value
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  code:
+                    type: string
+                    example: E_VALIDATION
+                  message:
+                    type: string
+                    example: Parameter period harus berupa: daily, weekly, monthly, atau all
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -417,6 +417,12 @@ paths:
                       timezone:
                         type: string
                         example: 'Asia/Jakarta'
+                      snapshot_type:
+                        type: string
+                        example: 'attendance_checkin_snapshot'
+                      is_live_tracking:
+                        type: boolean
+                        example: false
                       total_users:
                         type: integer
                         example: 1
@@ -454,6 +460,8 @@ paths:
                   data:
                     date: '2026-04-22'
                     timezone: 'Asia/Jakarta'
+                    snapshot_type: 'attendance_checkin_snapshot'
+                    is_live_tracking: false
                     total_users: 1
                     locations:
                       - user_id: 7
@@ -1601,306 +1609,6 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
 
-  /api/wfa/test-ahp:
-    post:
-      tags:
-        - WFA System
-      summary: Test Fuzzy AHP algorithm (Admin only)
-      description: Test the Fuzzy AHP algorithm with custom values
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                test_locations:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      name:
-                        type: string
-                        example: 'Test Cafe'
-                      wifi_quality:
-                        type: number
-                        format: float
-                        example: 4.5
-                      noise_level:
-                        type: number
-                        format: float
-                        example: 3.0
-                      amenities:
-                        type: integer
-                        example: 8
-                      distance:
-                        type: number
-                        format: float
-                        example: 500.0
-                custom_weights:
-                  type: object
-                  properties:
-                    wifi_quality:
-                      type: number
-                      format: float
-                      example: 0.4
-                    noise_level:
-                      type: number
-                      format: float
-                      example: 0.3
-                    amenities:
-                      type: number
-                      format: float
-                      example: 0.2
-                    distance:
-                      type: number
-                      format: float
-                      example: 0.1
-      responses:
-        '200':
-          description: AHP test completed successfully
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  success:
-                    type: boolean
-                    example: true
-                  data:
-                    type: object
-                    properties:
-                      test_results:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            location:
-                              type: string
-                              example: 'Test Cafe'
-                            score:
-                              type: number
-                              format: float
-                              example: 0.87
-                            ranking:
-                              type: integer
-                              example: 1
-                      algorithm_details:
-                        type: object
-                        description: Detailed algorithm computation results
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-
-  # Job Management Endpoints
-  /api/jobs/status:
-    get:
-      tags:
-        - Job Management
-      summary: Get jobs status (Admin only)
-      description: Get status and information about all cron jobs
-      responses:
-        '200':
-          description: Jobs status retrieved successfully
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  success:
-                    type: boolean
-                    example: true
-                  data:
-                    type: object
-                    properties:
-                      jobs:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/JobStatus'
-                      server_info:
-                        type: object
-                        properties:
-                          uptime:
-                            type: string
-                            example: '2 hours, 15 minutes'
-                          timezone:
-                            type: string
-                            example: 'Asia/Jakarta'
-                          current_time:
-                            type: string
-                            example: '2025-07-05 15:30:00 WIB'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-
-  /api/jobs/trigger/general-alpha:
-    post:
-      tags:
-        - Job Management
-      summary: Trigger General Alpha job (Admin only)
-      description: Manually trigger the general alpha generation job
-      responses:
-        '200':
-          description: General Alpha job triggered successfully
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  success:
-                    type: boolean
-                    example: true
-                  message:
-                    type: string
-                    example: 'General Alpha job triggered successfully'
-                  data:
-                    type: object
-                    properties:
-                      job_id:
-                        type: string
-                        example: 'general-alpha-20250705-153000'
-                      execution_time:
-                        type: string
-                        example: '2025-07-05 15:30:00 WIB'
-                      records_processed:
-                        type: integer
-                        example: 25
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-
-  /api/jobs/trigger/wfa-bookings:
-    post:
-      tags:
-        - Job Management
-      summary: Trigger WFA bookings job (Admin only)
-      description: Manually trigger the WFA bookings resolution job
-      responses:
-        '200':
-          description: WFA bookings job triggered successfully
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  success:
-                    type: boolean
-                    example: true
-                  message:
-                    type: string
-                    example: 'WFA bookings job triggered successfully'
-                  data:
-                    type: object
-                    properties:
-                      job_id:
-                        type: string
-                        example: 'wfa-bookings-20250705-153000'
-                      execution_time:
-                        type: string
-                        example: '2025-07-05 15:30:00 WIB'
-                      bookings_processed:
-                        type: integer
-                        example: 5
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-
-  /api/jobs/trigger/auto-checkout:
-    post:
-      tags:
-        - Job Management
-      summary: Trigger auto checkout job (Admin only)
-      description: Manually trigger the smart auto checkout job
-      responses:
-        '200':
-          description: Auto checkout job triggered successfully
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  success:
-                    type: boolean
-                    example: true
-                  message:
-                    type: string
-                    example: 'Auto checkout job triggered successfully'
-                  data:
-                    type: object
-                    properties:
-                      job_id:
-                        type: string
-                        example: 'auto-checkout-20250705-153000'
-                      execution_time:
-                        type: string
-                        example: '2025-07-05 15:30:00 WIB'
-                      users_processed:
-                        type: integer
-                        example: 12
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-
-  /api/jobs/trigger/all:
-    post:
-      tags:
-        - Job Management
-      summary: Trigger all jobs (Admin only)
-      description: Manually trigger all available jobs in sequence
-      responses:
-        '200':
-          description: All jobs triggered successfully
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  success:
-                    type: boolean
-                    example: true
-                  message:
-                    type: string
-                    example: 'All jobs triggered successfully'
-                  data:
-                    type: object
-                    properties:
-                      jobs_executed:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            job_name:
-                              type: string
-                              example: 'general-alpha'
-                            status:
-                              type: string
-                              example: 'completed'
-                            execution_time:
-                              type: string
-                              example: '2025-07-05 15:30:00 WIB'
-                            records_processed:
-                              type: integer
-                              example: 25
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-
   # Summary & Reports Endpoints
   /api/summary/dashboard-analytics:
     get:
@@ -1952,8 +1660,7 @@ paths:
                           generated_at:
                             type: string
                             format: date-time
-                            nullable: true
-                            example: null
+                            example: '2026-05-03T02:30:00.000Z'
                           timezone:
                             type: string
                             example: Asia/Jakarta
@@ -1976,7 +1683,7 @@ paths:
                                 example: '2026-04-30'
                           section_windows:
                             type: object
-                            description: Window efektif yang benar-benar dipakai untuk agregasi historis dan snapshot fuzzy AHP.
+                            description: Window efektif yang benar-benar dipakai untuk agregasi historis, geofence context, dan snapshot fuzzy AHP.
                             properties:
                               executive_kpis:
                                 type: object
@@ -2030,6 +1737,19 @@ paths:
                                     format: date
                                     nullable: true
                                     example: '2026-04-30'
+                              geofence_evidence_context:
+                                type: object
+                                properties:
+                                  from:
+                                    type: string
+                                    format: date
+                                    nullable: true
+                                    example: '2026-04-01'
+                                  to:
+                                    type: string
+                                    format: date
+                                    nullable: true
+                                    example: '2026-04-30'
                               today_locations:
                                 type: object
                                 properties:
@@ -2040,36 +1760,56 @@ paths:
                             type: array
                             items:
                               type: string
-                            example: [Attendance, AttendanceCategory, AttendanceStatus, Location, User]
+                            example: [Attendance, AttendanceCategory, AttendanceStatus, Location, LocationEvent, User]
                       executive_kpis:
                         type: object
                         properties:
-                          total_attendance_records:
-                            type: integer
-                            example: 3
-                          total_present:
-                            type: integer
-                            example: 2
-                          total_alpha:
-                            type: integer
-                            example: 1
-                          total_wfo:
-                            type: integer
-                            example: 1
-                          total_wfh:
-                            type: integer
-                            example: 1
-                          total_wfa:
-                            type: integer
-                            example: 1
-                          discipline_average:
+                          attendance_rate:
+                            type: number
+                            format: float
+                            example: 66.67
+                          late_alpha_risk:
+                            type: number
+                            format: float
+                            example: 66.67
+                          avg_discipline:
                             type: number
                             format: float
                             nullable: true
                             example: 82
-                          discipline_users_analyzed:
+                          needs_attention:
                             type: integer
-                            example: 2
+                            example: 1
+                          raw_counts:
+                            type: object
+                            properties:
+                              total_attendance_records:
+                                type: integer
+                                example: 3
+                              total_present:
+                                type: integer
+                                example: 2
+                              total_alpha:
+                                type: integer
+                                example: 1
+                              total_late:
+                                type: integer
+                                example: 1
+                              total_on_time:
+                                type: integer
+                                example: 1
+                              total_wfo:
+                                type: integer
+                                example: 1
+                              total_wfh:
+                                type: integer
+                                example: 1
+                              total_wfa:
+                                type: integer
+                                example: 1
+                              discipline_users_analyzed:
+                                type: integer
+                                example: 2
                       historical_trend:
                         type: object
                         properties:
@@ -2082,6 +1822,12 @@ paths:
                                   type: string
                                   format: date
                                   example: '2026-04-01'
+                                on_time:
+                                  type: integer
+                                  example: 1
+                                late:
+                                  type: integer
+                                  example: 0
                                 present:
                                   type: integer
                                   example: 1
@@ -2118,15 +1864,15 @@ paths:
                               wfo:
                                 type: number
                                 format: float
-                                example: 33.3333333333
+                                example: 33.33
                               wfh:
                                 type: number
                                 format: float
-                                example: 33.3333333333
+                                example: 33.33
                               wfa:
                                 type: number
                                 format: float
-                                example: 33.3333333333
+                                example: 33.33
                       today_locations:
                         type: object
                         properties:
@@ -2137,6 +1883,12 @@ paths:
                           timezone:
                             type: string
                             example: Asia/Jakarta
+                          snapshot_type:
+                            type: string
+                            example: attendance_checkin_snapshot
+                          is_live_tracking:
+                            type: boolean
+                            example: false
                           total_users:
                             type: integer
                             example: 2
@@ -2169,17 +1921,61 @@ paths:
                                   type: number
                                   format: float
                                   example: 119.8707
+                      geofence_evidence_context:
+                        type: object
+                        properties:
+                          status:
+                            type: string
+                            enum: [available, no_events]
+                            example: available
+                          authority:
+                            type: string
+                            example: context_only
+                          final_attendance_authority:
+                            type: string
+                            example: attendance_records
+                          window:
+                            type: object
+                            properties:
+                              from:
+                                type: string
+                                format: date
+                                nullable: true
+                                example: '2026-04-01'
+                              to:
+                                type: string
+                                format: date
+                                nullable: true
+                                example: '2026-04-30'
+                          raw_counts:
+                            type: object
+                            properties:
+                              total_events:
+                                type: integer
+                                example: 3
+                              enter_events:
+                                type: integer
+                                example: 1
+                              exit_events:
+                                type: integer
+                                example: 2
+                              unique_users:
+                                type: integer
+                                example: 2
                       fuzzy_ahp_snapshot:
                         type: object
                         properties:
                           discipline:
                             type: object
                             properties:
+                              status:
+                                type: string
+                                enum: [ready, no_data]
+                                example: ready
                               generated_at:
                                 type: string
                                 format: date-time
-                                nullable: true
-                                example: null
+                                example: '2026-05-03T02:30:00.000Z'
                               window:
                                 type: object
                                 properties:
@@ -2243,11 +2039,14 @@ paths:
                           wfa:
                             type: object
                             properties:
+                              status:
+                                type: string
+                                enum: [ready, no_data]
+                                example: ready
                               generated_at:
                                 type: string
                                 format: date-time
-                                nullable: true
-                                example: null
+                                example: '2026-05-03T02:30:00.000Z'
                               window:
                                 type: object
                                 properties:
@@ -2311,11 +2110,14 @@ paths:
                           smart_ac:
                             type: object
                             properties:
+                              status:
+                                type: string
+                                enum: [ready, no_data]
+                                example: ready
                               generated_at:
                                 type: string
                                 format: date-time
-                                nullable: true
-                                example: null
+                                example: '2026-05-03T02:30:00.000Z'
                               window:
                                 type: object
                                 properties:

--- a/src/controllers/analysis.controller.js
+++ b/src/controllers/analysis.controller.js
@@ -13,7 +13,7 @@ const EMPTY_DISTRIBUTION = {
   'Sangat Rendah': 0
 };
 
-const getAnalysisWindow = (period) => {
+export const getAnalysisWindow = (period) => {
   const now = new Date();
   const wibNow = new Date(now.toLocaleString('en-US', { timeZone: 'Asia/Jakarta' }));
 
@@ -86,7 +86,7 @@ const buildDisciplineMetrics = (attendances, startAt, endAt) => {
   };
 };
 
-const buildDisciplineAnalysis = async ({ startAt, endAt }) => {
+export const buildDisciplineAnalysis = async ({ startAt, endAt }) => {
   const users = await User.findAll({});
   const weightsObj = fuzzyEngine.getDisciplineAhpWeights();
   const criteria = ['alpha_rate', 'lateness_severity', 'lateness_frequency', 'work_focus'];
@@ -146,7 +146,7 @@ const buildDisciplineAnalysis = async ({ startAt, endAt }) => {
   };
 };
 
-const buildWfaAnalysis = async () => {
+export const buildWfaAnalysis = async () => {
   const places = await Location.findAll({});
   const weightsObj = fuzzyEngine.getWfaAhpWeights();
   const criteria = ['location_type', 'distance_factor', 'amenity_score'];
@@ -264,7 +264,7 @@ const computeSmartAcScore = (metrics, weights) => {
   };
 };
 
-const buildSmartAcAnalysis = async ({ startAt, endAt }) => {
+export const buildSmartAcAnalysis = async ({ startAt, endAt }) => {
   const users = await User.findAll({});
   const values = getSmartAcWeights();
   const criteria = ['history', 'checkin_pattern', 'context', 'transition'];

--- a/src/controllers/analysis.controller.js
+++ b/src/controllers/analysis.controller.js
@@ -146,7 +146,7 @@ export const buildDisciplineAnalysis = async ({ startAt, endAt }) => {
   };
 };
 
-export const buildWfaAnalysis = async () => {
+export const buildWfaAnalysis = async ({ startAt: _startAt, endAt: _endAt } = {}) => {
   const places = await Location.findAll({});
   const weightsObj = fuzzyEngine.getWfaAhpWeights();
   const criteria = ['location_type', 'distance_factor', 'amenity_score'];
@@ -191,6 +191,8 @@ export const buildWfaAnalysis = async () => {
 
   return {
     entity_kind: 'place',
+    scope: 'place_catalog_static',
+    window_applied: false,
     consistency: buildConsistency({
       CR: Number(weightsObj.consistency_ratio?.toFixed?.(3) || 0),
       CI: 0,

--- a/src/controllers/attendance.controller.js
+++ b/src/controllers/attendance.controller.js
@@ -26,6 +26,7 @@ import { formatWorkHour, calculateWorkHour, formatTimeOnly } from '../utils/work
 import { applySearch } from '../utils/searchHelper.js';
 import { getOperationalSettings } from '../utils/settings.js';
 import { isAttendanceDuplicateConstraintError } from '../utils/attendanceDuplicateError.js';
+import { buildTodayLocationsSnapshot } from '../utils/todayLocationsSnapshot.js';
 import { triggerAutoCheckout, runSmartAutoCheckoutForDate } from '../jobs/autoCheckout.job.js';
 import {
   triggerResolveWfaBookings,
@@ -1245,92 +1246,11 @@ export const deleteAttendance = async (req, res, next) => {
  */
 export const getTodayLocations = async (req, res, next) => {
   try {
-    const todayDate = getJakartaDateString();
-
-    const rows = await Attendance.findAll({
-      where: {
-        attendance_date: todayDate,
-        time_in: {
-          [Op.not]: null
-        }
-      },
-      include: [
-        {
-          model: User,
-          as: 'user',
-          attributes: ['id_users', 'full_name'],
-          include: [
-            {
-              model: Photo,
-              as: 'photo_file',
-              attributes: ['photo_url'],
-              required: false
-            }
-          ]
-        },
-        {
-          model: Location,
-          as: 'location',
-          attributes: ['latitude', 'longitude'],
-          required: false
-        },
-        {
-          model: AttendanceCategory,
-          as: 'attendance_category',
-          attributes: ['category_name']
-        }
-      ],
-      order: [['time_in', 'ASC']]
-    });
-
-    const heroMapStatusByCategory = {
-      WFO: 'WFO',
-      WFH: 'WFH',
-      WFA: 'WFA',
-      'Work From Office': 'WFO',
-      'Work From Home': 'WFH',
-      'Work From Anywhere': 'WFA'
-    };
-
-    const locations = rows
-      .map((attendance) => {
-        const latitude =
-          attendance.location?.latitude != null ? parseFloat(attendance.location.latitude) : null;
-        const longitude =
-          attendance.location?.longitude != null ? parseFloat(attendance.location.longitude) : null;
-        const categoryName = attendance.attendance_category?.category_name;
-        const status = categoryName ? heroMapStatusByCategory[categoryName] ?? null : null;
-
-        if (
-          latitude == null ||
-          longitude == null ||
-          Number.isNaN(latitude) ||
-          Number.isNaN(longitude) ||
-          !status
-        ) {
-          return null;
-        }
-
-        return {
-          user_id: attendance.user?.id_users,
-          full_name: attendance.user?.full_name || 'Unknown User',
-          photo: attendance.user?.photo_file?.photo_url || null,
-          status,
-          check_in_time: formatTimeOnly(attendance.time_in),
-          latitude,
-          longitude
-        };
-      })
-      .filter(Boolean);
+    const data = await buildTodayLocationsSnapshot();
 
     return res.status(200).json({
       success: true,
-      data: {
-        date: todayDate,
-        timezone: 'Asia/Jakarta',
-        total_users: locations.length,
-        locations
-      },
+      data,
       message: 'Today locations retrieved successfully'
     });
   } catch (error) {

--- a/src/controllers/summary.controller.js
+++ b/src/controllers/summary.controller.js
@@ -13,6 +13,7 @@ import {
 import logger from '../utils/logger.js';
 import { formatWorkHour, formatTimeOnly, calculateWorkHour } from '../utils/workHourFormatter.js';
 import fuzzyAhpEngine from '../utils/fuzzyAhpEngine.js';
+import { buildDashboardAnalytics } from '../utils/dashboardAnalytics.js';
 
 /**
  * Calculate user metrics for discipline index calculation
@@ -618,6 +619,22 @@ export const getSummaryReport = async (req, res, next) => {
   }
 };
 
+export const getDashboardAnalytics = async (req, res, next) => {
+  try {
+    const { period = '30d', from = null, to = null } = req.query;
+    const data = await buildDashboardAnalytics({ period, from, to });
+
+    return res.status(200).json({
+      success: true,
+      data,
+      message: 'Dashboard analytics retrieved successfully'
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
 export default {
-  getSummaryReport
+  getSummaryReport,
+  getDashboardAnalytics
 };

--- a/src/middlewares/validator.js
+++ b/src/middlewares/validator.js
@@ -1,7 +1,8 @@
-import { body, validationResult } from 'express-validator';
+import { body, query, validationResult } from 'express-validator';
 import multer from 'multer';
 
 import User from '../models/user.model.js';
+import { parseIsoDateUtcStrict } from '../utils/isoDate.js';
 import { assertSafeUrl } from '../utils/url.js';
 
 // Remove the file system setup as we're switching to Cloudinary
@@ -518,4 +519,57 @@ export const locationEventValidation = [
 
       return true;
     })
+];
+
+const DASHBOARD_PERIODS = ['30d', 'current_month', 'custom'];
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export const dashboardAnalyticsValidation = [
+  query('period')
+    .optional()
+    .isIn(DASHBOARD_PERIODS)
+    .withMessage('Parameter period harus berupa: 30d, current_month, atau custom'),
+  query('from').optional().custom((value) => {
+    if (!parseIsoDateUtcStrict(value)) {
+      throw new Error('Parameter from harus menggunakan format YYYY-MM-DD');
+    }
+    return true;
+  }),
+  query('to').optional().custom((value) => {
+    if (!parseIsoDateUtcStrict(value)) {
+      throw new Error('Parameter to harus menggunakan format YYYY-MM-DD');
+    }
+    return true;
+  }),
+  query().custom((_, { req }) => {
+    const period = req.query.period || '30d';
+    const { from, to } = req.query;
+
+    if (period !== 'custom') {
+      return true;
+    }
+
+    if (!from || !to) {
+      throw new Error('Parameter from dan to wajib diisi saat period=custom');
+    }
+
+    const fromDate = parseIsoDateUtcStrict(from);
+    const toDate = parseIsoDateUtcStrict(to);
+
+    if (!fromDate || !toDate) {
+      return true;
+    }
+
+    if (fromDate.getTime() > toDate.getTime()) {
+      throw new Error('Parameter from tidak boleh lebih besar dari to');
+    }
+
+    const rangeDays = Math.floor((toDate.getTime() - fromDate.getTime()) / MS_PER_DAY) + 1;
+    if (rangeDays > 31) {
+      throw new Error('Rentang tanggal custom maksimal 31 hari');
+    }
+
+    return true;
+  }),
+  validate
 ];

--- a/src/routes/summary.routes.js
+++ b/src/routes/summary.routes.js
@@ -1,10 +1,19 @@
 import express from 'express';
 
-import { getSummaryReport } from '../controllers/summary.controller.js';
+import { getDashboardAnalytics, getSummaryReport } from '../controllers/summary.controller.js';
 import { verifyToken } from '../middlewares/authJwt.js';
 import roleGuard from '../middlewares/roleGuard.js';
+import { dashboardAnalyticsValidation } from '../middlewares/validator.js';
 
 const router = express.Router();
+
+router.get(
+  '/dashboard-analytics',
+  verifyToken,
+  roleGuard(['Admin', 'Management']),
+  dashboardAnalyticsValidation,
+  getDashboardAnalytics
+);
 
 router.get('/', verifyToken, roleGuard(['Admin', 'Management']), getSummaryReport);
 

--- a/src/utils/dashboardAnalytics.js
+++ b/src/utils/dashboardAnalytics.js
@@ -1,0 +1,393 @@
+import { Op } from 'sequelize';
+
+import { Attendance, AttendanceCategory, AttendanceStatus } from '../models/index.js';
+import {
+  buildDisciplineAnalysis,
+  buildSmartAcAnalysis,
+  buildWfaAnalysis
+} from '../controllers/analysis.controller.js';
+import { getJakartaDateString } from './geofence.js';
+import { parseIsoDateUtcStrict } from './isoDate.js';
+import { buildTodayLocationsSnapshot } from './todayLocationsSnapshot.js';
+
+const STATUS_ALPHA = new Set(['alpa', 'alpha']);
+const CATEGORY_MAP = {
+  wfo: 'wfo',
+  'work from office': 'wfo',
+  wfh: 'wfh',
+  'work from home': 'wfh',
+  wfa: 'wfa',
+  'work from anywhere': 'wfa'
+};
+
+const buildRequestedWindow = ({ period, from, to }) => ({
+  period,
+  from,
+  to
+});
+
+const buildExecutedWindow = (effectiveWindow) => ({
+  from: effectiveWindow.startDateStr,
+  to: effectiveWindow.endDateStr
+});
+
+const buildSectionWindows = (effectiveWindow) => ({
+  executive_kpis: buildExecutedWindow(effectiveWindow),
+  historical_trend: buildExecutedWindow(effectiveWindow),
+  mode_mix: buildExecutedWindow(effectiveWindow),
+  fuzzy_ahp_snapshot: buildExecutedWindow(effectiveWindow),
+  today_locations: {
+    mode: 'jakarta_today'
+  }
+});
+
+const buildEmptySnapshotCard = (effectiveWindow) => ({
+  generated_at: null,
+  window: buildExecutedWindow(effectiveWindow),
+  weights: {},
+  consistency: null,
+  top_rank: null,
+  distribution: {}
+});
+
+const formatDateOnly = (date) => date.toISOString().split('T')[0];
+
+const parseDateOnlyUtc = (value) => {
+  const date = parseIsoDateUtcStrict(value);
+
+  if (!date) {
+    throw new Error(`Invalid ISO date: ${value}`);
+  }
+
+  return date;
+};
+
+const addUtcDays = (date, days) => {
+  const next = new Date(date);
+  next.setUTCDate(next.getUTCDate() + days);
+  return next;
+};
+
+const normalizeCategoryName = (categoryName) => {
+  if (!categoryName) return null;
+  return CATEGORY_MAP[String(categoryName).trim().toLowerCase()] ?? null;
+};
+
+const isAlphaStatusName = (statusName) => STATUS_ALPHA.has(String(statusName || '').trim().toLowerCase());
+
+const buildEffectiveWindow = ({ period, from, to }) => {
+  const todayDate = getJakartaDateString();
+  const todayUtc = parseDateOnlyUtc(todayDate);
+
+  if (period === 'custom' && from && to) {
+    const startDate = parseDateOnlyUtc(from);
+    const endDate = parseDateOnlyUtc(to);
+
+    return {
+      startDate,
+      endDate,
+      startDateStr: from,
+      endDateStr: to
+    };
+  }
+
+  if (period === 'current_month') {
+    const startDate = new Date(Date.UTC(todayUtc.getUTCFullYear(), todayUtc.getUTCMonth(), 1));
+    return {
+      startDate,
+      endDate: todayUtc,
+      startDateStr: formatDateOnly(startDate),
+      endDateStr: todayDate
+    };
+  }
+
+  const startDate = addUtcDays(todayUtc, -29);
+  return {
+    startDate,
+    endDate: todayUtc,
+    startDateStr: formatDateOnly(startDate),
+    endDateStr: todayDate
+  };
+};
+
+const enumerateDateRange = (startDate, endDate) => {
+  const points = [];
+  for (let cursor = new Date(startDate); cursor.getTime() <= endDate.getTime(); cursor = addUtcDays(cursor, 1)) {
+    points.push(formatDateOnly(cursor));
+  }
+  return points;
+};
+
+const buildWeightsObject = (weights) => {
+  if (!weights?.criteria || !weights?.values) {
+    return {};
+  }
+
+  return weights.criteria.reduce((acc, criterion, index) => {
+    acc[criterion] = weights.values[index] ?? null;
+    return acc;
+  }, {});
+};
+
+const buildDistributionFromRanking = (ranking) => {
+  return ranking.reduce((acc, item) => {
+    acc[item.label] = (acc[item.label] || 0) + 1;
+    return acc;
+  }, {});
+};
+
+const buildSnapshotCard = ({ analysis, effectiveWindow, allowedIds = null }) => {
+  const ranking = Array.isArray(analysis?.ranking) ? analysis.ranking : [];
+  const filteredRanking =
+    allowedIds == null ? ranking : ranking.filter((item) => allowedIds.has(String(item.id)));
+
+  if (filteredRanking.length === 0) {
+    return buildEmptySnapshotCard(effectiveWindow);
+  }
+
+  const topRank = filteredRanking[0];
+
+  return {
+    generated_at: null,
+    window: buildExecutedWindow(effectiveWindow),
+    weights: buildWeightsObject(analysis?.weights),
+    consistency: analysis?.consistency || null,
+    top_rank: {
+      id: topRank.id,
+      name: topRank.name,
+      score: topRank.score,
+      label: topRank.label
+    },
+    distribution: buildDistributionFromRanking(filteredRanking)
+  };
+};
+
+const buildInsights = ({ executiveKpis, modeMix, todayLocations }) => {
+  const items = [];
+
+  if (executiveKpis.total_attendance_records > 0) {
+    const alphaRate = (executiveKpis.total_alpha / executiveKpis.total_attendance_records) * 100;
+    if (alphaRate >= 20) {
+      items.push({
+        type: 'alpha_spike',
+        title: 'Alpha rate elevated',
+        message: `Alpha reached ${alphaRate.toFixed(1)}% of attendance records in the selected window.`,
+        severity: 'high'
+      });
+    }
+  }
+
+  const totalMode = modeMix.totals.wfo + modeMix.totals.wfh + modeMix.totals.wfa;
+  if (totalMode > 0 && modeMix.percentages.wfa >= 50) {
+    items.push({
+      type: 'wfa_dominant',
+      title: 'WFA is the dominant mode',
+      message: `WFA contributed ${modeMix.percentages.wfa.toFixed(1)}% of recorded attendance modes.`,
+      severity: 'medium'
+    });
+  }
+
+  if (executiveKpis.discipline_average != null && executiveKpis.discipline_average < 60) {
+    items.push({
+      type: 'discipline_drop',
+      title: 'Discipline average needs attention',
+      message: `Average discipline score is ${executiveKpis.discipline_average.toFixed(2)} for the selected window.`,
+      severity: 'medium'
+    });
+  }
+
+  if (todayLocations.total_users === 0) {
+    return { items };
+  }
+
+  const wfhOrWfaUsers = todayLocations.locations.filter((item) => item.status === 'WFH' || item.status === 'WFA').length;
+  if (todayLocations.total_users > 0 && wfhOrWfaUsers === todayLocations.total_users) {
+    items.push({
+      type: 'location_coverage_low',
+      title: 'No office-based check-ins today',
+      message: 'Today location snapshot only shows WFH or WFA check-ins.',
+      severity: 'low'
+    });
+  }
+
+  return { items };
+};
+
+export const buildDashboardAnalytics = async ({ period = '30d', from = null, to = null } = {}) => {
+  const requestedWindow = buildRequestedWindow({ period, from, to });
+  const effectiveWindow = buildEffectiveWindow({ period, from, to });
+  const historicalDates = enumerateDateRange(effectiveWindow.startDate, effectiveWindow.endDate);
+
+  const [attendanceRows, disciplineAnalysis, wfaAnalysis, smartAcAnalysis, todayLocations] =
+    await Promise.all([
+      Attendance.findAll({
+        where: {
+          attendance_date: {
+            [Op.between]: [effectiveWindow.startDateStr, effectiveWindow.endDateStr]
+          }
+        },
+        attributes: ['attendance_date', 'user_id', 'status_id', 'category_id'],
+        include: [
+          {
+            model: AttendanceStatus,
+            as: 'status',
+            attributes: ['attendance_status_name']
+          },
+          {
+            model: AttendanceCategory,
+            as: 'attendance_category',
+            attributes: ['category_name']
+          }
+        ],
+        order: [
+          ['attendance_date', 'ASC'],
+          ['id_attendance', 'ASC']
+        ]
+      }),
+      buildDisciplineAnalysis({
+        startAt: effectiveWindow.startDate,
+        endAt: effectiveWindow.endDate
+      }),
+      buildWfaAnalysis({
+        startAt: effectiveWindow.startDate,
+        endAt: effectiveWindow.endDate
+      }),
+      buildSmartAcAnalysis({
+        startAt: effectiveWindow.startDate,
+        endAt: effectiveWindow.endDate
+      }),
+      buildTodayLocationsSnapshot()
+    ]);
+
+  const historicalMap = historicalDates.reduce((acc, date) => {
+    acc.set(date, {
+      date,
+      present: 0,
+      alpha: 0,
+      wfo: 0,
+      wfh: 0,
+      wfa: 0
+    });
+    return acc;
+  }, new Map());
+
+  const modeTotals = {
+    wfo: 0,
+    wfh: 0,
+    wfa: 0
+  };
+
+  let totalPresent = 0;
+  let totalAlpha = 0;
+  const analyzedUserIds = new Set();
+
+  for (const attendance of attendanceRows) {
+    const point = historicalMap.get(attendance.attendance_date);
+    const statusName = attendance.status?.attendance_status_name;
+    const normalizedCategory = normalizeCategoryName(attendance.attendance_category?.category_name);
+    const isAlpha = isAlphaStatusName(statusName);
+
+    if (point) {
+      if (isAlpha) {
+        point.alpha += 1;
+      } else {
+        point.present += 1;
+      }
+
+      if (normalizedCategory) {
+        point[normalizedCategory] += 1;
+      }
+    }
+
+    if (isAlpha) {
+      totalAlpha += 1;
+    } else {
+      totalPresent += 1;
+    }
+
+    if (normalizedCategory) {
+      modeTotals[normalizedCategory] += 1;
+    }
+
+    if (attendance.user_id != null) {
+      analyzedUserIds.add(String(attendance.user_id));
+    }
+  }
+
+  const analyzedDisciplineRanking = (disciplineAnalysis?.ranking || []).filter((item) =>
+    analyzedUserIds.has(String(item.id))
+  );
+  const disciplineAverage =
+    analyzedDisciplineRanking.length > 0
+      ? analyzedDisciplineRanking.reduce((sum, item) => sum + Number(item.score || 0), 0) /
+        analyzedDisciplineRanking.length
+      : null;
+
+  const totalModeRecords = modeTotals.wfo + modeTotals.wfh + modeTotals.wfa;
+  const percentages = {
+    wfo: totalModeRecords > 0 ? (modeTotals.wfo / totalModeRecords) * 100 : 0,
+    wfh: totalModeRecords > 0 ? (modeTotals.wfh / totalModeRecords) * 100 : 0,
+    wfa: totalModeRecords > 0 ? (modeTotals.wfa / totalModeRecords) * 100 : 0
+  };
+
+  const executiveKpis = {
+    total_attendance_records: attendanceRows.length,
+    total_present: totalPresent,
+    total_alpha: totalAlpha,
+    total_wfo: modeTotals.wfo,
+    total_wfh: modeTotals.wfh,
+    total_wfa: modeTotals.wfa,
+    discipline_average:
+      disciplineAverage == null ? null : Math.round((disciplineAverage + Number.EPSILON) * 100) / 100,
+    discipline_users_analyzed: analyzedDisciplineRanking.length
+  };
+
+  const fuzzySnapshot = {
+    discipline: buildSnapshotCard({
+      analysis: disciplineAnalysis,
+      effectiveWindow,
+      allowedIds: analyzedUserIds
+    }),
+    wfa: buildSnapshotCard({
+      analysis: wfaAnalysis,
+      effectiveWindow
+    }),
+    smart_ac: buildSnapshotCard({
+      analysis: smartAcAnalysis,
+      effectiveWindow,
+      allowedIds: analyzedUserIds
+    })
+  };
+
+  return {
+    meta: {
+      generated_at: null,
+      timezone: 'Asia/Jakarta',
+      requested_window: requestedWindow,
+      section_windows: buildSectionWindows(effectiveWindow),
+      sources: ['Attendance', 'AttendanceCategory', 'AttendanceStatus', 'Location', 'User']
+    },
+    executive_kpis: executiveKpis,
+    historical_trend: {
+      points: Array.from(historicalMap.values())
+    },
+    mode_mix: {
+      totals: modeTotals,
+      percentages
+    },
+    today_locations: todayLocations,
+    fuzzy_ahp_snapshot: fuzzySnapshot,
+    insights: buildInsights({
+      executiveKpis,
+      modeMix: {
+        totals: modeTotals,
+        percentages
+      },
+      todayLocations
+    })
+  };
+};
+
+export default {
+  buildDashboardAnalytics
+};

--- a/src/utils/dashboardAnalytics.js
+++ b/src/utils/dashboardAnalytics.js
@@ -1,6 +1,6 @@
 import { Op } from 'sequelize';
 
-import { Attendance, AttendanceCategory, AttendanceStatus } from '../models/index.js';
+import { Attendance, AttendanceCategory, AttendanceStatus, LocationEvent } from '../models/index.js';
 import {
   buildDisciplineAnalysis,
   buildSmartAcAnalysis,
@@ -11,6 +11,8 @@ import { parseIsoDateUtcStrict } from './isoDate.js';
 import { buildTodayLocationsSnapshot } from './todayLocationsSnapshot.js';
 
 const STATUS_ALPHA = new Set(['alpa', 'alpha']);
+const STATUS_LATE = new Set(['terlambat', 'late']);
+const STATUS_EARLY = new Set(['early', 'lebih awal']);
 const CATEGORY_MAP = {
   wfo: 'wfo',
   'work from office': 'wfo',
@@ -36,13 +38,15 @@ const buildSectionWindows = (effectiveWindow) => ({
   historical_trend: buildExecutedWindow(effectiveWindow),
   mode_mix: buildExecutedWindow(effectiveWindow),
   fuzzy_ahp_snapshot: buildExecutedWindow(effectiveWindow),
+  geofence_evidence_context: buildExecutedWindow(effectiveWindow),
   today_locations: {
     mode: 'jakarta_today'
   }
 });
 
-const buildEmptySnapshotCard = (effectiveWindow) => ({
-  generated_at: null,
+const buildEmptySnapshotCard = (effectiveWindow, generatedAt) => ({
+  status: 'no_data',
+  generated_at: generatedAt,
   window: buildExecutedWindow(effectiveWindow),
   weights: {},
   consistency: null,
@@ -68,12 +72,47 @@ const addUtcDays = (date, days) => {
   return next;
 };
 
+const buildJakartaDayStartUtc = (dateStr) => new Date(`${dateStr}T00:00:00+07:00`);
+
+const roundToTwo = (value) => Math.round((value + Number.EPSILON) * 100) / 100;
+
+const percentageOf = (count, total) => (total > 0 ? roundToTwo((count / total) * 100) : 0);
+
 const normalizeCategoryName = (categoryName) => {
   if (!categoryName) return null;
   return CATEGORY_MAP[String(categoryName).trim().toLowerCase()] ?? null;
 };
 
-const isAlphaStatusName = (statusName) => STATUS_ALPHA.has(String(statusName || '').trim().toLowerCase());
+const normalizeStatusName = (statusName) => String(statusName || '').trim().toLowerCase();
+
+const getAttendanceStatusFlags = (statusName) => {
+  const normalizedStatusName = normalizeStatusName(statusName);
+  const isAlpha = STATUS_ALPHA.has(normalizedStatusName);
+
+  return {
+    isAlpha,
+    isLate: !isAlpha && STATUS_LATE.has(normalizedStatusName),
+    isEarly: !isAlpha && STATUS_EARLY.has(normalizedStatusName)
+  };
+};
+
+const incrementAttendanceCounters = (counters, { isAlpha, isLate, isEarly }) => {
+  if (isAlpha) {
+    counters.alpha += 1;
+    return;
+  }
+
+  counters.present += 1;
+
+  if (isLate) {
+    counters.late += 1;
+    return;
+  }
+
+  if (!isEarly) {
+    counters.on_time += 1;
+  }
+};
 
 const buildEffectiveWindow = ({ period, from, to }) => {
   const todayDate = getJakartaDateString();
@@ -136,19 +175,20 @@ const buildDistributionFromRanking = (ranking) => {
   }, {});
 };
 
-const buildSnapshotCard = ({ analysis, effectiveWindow, allowedIds = null }) => {
+const buildSnapshotCard = ({ analysis, effectiveWindow, generatedAt, allowedIds = null }) => {
   const ranking = Array.isArray(analysis?.ranking) ? analysis.ranking : [];
   const filteredRanking =
     allowedIds == null ? ranking : ranking.filter((item) => allowedIds.has(String(item.id)));
 
   if (filteredRanking.length === 0) {
-    return buildEmptySnapshotCard(effectiveWindow);
+    return buildEmptySnapshotCard(effectiveWindow, generatedAt);
   }
 
   const topRank = filteredRanking[0];
 
   return {
-    generated_at: null,
+    status: 'ready',
+    generated_at: generatedAt,
     window: buildExecutedWindow(effectiveWindow),
     weights: buildWeightsObject(analysis?.weights),
     consistency: analysis?.consistency || null,
@@ -162,11 +202,45 @@ const buildSnapshotCard = ({ analysis, effectiveWindow, allowedIds = null }) => 
   };
 };
 
+const buildGeofenceEvidenceContext = ({ effectiveWindow, locationEvents }) => {
+  const uniqueUsers = new Set();
+  let enterEvents = 0;
+  let exitEvents = 0;
+
+  for (const event of locationEvents) {
+    if (event.user_id != null) {
+      uniqueUsers.add(String(event.user_id));
+    }
+
+    if (event.event_type === 'ENTER') {
+      enterEvents += 1;
+    }
+
+    if (event.event_type === 'EXIT') {
+      exitEvents += 1;
+    }
+  }
+
+  return {
+    status: locationEvents.length > 0 ? 'available' : 'no_events',
+    authority: 'context_only',
+    final_attendance_authority: 'attendance_records',
+    window: buildExecutedWindow(effectiveWindow),
+    raw_counts: {
+      total_events: locationEvents.length,
+      enter_events: enterEvents,
+      exit_events: exitEvents,
+      unique_users: uniqueUsers.size
+    }
+  };
+};
+
 const buildInsights = ({ executiveKpis, modeMix, todayLocations }) => {
   const items = [];
+  const rawCounts = executiveKpis.raw_counts;
 
-  if (executiveKpis.total_attendance_records > 0) {
-    const alphaRate = (executiveKpis.total_alpha / executiveKpis.total_attendance_records) * 100;
+  if (rawCounts.total_attendance_records > 0) {
+    const alphaRate = (rawCounts.total_alpha / rawCounts.total_attendance_records) * 100;
     if (alphaRate >= 20) {
       items.push({
         type: 'alpha_spike',
@@ -187,11 +261,11 @@ const buildInsights = ({ executiveKpis, modeMix, todayLocations }) => {
     });
   }
 
-  if (executiveKpis.discipline_average != null && executiveKpis.discipline_average < 60) {
+  if (executiveKpis.avg_discipline != null && executiveKpis.avg_discipline < 60) {
     items.push({
       type: 'discipline_drop',
       title: 'Discipline average needs attention',
-      message: `Average discipline score is ${executiveKpis.discipline_average.toFixed(2)} for the selected window.`,
+      message: `Average discipline score is ${executiveKpis.avg_discipline.toFixed(2)} for the selected window.`,
       severity: 'medium'
     });
   }
@@ -201,7 +275,7 @@ const buildInsights = ({ executiveKpis, modeMix, todayLocations }) => {
   }
 
   const wfhOrWfaUsers = todayLocations.locations.filter((item) => item.status === 'WFH' || item.status === 'WFA').length;
-  if (todayLocations.total_users > 0 && wfhOrWfaUsers === todayLocations.total_users) {
+  if (wfhOrWfaUsers === todayLocations.total_users) {
     items.push({
       type: 'location_coverage_low',
       title: 'No office-based check-ins today',
@@ -217,8 +291,11 @@ export const buildDashboardAnalytics = async ({ period = '30d', from = null, to 
   const requestedWindow = buildRequestedWindow({ period, from, to });
   const effectiveWindow = buildEffectiveWindow({ period, from, to });
   const historicalDates = enumerateDateRange(effectiveWindow.startDate, effectiveWindow.endDate);
+  const generatedAt = new Date().toISOString();
+  const geofenceStartInclusive = buildJakartaDayStartUtc(effectiveWindow.startDateStr);
+  const geofenceEndExclusive = buildJakartaDayStartUtc(formatDateOnly(addUtcDays(effectiveWindow.endDate, 1)));
 
-  const [attendanceRows, disciplineAnalysis, wfaAnalysis, smartAcAnalysis, todayLocations] =
+  const [attendanceRows, locationEvents, disciplineAnalysis, wfaAnalysis, smartAcAnalysis, todayLocations] =
     await Promise.all([
       Attendance.findAll({
         where: {
@@ -244,6 +321,16 @@ export const buildDashboardAnalytics = async ({ period = '30d', from = null, to 
           ['id_attendance', 'ASC']
         ]
       }),
+      LocationEvent.findAll({
+        where: {
+          event_timestamp: {
+            [Op.gte]: geofenceStartInclusive,
+            [Op.lt]: geofenceEndExclusive
+          }
+        },
+        attributes: ['user_id', 'event_type'],
+        order: [['event_timestamp', 'ASC']]
+      }),
       buildDisciplineAnalysis({
         startAt: effectiveWindow.startDate,
         endAt: effectiveWindow.endDate
@@ -262,6 +349,8 @@ export const buildDashboardAnalytics = async ({ period = '30d', from = null, to 
   const historicalMap = historicalDates.reduce((acc, date) => {
     acc.set(date, {
       date,
+      on_time: 0,
+      late: 0,
       present: 0,
       alpha: 0,
       wfo: 0,
@@ -277,33 +366,28 @@ export const buildDashboardAnalytics = async ({ period = '30d', from = null, to 
     wfa: 0
   };
 
-  let totalPresent = 0;
-  let totalAlpha = 0;
+  const attendanceTotals = {
+    present: 0,
+    alpha: 0,
+    late: 0,
+    on_time: 0
+  };
   const analyzedUserIds = new Set();
 
   for (const attendance of attendanceRows) {
     const point = historicalMap.get(attendance.attendance_date);
-    const statusName = attendance.status?.attendance_status_name;
+    const statusFlags = getAttendanceStatusFlags(attendance.status?.attendance_status_name);
     const normalizedCategory = normalizeCategoryName(attendance.attendance_category?.category_name);
-    const isAlpha = isAlphaStatusName(statusName);
 
     if (point) {
-      if (isAlpha) {
-        point.alpha += 1;
-      } else {
-        point.present += 1;
-      }
+      incrementAttendanceCounters(point, statusFlags);
 
       if (normalizedCategory) {
         point[normalizedCategory] += 1;
       }
     }
 
-    if (isAlpha) {
-      totalAlpha += 1;
-    } else {
-      totalPresent += 1;
-    }
+    incrementAttendanceCounters(attendanceTotals, statusFlags);
 
     if (normalizedCategory) {
       modeTotals[normalizedCategory] += 1;
@@ -325,47 +409,60 @@ export const buildDashboardAnalytics = async ({ period = '30d', from = null, to 
 
   const totalModeRecords = modeTotals.wfo + modeTotals.wfh + modeTotals.wfa;
   const percentages = {
-    wfo: totalModeRecords > 0 ? (modeTotals.wfo / totalModeRecords) * 100 : 0,
-    wfh: totalModeRecords > 0 ? (modeTotals.wfh / totalModeRecords) * 100 : 0,
-    wfa: totalModeRecords > 0 ? (modeTotals.wfa / totalModeRecords) * 100 : 0
+    wfo: percentageOf(modeTotals.wfo, totalModeRecords),
+    wfh: percentageOf(modeTotals.wfh, totalModeRecords),
+    wfa: percentageOf(modeTotals.wfa, totalModeRecords)
   };
 
-  const executiveKpis = {
+  const rawCounts = {
     total_attendance_records: attendanceRows.length,
-    total_present: totalPresent,
-    total_alpha: totalAlpha,
+    total_present: attendanceTotals.present,
+    total_alpha: attendanceTotals.alpha,
+    total_late: attendanceTotals.late,
+    total_on_time: attendanceTotals.on_time,
     total_wfo: modeTotals.wfo,
     total_wfh: modeTotals.wfh,
     total_wfa: modeTotals.wfa,
-    discipline_average:
-      disciplineAverage == null ? null : Math.round((disciplineAverage + Number.EPSILON) * 100) / 100,
     discipline_users_analyzed: analyzedDisciplineRanking.length
+  };
+
+  const executiveKpis = {
+    attendance_rate: percentageOf(rawCounts.total_present, rawCounts.total_attendance_records),
+    late_alpha_risk: percentageOf(rawCounts.total_late + rawCounts.total_alpha, rawCounts.total_attendance_records),
+    avg_discipline: disciplineAverage == null ? null : roundToTwo(disciplineAverage),
+    needs_attention:
+      Number(rawCounts.total_late + rawCounts.total_alpha > 0) +
+      Number(disciplineAverage != null && disciplineAverage < 60),
+    raw_counts: rawCounts
   };
 
   const fuzzySnapshot = {
     discipline: buildSnapshotCard({
       analysis: disciplineAnalysis,
       effectiveWindow,
+      generatedAt,
       allowedIds: analyzedUserIds
     }),
     wfa: buildSnapshotCard({
       analysis: wfaAnalysis,
-      effectiveWindow
+      effectiveWindow,
+      generatedAt
     }),
     smart_ac: buildSnapshotCard({
       analysis: smartAcAnalysis,
       effectiveWindow,
+      generatedAt,
       allowedIds: analyzedUserIds
     })
   };
 
   return {
     meta: {
-      generated_at: null,
+      generated_at: generatedAt,
       timezone: 'Asia/Jakarta',
       requested_window: requestedWindow,
       section_windows: buildSectionWindows(effectiveWindow),
-      sources: ['Attendance', 'AttendanceCategory', 'AttendanceStatus', 'Location', 'User']
+      sources: ['Attendance', 'AttendanceCategory', 'AttendanceStatus', 'Location', 'LocationEvent', 'User']
     },
     executive_kpis: executiveKpis,
     historical_trend: {
@@ -376,6 +473,10 @@ export const buildDashboardAnalytics = async ({ period = '30d', from = null, to 
       percentages
     },
     today_locations: todayLocations,
+    geofence_evidence_context: buildGeofenceEvidenceContext({
+      effectiveWindow,
+      locationEvents
+    }),
     fuzzy_ahp_snapshot: fuzzySnapshot,
     insights: buildInsights({
       executiveKpis,

--- a/src/utils/isoDate.js
+++ b/src/utils/isoDate.js
@@ -1,0 +1,21 @@
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+export const parseIsoDateUtcStrict = (value) => {
+  if (!ISO_DATE_PATTERN.test(value)) {
+    return null;
+  }
+
+  const [year, month, day] = value.split('-').map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day));
+
+  if (
+    Number.isNaN(date.getTime()) ||
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month - 1 ||
+    date.getUTCDate() !== day
+  ) {
+    return null;
+  }
+
+  return date;
+};

--- a/src/utils/todayLocationsSnapshot.js
+++ b/src/utils/todayLocationsSnapshot.js
@@ -1,0 +1,94 @@
+import { Op } from 'sequelize';
+
+import { Attendance, AttendanceCategory, Location, Photo, User } from '../models/index.js';
+import { getJakartaDateString } from './geofence.js';
+import { formatTimeOnly } from './workHourFormatter.js';
+
+const HERO_MAP_STATUS_BY_CATEGORY = {
+  WFO: 'WFO',
+  WFH: 'WFH',
+  WFA: 'WFA',
+  'Work From Office': 'WFO',
+  'Work From Home': 'WFH',
+  'Work From Anywhere': 'WFA'
+};
+
+export const buildTodayLocationsSnapshot = async ({ date = getJakartaDateString() } = {}) => {
+  const rows = await Attendance.findAll({
+    where: {
+      attendance_date: date,
+      time_in: {
+        [Op.not]: null
+      }
+    },
+    include: [
+      {
+        model: User,
+        as: 'user',
+        attributes: ['id_users', 'full_name'],
+        include: [
+          {
+            model: Photo,
+            as: 'photo_file',
+            attributes: ['photo_url'],
+            required: false
+          }
+        ]
+      },
+      {
+        model: Location,
+        as: 'location',
+        attributes: ['latitude', 'longitude'],
+        required: false
+      },
+      {
+        model: AttendanceCategory,
+        as: 'attendance_category',
+        attributes: ['category_name']
+      }
+    ],
+    order: [['time_in', 'ASC']]
+  });
+
+  const locations = rows
+    .map((attendance) => {
+      const latitude =
+        attendance.location?.latitude != null ? parseFloat(attendance.location.latitude) : null;
+      const longitude =
+        attendance.location?.longitude != null ? parseFloat(attendance.location.longitude) : null;
+      const categoryName = attendance.attendance_category?.category_name;
+      const status = categoryName ? HERO_MAP_STATUS_BY_CATEGORY[categoryName] ?? null : null;
+
+      if (
+        latitude == null ||
+        longitude == null ||
+        Number.isNaN(latitude) ||
+        Number.isNaN(longitude) ||
+        !status
+      ) {
+        return null;
+      }
+
+      return {
+        user_id: attendance.user?.id_users,
+        full_name: attendance.user?.full_name || 'Unknown User',
+        photo: attendance.user?.photo_file?.photo_url || null,
+        status,
+        check_in_time: formatTimeOnly(attendance.time_in),
+        latitude,
+        longitude
+      };
+    })
+    .filter(Boolean);
+
+  return {
+    date,
+    timezone: 'Asia/Jakarta',
+    total_users: locations.length,
+    locations
+  };
+};
+
+export default {
+  buildTodayLocationsSnapshot
+};

--- a/src/utils/todayLocationsSnapshot.js
+++ b/src/utils/todayLocationsSnapshot.js
@@ -84,6 +84,8 @@ export const buildTodayLocationsSnapshot = async ({ date = getJakartaDateString(
   return {
     date,
     timezone: 'Asia/Jakarta',
+    snapshot_type: 'attendance_checkin_snapshot',
+    is_live_tracking: false,
     total_users: locations.length,
     locations
   };

--- a/tests/analysisFuzzyAhpContract.test.js
+++ b/tests/analysisFuzzyAhpContract.test.js
@@ -259,6 +259,8 @@ describe('analysis fuzzy ahp contract', () => {
         data: expect.objectContaining({
           type: 'wfa',
           entity_kind: 'place',
+          scope: 'place_catalog_static',
+          window_applied: false,
           ranking: expect.arrayContaining([
             expect.objectContaining({
               rank: 1,

--- a/tests/attendanceTodayLocationsContract.test.js
+++ b/tests/attendanceTodayLocationsContract.test.js
@@ -120,6 +120,8 @@ describe('attendance today locations handler', () => {
         data: expect.objectContaining({
           date: '2026-04-22',
           timezone: 'Asia/Jakarta',
+          snapshot_type: 'attendance_checkin_snapshot',
+          is_live_tracking: false,
           total_users: 1,
           locations: [
             expect.objectContaining({
@@ -153,6 +155,8 @@ describe('attendance today locations handler', () => {
       expect.objectContaining({
         success: true,
         data: expect.objectContaining({
+          snapshot_type: 'attendance_checkin_snapshot',
+          is_live_tracking: false,
           total_users: 0,
           locations: []
         })
@@ -207,6 +211,8 @@ describe('attendance today locations handler', () => {
       expect.objectContaining({
         success: true,
         data: expect.objectContaining({
+          snapshot_type: 'attendance_checkin_snapshot',
+          is_live_tracking: false,
           total_users: 1,
           locations: [
             expect.objectContaining({

--- a/tests/clientCriticalOpenApiContract.test.js
+++ b/tests/clientCriticalOpenApiContract.test.js
@@ -22,7 +22,7 @@ describe('client-critical OpenAPI contract', () => {
     );
   });
 
-  test('documents check-in request body fields from the runtime controller', () => {
+  test('documents check-in request body fields in the public OpenAPI contract', () => {
     const checkInSchema = jsonRequestSchema(openapi.paths['/api/attendance/check-in'].post);
 
     expect(checkInSchema.required).toEqual(['category_id', 'latitude', 'longitude']);
@@ -64,7 +64,7 @@ describe('client-critical OpenAPI contract', () => {
     });
   });
 
-  test('documents status-today response shape returned by the live controller', () => {
+  test('documents status-today response shape in the public OpenAPI contract', () => {
     const statusSchema = schemaAt(openapi.paths['/api/attendance/status-today'].get);
     const dataSchema = statusSchema.properties.data;
 
@@ -100,7 +100,27 @@ describe('client-critical OpenAPI contract', () => {
     expect(dataSchema.properties).not.toHaveProperty('attendance');
   });
 
-  test('documents booking creation request payload from the runtime validator', () => {
+  test('documents attendance today-locations snapshot metadata in the public OpenAPI contract', () => {
+    const todayLocationsSchema = schemaAt(openapi.paths['/api/attendance/today-locations'].get);
+    const dataSchema = todayLocationsSchema.properties.data;
+
+    expect(dataSchema.properties).toMatchObject({
+      date: { type: 'string', format: 'date' },
+      timezone: { type: 'string', example: 'Asia/Jakarta' },
+      snapshot_type: {
+        type: 'string',
+        example: 'attendance_checkin_snapshot'
+      },
+      is_live_tracking: {
+        type: 'boolean',
+        example: false
+      },
+      total_users: { type: 'integer' },
+      locations: { type: 'array' }
+    });
+  });
+
+  test('documents booking creation request payload in the public OpenAPI contract', () => {
     const bookingSchema = jsonRequestSchema(openapi.paths['/api/bookings'].post);
 
     expect(bookingSchema.required).toEqual(['schedule_date', 'latitude', 'longitude']);
@@ -126,7 +146,7 @@ describe('client-critical OpenAPI contract', () => {
     expect(bookingSchema.properties).not.toHaveProperty('reason');
   });
 
-  test('documents booking creation success response shape from the runtime controller', () => {
+  test('documents booking creation success response shape in the public OpenAPI contract', () => {
     const bookingSuccessSchema = schemaAt(openapi.paths['/api/bookings'].post, '201');
     const dataSchema = bookingSuccessSchema.properties.data;
 
@@ -154,6 +174,59 @@ describe('client-critical OpenAPI contract', () => {
         type: 'string',
         nullable: true
       }
+    });
+  });
+
+  test('documents dashboard analytics response shape in the public OpenAPI contract', () => {
+    const dashboardSchema = schemaAt(openapi.paths['/api/summary/dashboard-analytics'].get);
+    const dataSchema = dashboardSchema.properties.data;
+
+    expect(dataSchema.properties.meta.properties).toMatchObject({
+      generated_at: {
+        type: 'string',
+        format: 'date-time',
+        example: '2026-05-03T02:30:00.000Z'
+      },
+      requested_window: { type: 'object' },
+      section_windows: { type: 'object' },
+      sources: { type: 'array' }
+    });
+    expect(dataSchema.properties.executive_kpis.properties).toMatchObject({
+      attendance_rate: { type: 'number', format: 'float' },
+      late_alpha_risk: { type: 'number', format: 'float' },
+      avg_discipline: { type: 'number', format: 'float', nullable: true },
+      needs_attention: { type: 'integer' },
+      raw_counts: { type: 'object' }
+    });
+    expect(dataSchema.properties.historical_trend.properties.points.items.properties).toMatchObject({
+      date: { type: 'string', format: 'date' },
+      on_time: { type: 'integer' },
+      late: { type: 'integer' },
+      present: { type: 'integer' },
+      alpha: { type: 'integer' }
+    });
+    expect(dataSchema.properties.today_locations.properties).toMatchObject({
+      snapshot_type: {
+        type: 'string',
+        example: 'attendance_checkin_snapshot'
+      },
+      is_live_tracking: {
+        type: 'boolean',
+        example: false
+      }
+    });
+    expect(dataSchema.properties.geofence_evidence_context.properties.status).toMatchObject({
+      type: 'string',
+      example: 'available'
+    });
+    expect(dataSchema.properties.fuzzy_ahp_snapshot.properties.discipline.properties.status).toMatchObject({
+      type: 'string',
+      example: 'ready'
+    });
+    expect(dataSchema.properties.fuzzy_ahp_snapshot.properties.discipline.properties.generated_at).toMatchObject({
+      type: 'string',
+      format: 'date-time',
+      example: '2026-05-03T02:30:00.000Z'
     });
   });
 });

--- a/tests/dashboardAnalyticsHelper.test.js
+++ b/tests/dashboardAnalyticsHelper.test.js
@@ -1,0 +1,526 @@
+import { Op } from 'sequelize';
+import { jest } from '@jest/globals';
+
+const mockGetJakartaDateString = jest.fn(() => '2026-05-03');
+const mockAttendanceFindAll = jest.fn();
+const mockBuildDisciplineAnalysis = jest.fn();
+const mockBuildWfaAnalysis = jest.fn();
+const mockBuildSmartAcAnalysis = jest.fn();
+const mockBuildTodayLocationsSnapshot = jest.fn();
+
+jest.unstable_mockModule('../src/utils/geofence.js', () => ({
+  getJakartaDateString: mockGetJakartaDateString
+}));
+
+jest.unstable_mockModule('../src/models/index.js', () => ({
+  Attendance: { findAll: mockAttendanceFindAll },
+  AttendanceCategory: {},
+  AttendanceStatus: {}
+}));
+
+jest.unstable_mockModule('../src/controllers/analysis.controller.js', () => ({
+  buildDisciplineAnalysis: mockBuildDisciplineAnalysis,
+  buildWfaAnalysis: mockBuildWfaAnalysis,
+  buildSmartAcAnalysis: mockBuildSmartAcAnalysis
+}));
+
+jest.unstable_mockModule('../src/utils/todayLocationsSnapshot.js', () => ({
+  buildTodayLocationsSnapshot: mockBuildTodayLocationsSnapshot
+}));
+
+const { buildDashboardAnalytics } = await import('../src/utils/dashboardAnalytics.js');
+
+describe('dashboard analytics helper contract', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('aggregates attendance metrics, compact snapshots, and keeps today locations on Jakarta today', async () => {
+    mockAttendanceFindAll.mockResolvedValueOnce([
+      {
+        attendance_date: '2026-04-01',
+        user_id: 7,
+        status: { attendance_status_name: 'Present' },
+        attendance_category: { category_name: 'Work From Office' }
+      },
+      {
+        attendance_date: '2026-04-02',
+        user_id: 8,
+        status: { attendance_status_name: 'Alpha' },
+        attendance_category: { category_name: 'Work From Home' }
+      },
+      {
+        attendance_date: '2026-04-03',
+        user_id: 7,
+        status: { attendance_status_name: 'Present' },
+        attendance_category: { category_name: 'Work From Anywhere' }
+      }
+    ]);
+
+    mockBuildDisciplineAnalysis.mockResolvedValueOnce({
+      consistency: { CR: 0.021, threshold: 0.1, is_consistent: true },
+      weights: {
+        criteria: ['alpha_rate', 'lateness_severity'],
+        values: [0.6, 0.4]
+      },
+      ranking: [
+        { id: 9, name: 'Outsider', score: 99, label: 'Sangat Tinggi' },
+        { id: 7, name: 'Febri', score: 84, label: 'Tinggi' },
+        { id: 8, name: 'Diana', score: 80, label: 'Sedang' }
+      ]
+    });
+
+    mockBuildWfaAnalysis.mockResolvedValueOnce({
+      consistency: { CR: 0.018, threshold: 0.1, is_consistent: true },
+      weights: {
+        criteria: ['location_type', 'distance_factor'],
+        values: [0.55, 0.45]
+      },
+      ranking: [
+        { id: 31, name: 'Cafe Satu', score: 90, label: 'Sangat Tinggi' },
+        { id: 32, name: 'Library Dua', score: 70, label: 'Tinggi' }
+      ]
+    });
+
+    mockBuildSmartAcAnalysis.mockResolvedValueOnce({
+      consistency: { CR: 0, threshold: 0.1, is_consistent: true },
+      weights: {
+        criteria: ['history', 'context'],
+        values: [0.4, 0.6]
+      },
+      ranking: [
+        { id: 99, name: 'Untracked User', score: 95, label: 'Sangat Tinggi' },
+        { id: 8, name: 'Diana', score: 72, label: 'Tinggi' },
+        { id: 7, name: 'Febri', score: 65, label: 'Sedang' }
+      ]
+    });
+
+    mockBuildTodayLocationsSnapshot.mockResolvedValueOnce({
+      date: '2026-05-03',
+      timezone: 'Asia/Jakarta',
+      total_users: 2,
+      locations: [
+        {
+          user_id: 7,
+          full_name: 'Febri',
+          status: 'WFO',
+          check_in_time: '08:15',
+          latitude: -0.8917,
+          longitude: 119.8707,
+          photo: null
+        },
+        {
+          user_id: 8,
+          full_name: 'Diana',
+          status: 'WFA',
+          check_in_time: '08:20',
+          latitude: -0.9001,
+          longitude: 119.8802,
+          photo: null
+        }
+      ]
+    });
+
+    const result = await buildDashboardAnalytics({
+      period: 'custom',
+      from: '2026-04-01',
+      to: '2026-04-03'
+    });
+
+    expect(mockGetJakartaDateString).toHaveBeenCalledTimes(1);
+    expect(mockAttendanceFindAll).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          attendance_date: {
+            [Op.between]: ['2026-04-01', '2026-04-03']
+          }
+        },
+        attributes: ['attendance_date', 'user_id', 'status_id', 'category_id'],
+        order: [
+          ['attendance_date', 'ASC'],
+          ['id_attendance', 'ASC']
+        ]
+      })
+    );
+
+    const disciplineWindow = mockBuildDisciplineAnalysis.mock.calls[0][0];
+    const wfaWindow = mockBuildWfaAnalysis.mock.calls[0][0];
+    const smartAcWindow = mockBuildSmartAcAnalysis.mock.calls[0][0];
+
+    expect(disciplineWindow.startAt.toISOString()).toBe('2026-04-01T00:00:00.000Z');
+    expect(disciplineWindow.endAt.toISOString()).toBe('2026-04-03T00:00:00.000Z');
+    expect(wfaWindow.startAt.toISOString()).toBe('2026-04-01T00:00:00.000Z');
+    expect(wfaWindow.endAt.toISOString()).toBe('2026-04-03T00:00:00.000Z');
+    expect(smartAcWindow.startAt.toISOString()).toBe('2026-04-01T00:00:00.000Z');
+    expect(smartAcWindow.endAt.toISOString()).toBe('2026-04-03T00:00:00.000Z');
+    expect(mockBuildTodayLocationsSnapshot).toHaveBeenCalledWith();
+
+    expect(result.meta).toEqual({
+      generated_at: null,
+      timezone: 'Asia/Jakarta',
+      requested_window: {
+        period: 'custom',
+        from: '2026-04-01',
+        to: '2026-04-03'
+      },
+      section_windows: {
+        executive_kpis: { from: '2026-04-01', to: '2026-04-03' },
+        historical_trend: { from: '2026-04-01', to: '2026-04-03' },
+        mode_mix: { from: '2026-04-01', to: '2026-04-03' },
+        fuzzy_ahp_snapshot: { from: '2026-04-01', to: '2026-04-03' },
+        today_locations: { mode: 'jakarta_today' }
+      },
+      sources: ['Attendance', 'AttendanceCategory', 'AttendanceStatus', 'Location', 'User']
+    });
+
+    expect(result.executive_kpis).toEqual({
+      total_attendance_records: 3,
+      total_present: 2,
+      total_alpha: 1,
+      total_wfo: 1,
+      total_wfh: 1,
+      total_wfa: 1,
+      discipline_average: 82,
+      discipline_users_analyzed: 2
+    });
+
+    expect(result.historical_trend).toEqual({
+      points: [
+        { date: '2026-04-01', present: 1, alpha: 0, wfo: 1, wfh: 0, wfa: 0 },
+        { date: '2026-04-02', present: 0, alpha: 1, wfo: 0, wfh: 1, wfa: 0 },
+        { date: '2026-04-03', present: 1, alpha: 0, wfo: 0, wfh: 0, wfa: 1 }
+      ]
+    });
+
+    expect(result.mode_mix.totals).toEqual({ wfo: 1, wfh: 1, wfa: 1 });
+    expect(result.mode_mix.percentages.wfo).toBeCloseTo(33.3333333333);
+    expect(result.mode_mix.percentages.wfh).toBeCloseTo(33.3333333333);
+    expect(result.mode_mix.percentages.wfa).toBeCloseTo(33.3333333333);
+
+    expect(result.today_locations).toEqual({
+      date: '2026-05-03',
+      timezone: 'Asia/Jakarta',
+      total_users: 2,
+      locations: [
+        {
+          user_id: 7,
+          full_name: 'Febri',
+          status: 'WFO',
+          check_in_time: '08:15',
+          latitude: -0.8917,
+          longitude: 119.8707,
+          photo: null
+        },
+        {
+          user_id: 8,
+          full_name: 'Diana',
+          status: 'WFA',
+          check_in_time: '08:20',
+          latitude: -0.9001,
+          longitude: 119.8802,
+          photo: null
+        }
+      ]
+    });
+
+    expect(result.fuzzy_ahp_snapshot).toEqual({
+      discipline: {
+        generated_at: null,
+        window: { from: '2026-04-01', to: '2026-04-03' },
+        weights: {
+          alpha_rate: 0.6,
+          lateness_severity: 0.4
+        },
+        consistency: { CR: 0.021, threshold: 0.1, is_consistent: true },
+        top_rank: {
+          id: 7,
+          name: 'Febri',
+          score: 84,
+          label: 'Tinggi'
+        },
+        distribution: {
+          Tinggi: 1,
+          Sedang: 1
+        }
+      },
+      wfa: {
+        generated_at: null,
+        window: { from: '2026-04-01', to: '2026-04-03' },
+        weights: {
+          location_type: 0.55,
+          distance_factor: 0.45
+        },
+        consistency: { CR: 0.018, threshold: 0.1, is_consistent: true },
+        top_rank: {
+          id: 31,
+          name: 'Cafe Satu',
+          score: 90,
+          label: 'Sangat Tinggi'
+        },
+        distribution: {
+          'Sangat Tinggi': 1,
+          Tinggi: 1
+        }
+      },
+      smart_ac: {
+        generated_at: null,
+        window: { from: '2026-04-01', to: '2026-04-03' },
+        weights: {
+          history: 0.4,
+          context: 0.6
+        },
+        consistency: { CR: 0, threshold: 0.1, is_consistent: true },
+        top_rank: {
+          id: 8,
+          name: 'Diana',
+          score: 72,
+          label: 'Tinggi'
+        },
+        distribution: {
+          Tinggi: 1,
+          Sedang: 1
+        }
+      }
+    });
+
+    expect(result.insights).toEqual({
+      items: [
+        {
+          type: 'alpha_spike',
+          title: 'Alpha rate elevated',
+          message: 'Alpha reached 33.3% of attendance records in the selected window.',
+          severity: 'high'
+        }
+      ]
+    });
+  });
+
+  it('combines realistic WFA-dominant and no-office-today signals into dashboard insights', async () => {
+    mockAttendanceFindAll.mockResolvedValueOnce([
+      {
+        attendance_date: '2026-04-01',
+        user_id: 7,
+        status: { attendance_status_name: 'Present' },
+        attendance_category: { category_name: 'Work From Anywhere' }
+      },
+      {
+        attendance_date: '2026-04-02',
+        user_id: 8,
+        status: { attendance_status_name: 'Present' },
+        attendance_category: { category_name: 'Work From Anywhere' }
+      },
+      {
+        attendance_date: '2026-04-03',
+        user_id: 9,
+        status: { attendance_status_name: 'Present' },
+        attendance_category: { category_name: 'Work From Home' }
+      }
+    ]);
+
+    mockBuildDisciplineAnalysis.mockResolvedValueOnce({
+      ranking: [{ id: 7, name: 'Febri', score: 55, label: 'Sedang' }]
+    });
+    mockBuildWfaAnalysis.mockResolvedValueOnce({ ranking: [] });
+    mockBuildSmartAcAnalysis.mockResolvedValueOnce({
+      ranking: [{ id: 7, name: 'Febri', score: 40, label: 'Sedang' }]
+    });
+    mockBuildTodayLocationsSnapshot.mockResolvedValueOnce({
+      date: '2026-05-03',
+      timezone: 'Asia/Jakarta',
+      total_users: 2,
+      locations: [
+        {
+          user_id: 7,
+          full_name: 'Febri',
+          status: 'WFH',
+          check_in_time: '08:15',
+          latitude: -0.8917,
+          longitude: 119.8707,
+          photo: null
+        },
+        {
+          user_id: 8,
+          full_name: 'Diana',
+          status: 'WFA',
+          check_in_time: '08:20',
+          latitude: -0.9001,
+          longitude: 119.8802,
+          photo: null
+        }
+      ]
+    });
+
+    const result = await buildDashboardAnalytics({
+      period: 'custom',
+      from: '2026-04-01',
+      to: '2026-04-03'
+    });
+
+    expect(result.executive_kpis).toEqual({
+      total_attendance_records: 3,
+      total_present: 3,
+      total_alpha: 0,
+      total_wfo: 0,
+      total_wfh: 1,
+      total_wfa: 2,
+      discipline_average: 55,
+      discipline_users_analyzed: 1
+    });
+
+    expect(result.insights).toEqual({
+      items: [
+        {
+          type: 'wfa_dominant',
+          title: 'WFA is the dominant mode',
+          message: 'WFA contributed 66.7% of recorded attendance modes.',
+          severity: 'medium'
+        },
+        {
+          type: 'discipline_drop',
+          title: 'Discipline average needs attention',
+          message: 'Average discipline score is 55.00 for the selected window.',
+          severity: 'medium'
+        },
+        {
+          type: 'location_coverage_low',
+          title: 'No office-based check-ins today',
+          message: 'Today location snapshot only shows WFH or WFA check-ins.',
+          severity: 'low'
+        }
+      ]
+    });
+  });
+
+  it('reports the default 30-day request separately from the executed historical window', async () => {
+    mockAttendanceFindAll.mockResolvedValueOnce([]);
+    mockBuildDisciplineAnalysis.mockResolvedValueOnce({ ranking: [] });
+    mockBuildWfaAnalysis.mockResolvedValueOnce({ ranking: [] });
+    mockBuildSmartAcAnalysis.mockResolvedValueOnce({ ranking: [] });
+    mockBuildTodayLocationsSnapshot.mockResolvedValueOnce({
+      date: '2026-05-03',
+      timezone: 'Asia/Jakarta',
+      total_users: 0,
+      locations: []
+    });
+
+    const result = await buildDashboardAnalytics();
+
+    expect(result.meta.requested_window).toEqual({
+      period: '30d',
+      from: null,
+      to: null
+    });
+    expect(result.meta.section_windows).toEqual({
+      executive_kpis: { from: '2026-04-04', to: '2026-05-03' },
+      historical_trend: { from: '2026-04-04', to: '2026-05-03' },
+      mode_mix: { from: '2026-04-04', to: '2026-05-03' },
+      fuzzy_ahp_snapshot: { from: '2026-04-04', to: '2026-05-03' },
+      today_locations: { mode: 'jakarta_today' }
+    });
+    expect(result.fuzzy_ahp_snapshot).toEqual({
+      discipline: {
+        generated_at: null,
+        window: { from: '2026-04-04', to: '2026-05-03' },
+        weights: {},
+        consistency: null,
+        top_rank: null,
+        distribution: {}
+      },
+      wfa: {
+        generated_at: null,
+        window: { from: '2026-04-04', to: '2026-05-03' },
+        weights: {},
+        consistency: null,
+        top_rank: null,
+        distribution: {}
+      },
+      smart_ac: {
+        generated_at: null,
+        window: { from: '2026-04-04', to: '2026-05-03' },
+        weights: {},
+        consistency: null,
+        top_rank: null,
+        distribution: {}
+      }
+    });
+  });
+
+  it('returns stable empty-state cards and zero-filled daily points', async () => {
+    mockAttendanceFindAll.mockResolvedValueOnce([]);
+    mockBuildDisciplineAnalysis.mockResolvedValueOnce({ ranking: [] });
+    mockBuildWfaAnalysis.mockResolvedValueOnce({ ranking: [] });
+    mockBuildSmartAcAnalysis.mockResolvedValueOnce({ ranking: [] });
+    mockBuildTodayLocationsSnapshot.mockResolvedValueOnce({
+      date: '2026-05-03',
+      timezone: 'Asia/Jakarta',
+      total_users: 0,
+      locations: []
+    });
+
+    const result = await buildDashboardAnalytics({
+      period: 'custom',
+      from: '2026-04-01',
+      to: '2026-04-03'
+    });
+
+    expect(result.executive_kpis).toEqual({
+      total_attendance_records: 0,
+      total_present: 0,
+      total_alpha: 0,
+      total_wfo: 0,
+      total_wfh: 0,
+      total_wfa: 0,
+      discipline_average: null,
+      discipline_users_analyzed: 0
+    });
+
+    expect(result.historical_trend).toEqual({
+      points: [
+        { date: '2026-04-01', present: 0, alpha: 0, wfo: 0, wfh: 0, wfa: 0 },
+        { date: '2026-04-02', present: 0, alpha: 0, wfo: 0, wfh: 0, wfa: 0 },
+        { date: '2026-04-03', present: 0, alpha: 0, wfo: 0, wfh: 0, wfa: 0 }
+      ]
+    });
+
+    expect(result.mode_mix).toEqual({
+      totals: { wfo: 0, wfh: 0, wfa: 0 },
+      percentages: { wfo: 0, wfh: 0, wfa: 0 }
+    });
+
+    expect(result.today_locations).toEqual({
+      date: '2026-05-03',
+      timezone: 'Asia/Jakarta',
+      total_users: 0,
+      locations: []
+    });
+
+    expect(result.fuzzy_ahp_snapshot).toEqual({
+      discipline: {
+        generated_at: null,
+        window: { from: '2026-04-01', to: '2026-04-03' },
+        weights: {},
+        consistency: null,
+        top_rank: null,
+        distribution: {}
+      },
+      wfa: {
+        generated_at: null,
+        window: { from: '2026-04-01', to: '2026-04-03' },
+        weights: {},
+        consistency: null,
+        top_rank: null,
+        distribution: {}
+      },
+      smart_ac: {
+        generated_at: null,
+        window: { from: '2026-04-01', to: '2026-04-03' },
+        weights: {},
+        consistency: null,
+        top_rank: null,
+        distribution: {}
+      }
+    });
+
+    expect(result.insights).toEqual({ items: [] });
+  });
+});

--- a/tests/dashboardAnalyticsHelper.test.js
+++ b/tests/dashboardAnalyticsHelper.test.js
@@ -3,6 +3,7 @@ import { jest } from '@jest/globals';
 
 const mockGetJakartaDateString = jest.fn(() => '2026-05-03');
 const mockAttendanceFindAll = jest.fn();
+const mockLocationEventFindAll = jest.fn();
 const mockBuildDisciplineAnalysis = jest.fn();
 const mockBuildWfaAnalysis = jest.fn();
 const mockBuildSmartAcAnalysis = jest.fn();
@@ -15,7 +16,8 @@ jest.unstable_mockModule('../src/utils/geofence.js', () => ({
 jest.unstable_mockModule('../src/models/index.js', () => ({
   Attendance: { findAll: mockAttendanceFindAll },
   AttendanceCategory: {},
-  AttendanceStatus: {}
+  AttendanceStatus: {},
+  LocationEvent: { findAll: mockLocationEventFindAll }
 }));
 
 jest.unstable_mockModule('../src/controllers/analysis.controller.js', () => ({
@@ -35,12 +37,12 @@ describe('dashboard analytics helper contract', () => {
     jest.clearAllMocks();
   });
 
-  it('aggregates attendance metrics, compact snapshots, and keeps today locations on Jakarta today', async () => {
+  it('aggregates attendance metrics, geofence evidence, compact snapshots, and honest today-location metadata', async () => {
     mockAttendanceFindAll.mockResolvedValueOnce([
       {
         attendance_date: '2026-04-01',
         user_id: 7,
-        status: { attendance_status_name: 'Present' },
+        status: { attendance_status_name: 'Tepat Waktu' },
         attendance_category: { category_name: 'Work From Office' }
       },
       {
@@ -51,10 +53,16 @@ describe('dashboard analytics helper contract', () => {
       },
       {
         attendance_date: '2026-04-03',
-        user_id: 7,
-        status: { attendance_status_name: 'Present' },
+        user_id: 8,
+        status: { attendance_status_name: 'Terlambat' },
         attendance_category: { category_name: 'Work From Anywhere' }
       }
+    ]);
+
+    mockLocationEventFindAll.mockResolvedValueOnce([
+      { user_id: 7, event_type: 'ENTER' },
+      { user_id: 8, event_type: 'EXIT' },
+      { user_id: 8, event_type: 'EXIT' }
     ]);
 
     mockBuildDisciplineAnalysis.mockResolvedValueOnce({
@@ -98,6 +106,8 @@ describe('dashboard analytics helper contract', () => {
     mockBuildTodayLocationsSnapshot.mockResolvedValueOnce({
       date: '2026-05-03',
       timezone: 'Asia/Jakarta',
+      snapshot_type: 'attendance_checkin_snapshot',
+      is_live_tracking: false,
       total_users: 2,
       locations: [
         {
@@ -142,6 +152,12 @@ describe('dashboard analytics helper contract', () => {
         ]
       })
     );
+    expect(mockLocationEventFindAll).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attributes: ['user_id', 'event_type'],
+        order: [['event_timestamp', 'ASC']]
+      })
+    );
 
     const disciplineWindow = mockBuildDisciplineAnalysis.mock.calls[0][0];
     const wfaWindow = mockBuildWfaAnalysis.mock.calls[0][0];
@@ -156,7 +172,7 @@ describe('dashboard analytics helper contract', () => {
     expect(mockBuildTodayLocationsSnapshot).toHaveBeenCalledWith();
 
     expect(result.meta).toEqual({
-      generated_at: null,
+      generated_at: expect.any(String),
       timezone: 'Asia/Jakarta',
       requested_window: {
         period: 'custom',
@@ -168,38 +184,48 @@ describe('dashboard analytics helper contract', () => {
         historical_trend: { from: '2026-04-01', to: '2026-04-03' },
         mode_mix: { from: '2026-04-01', to: '2026-04-03' },
         fuzzy_ahp_snapshot: { from: '2026-04-01', to: '2026-04-03' },
+        geofence_evidence_context: { from: '2026-04-01', to: '2026-04-03' },
         today_locations: { mode: 'jakarta_today' }
       },
-      sources: ['Attendance', 'AttendanceCategory', 'AttendanceStatus', 'Location', 'User']
+      sources: ['Attendance', 'AttendanceCategory', 'AttendanceStatus', 'Location', 'LocationEvent', 'User']
     });
 
     expect(result.executive_kpis).toEqual({
-      total_attendance_records: 3,
-      total_present: 2,
-      total_alpha: 1,
-      total_wfo: 1,
-      total_wfh: 1,
-      total_wfa: 1,
-      discipline_average: 82,
-      discipline_users_analyzed: 2
+      attendance_rate: 66.67,
+      late_alpha_risk: 66.67,
+      avg_discipline: 82,
+      needs_attention: 1,
+      raw_counts: {
+        total_attendance_records: 3,
+        total_present: 2,
+        total_alpha: 1,
+        total_late: 1,
+        total_on_time: 1,
+        total_wfo: 1,
+        total_wfh: 1,
+        total_wfa: 1,
+        discipline_users_analyzed: 2
+      }
     });
 
     expect(result.historical_trend).toEqual({
       points: [
-        { date: '2026-04-01', present: 1, alpha: 0, wfo: 1, wfh: 0, wfa: 0 },
-        { date: '2026-04-02', present: 0, alpha: 1, wfo: 0, wfh: 1, wfa: 0 },
-        { date: '2026-04-03', present: 1, alpha: 0, wfo: 0, wfh: 0, wfa: 1 }
+        { date: '2026-04-01', on_time: 1, late: 0, alpha: 0, present: 1, wfo: 1, wfh: 0, wfa: 0 },
+        { date: '2026-04-02', on_time: 0, late: 0, alpha: 1, present: 0, wfo: 0, wfh: 1, wfa: 0 },
+        { date: '2026-04-03', on_time: 0, late: 1, alpha: 0, present: 1, wfo: 0, wfh: 0, wfa: 1 }
       ]
     });
 
-    expect(result.mode_mix.totals).toEqual({ wfo: 1, wfh: 1, wfa: 1 });
-    expect(result.mode_mix.percentages.wfo).toBeCloseTo(33.3333333333);
-    expect(result.mode_mix.percentages.wfh).toBeCloseTo(33.3333333333);
-    expect(result.mode_mix.percentages.wfa).toBeCloseTo(33.3333333333);
+    expect(result.mode_mix).toEqual({
+      totals: { wfo: 1, wfh: 1, wfa: 1 },
+      percentages: { wfo: 33.33, wfh: 33.33, wfa: 33.33 }
+    });
 
     expect(result.today_locations).toEqual({
       date: '2026-05-03',
       timezone: 'Asia/Jakarta',
+      snapshot_type: 'attendance_checkin_snapshot',
+      is_live_tracking: false,
       total_users: 2,
       locations: [
         {
@@ -223,9 +249,23 @@ describe('dashboard analytics helper contract', () => {
       ]
     });
 
+    expect(result.geofence_evidence_context).toEqual({
+      status: 'available',
+      authority: 'context_only',
+      final_attendance_authority: 'attendance_records',
+      window: { from: '2026-04-01', to: '2026-04-03' },
+      raw_counts: {
+        total_events: 3,
+        enter_events: 1,
+        exit_events: 2,
+        unique_users: 2
+      }
+    });
+
     expect(result.fuzzy_ahp_snapshot).toEqual({
       discipline: {
-        generated_at: null,
+        status: 'ready',
+        generated_at: expect.any(String),
         window: { from: '2026-04-01', to: '2026-04-03' },
         weights: {
           alpha_rate: 0.6,
@@ -244,7 +284,8 @@ describe('dashboard analytics helper contract', () => {
         }
       },
       wfa: {
-        generated_at: null,
+        status: 'ready',
+        generated_at: expect.any(String),
         window: { from: '2026-04-01', to: '2026-04-03' },
         weights: {
           location_type: 0.55,
@@ -263,7 +304,8 @@ describe('dashboard analytics helper contract', () => {
         }
       },
       smart_ac: {
-        generated_at: null,
+        status: 'ready',
+        generated_at: expect.any(String),
         window: { from: '2026-04-01', to: '2026-04-03' },
         weights: {
           history: 0.4,
@@ -317,6 +359,7 @@ describe('dashboard analytics helper contract', () => {
       }
     ]);
 
+    mockLocationEventFindAll.mockResolvedValueOnce([]);
     mockBuildDisciplineAnalysis.mockResolvedValueOnce({
       ranking: [{ id: 7, name: 'Febri', score: 55, label: 'Sedang' }]
     });
@@ -327,6 +370,8 @@ describe('dashboard analytics helper contract', () => {
     mockBuildTodayLocationsSnapshot.mockResolvedValueOnce({
       date: '2026-05-03',
       timezone: 'Asia/Jakarta',
+      snapshot_type: 'attendance_checkin_snapshot',
+      is_live_tracking: false,
       total_users: 2,
       locations: [
         {
@@ -357,14 +402,21 @@ describe('dashboard analytics helper contract', () => {
     });
 
     expect(result.executive_kpis).toEqual({
-      total_attendance_records: 3,
-      total_present: 3,
-      total_alpha: 0,
-      total_wfo: 0,
-      total_wfh: 1,
-      total_wfa: 2,
-      discipline_average: 55,
-      discipline_users_analyzed: 1
+      attendance_rate: 100,
+      late_alpha_risk: 0,
+      avg_discipline: 55,
+      needs_attention: 1,
+      raw_counts: {
+        total_attendance_records: 3,
+        total_present: 3,
+        total_alpha: 0,
+        total_late: 0,
+        total_on_time: 3,
+        total_wfo: 0,
+        total_wfh: 1,
+        total_wfa: 2,
+        discipline_users_analyzed: 1
+      }
     });
 
     expect(result.insights).toEqual({
@@ -391,14 +443,17 @@ describe('dashboard analytics helper contract', () => {
     });
   });
 
-  it('reports the default 30-day request separately from the executed historical window', async () => {
+  it('reports the default 30-day request separately from the executed historical and geofence windows', async () => {
     mockAttendanceFindAll.mockResolvedValueOnce([]);
+    mockLocationEventFindAll.mockResolvedValueOnce([]);
     mockBuildDisciplineAnalysis.mockResolvedValueOnce({ ranking: [] });
     mockBuildWfaAnalysis.mockResolvedValueOnce({ ranking: [] });
     mockBuildSmartAcAnalysis.mockResolvedValueOnce({ ranking: [] });
     mockBuildTodayLocationsSnapshot.mockResolvedValueOnce({
       date: '2026-05-03',
       timezone: 'Asia/Jakarta',
+      snapshot_type: 'attendance_checkin_snapshot',
+      is_live_tracking: false,
       total_users: 0,
       locations: []
     });
@@ -415,11 +470,13 @@ describe('dashboard analytics helper contract', () => {
       historical_trend: { from: '2026-04-04', to: '2026-05-03' },
       mode_mix: { from: '2026-04-04', to: '2026-05-03' },
       fuzzy_ahp_snapshot: { from: '2026-04-04', to: '2026-05-03' },
+      geofence_evidence_context: { from: '2026-04-04', to: '2026-05-03' },
       today_locations: { mode: 'jakarta_today' }
     });
     expect(result.fuzzy_ahp_snapshot).toEqual({
       discipline: {
-        generated_at: null,
+        status: 'no_data',
+        generated_at: expect.any(String),
         window: { from: '2026-04-04', to: '2026-05-03' },
         weights: {},
         consistency: null,
@@ -427,7 +484,8 @@ describe('dashboard analytics helper contract', () => {
         distribution: {}
       },
       wfa: {
-        generated_at: null,
+        status: 'no_data',
+        generated_at: expect.any(String),
         window: { from: '2026-04-04', to: '2026-05-03' },
         weights: {},
         consistency: null,
@@ -435,7 +493,8 @@ describe('dashboard analytics helper contract', () => {
         distribution: {}
       },
       smart_ac: {
-        generated_at: null,
+        status: 'no_data',
+        generated_at: expect.any(String),
         window: { from: '2026-04-04', to: '2026-05-03' },
         weights: {},
         consistency: null,
@@ -443,16 +502,114 @@ describe('dashboard analytics helper contract', () => {
         distribution: {}
       }
     });
+    expect(result.geofence_evidence_context).toEqual({
+      status: 'no_events',
+      authority: 'context_only',
+      final_attendance_authority: 'attendance_records',
+      window: { from: '2026-04-04', to: '2026-05-03' },
+      raw_counts: {
+        total_events: 0,
+        enter_events: 0,
+        exit_events: 0,
+        unique_users: 0
+      }
+    });
   });
 
-  it('returns stable empty-state cards and zero-filled daily points', async () => {
-    mockAttendanceFindAll.mockResolvedValueOnce([]);
+  it('keeps early attendance present without inflating on-time metrics', async () => {
+    mockAttendanceFindAll.mockResolvedValueOnce([
+      {
+        attendance_date: '2026-04-01',
+        user_id: 7,
+        status: { attendance_status_name: 'Early' },
+        attendance_category: { category_name: 'Work From Office' }
+      },
+      {
+        attendance_date: '2026-04-01',
+        user_id: 8,
+        status: { attendance_status_name: 'Lebih Awal' },
+        attendance_category: { category_name: 'Work From Office' }
+      }
+    ]);
+    mockLocationEventFindAll.mockResolvedValueOnce([]);
     mockBuildDisciplineAnalysis.mockResolvedValueOnce({ ranking: [] });
     mockBuildWfaAnalysis.mockResolvedValueOnce({ ranking: [] });
     mockBuildSmartAcAnalysis.mockResolvedValueOnce({ ranking: [] });
     mockBuildTodayLocationsSnapshot.mockResolvedValueOnce({
       date: '2026-05-03',
       timezone: 'Asia/Jakarta',
+      snapshot_type: 'attendance_checkin_snapshot',
+      is_live_tracking: false,
+      total_users: 0,
+      locations: []
+    });
+
+    const result = await buildDashboardAnalytics({
+      period: 'custom',
+      from: '2026-04-01',
+      to: '2026-04-01'
+    });
+
+    expect(result.executive_kpis.raw_counts).toEqual({
+      total_attendance_records: 2,
+      total_present: 2,
+      total_alpha: 0,
+      total_late: 0,
+      total_on_time: 0,
+      total_wfo: 2,
+      total_wfh: 0,
+      total_wfa: 0,
+      discipline_users_analyzed: 0
+    });
+    expect(result.historical_trend).toEqual({
+      points: [{ date: '2026-04-01', on_time: 0, late: 0, alpha: 0, present: 2, wfo: 2, wfh: 0, wfa: 0 }]
+    });
+  });
+
+  it('queries geofence evidence using Jakarta-day boundaries instead of UTC midnight', async () => {
+    mockAttendanceFindAll.mockResolvedValueOnce([]);
+    mockLocationEventFindAll.mockResolvedValueOnce([]);
+    mockBuildDisciplineAnalysis.mockResolvedValueOnce({ ranking: [] });
+    mockBuildWfaAnalysis.mockResolvedValueOnce({ ranking: [] });
+    mockBuildSmartAcAnalysis.mockResolvedValueOnce({ ranking: [] });
+    mockBuildTodayLocationsSnapshot.mockResolvedValueOnce({
+      date: '2026-05-03',
+      timezone: 'Asia/Jakarta',
+      snapshot_type: 'attendance_checkin_snapshot',
+      is_live_tracking: false,
+      total_users: 0,
+      locations: []
+    });
+
+    await buildDashboardAnalytics({
+      period: 'custom',
+      from: '2026-04-01',
+      to: '2026-04-03'
+    });
+
+    expect(mockLocationEventFindAll).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          event_timestamp: {
+            [Op.gte]: new Date('2026-03-31T17:00:00.000Z'),
+            [Op.lt]: new Date('2026-04-03T17:00:00.000Z')
+          }
+        }
+      })
+    );
+  });
+
+  it('returns stable empty-state cards, zero-filled points, and contextual empty geofence evidence', async () => {
+    mockAttendanceFindAll.mockResolvedValueOnce([]);
+    mockLocationEventFindAll.mockResolvedValueOnce([]);
+    mockBuildDisciplineAnalysis.mockResolvedValueOnce({ ranking: [] });
+    mockBuildWfaAnalysis.mockResolvedValueOnce({ ranking: [] });
+    mockBuildSmartAcAnalysis.mockResolvedValueOnce({ ranking: [] });
+    mockBuildTodayLocationsSnapshot.mockResolvedValueOnce({
+      date: '2026-05-03',
+      timezone: 'Asia/Jakarta',
+      snapshot_type: 'attendance_checkin_snapshot',
+      is_live_tracking: false,
       total_users: 0,
       locations: []
     });
@@ -464,21 +621,28 @@ describe('dashboard analytics helper contract', () => {
     });
 
     expect(result.executive_kpis).toEqual({
-      total_attendance_records: 0,
-      total_present: 0,
-      total_alpha: 0,
-      total_wfo: 0,
-      total_wfh: 0,
-      total_wfa: 0,
-      discipline_average: null,
-      discipline_users_analyzed: 0
+      attendance_rate: 0,
+      late_alpha_risk: 0,
+      avg_discipline: null,
+      needs_attention: 0,
+      raw_counts: {
+        total_attendance_records: 0,
+        total_present: 0,
+        total_alpha: 0,
+        total_late: 0,
+        total_on_time: 0,
+        total_wfo: 0,
+        total_wfh: 0,
+        total_wfa: 0,
+        discipline_users_analyzed: 0
+      }
     });
 
     expect(result.historical_trend).toEqual({
       points: [
-        { date: '2026-04-01', present: 0, alpha: 0, wfo: 0, wfh: 0, wfa: 0 },
-        { date: '2026-04-02', present: 0, alpha: 0, wfo: 0, wfh: 0, wfa: 0 },
-        { date: '2026-04-03', present: 0, alpha: 0, wfo: 0, wfh: 0, wfa: 0 }
+        { date: '2026-04-01', on_time: 0, late: 0, alpha: 0, present: 0, wfo: 0, wfh: 0, wfa: 0 },
+        { date: '2026-04-02', on_time: 0, late: 0, alpha: 0, present: 0, wfo: 0, wfh: 0, wfa: 0 },
+        { date: '2026-04-03', on_time: 0, late: 0, alpha: 0, present: 0, wfo: 0, wfh: 0, wfa: 0 }
       ]
     });
 
@@ -490,13 +654,29 @@ describe('dashboard analytics helper contract', () => {
     expect(result.today_locations).toEqual({
       date: '2026-05-03',
       timezone: 'Asia/Jakarta',
+      snapshot_type: 'attendance_checkin_snapshot',
+      is_live_tracking: false,
       total_users: 0,
       locations: []
     });
 
+    expect(result.geofence_evidence_context).toEqual({
+      status: 'no_events',
+      authority: 'context_only',
+      final_attendance_authority: 'attendance_records',
+      window: { from: '2026-04-01', to: '2026-04-03' },
+      raw_counts: {
+        total_events: 0,
+        enter_events: 0,
+        exit_events: 0,
+        unique_users: 0
+      }
+    });
+
     expect(result.fuzzy_ahp_snapshot).toEqual({
       discipline: {
-        generated_at: null,
+        status: 'no_data',
+        generated_at: expect.any(String),
         window: { from: '2026-04-01', to: '2026-04-03' },
         weights: {},
         consistency: null,
@@ -504,7 +684,8 @@ describe('dashboard analytics helper contract', () => {
         distribution: {}
       },
       wfa: {
-        generated_at: null,
+        status: 'no_data',
+        generated_at: expect.any(String),
         window: { from: '2026-04-01', to: '2026-04-03' },
         weights: {},
         consistency: null,
@@ -512,7 +693,8 @@ describe('dashboard analytics helper contract', () => {
         distribution: {}
       },
       smart_ac: {
-        generated_at: null,
+        status: 'no_data',
+        generated_at: expect.any(String),
         window: { from: '2026-04-01', to: '2026-04-03' },
         weights: {},
         consistency: null,

--- a/tests/summaryDashboardAnalyticsContract.test.js
+++ b/tests/summaryDashboardAnalyticsContract.test.js
@@ -1,0 +1,206 @@
+import { jest } from '@jest/globals';
+
+const mockBuildDashboardAnalytics = jest.fn();
+
+jest.unstable_mockModule('../src/config/database.js', () => ({
+  default: {}
+}));
+
+jest.unstable_mockModule('../src/models/index.js', () => ({
+  Attendance: {},
+  User: {},
+  Role: {},
+  Location: {},
+  AttendanceCategory: {},
+  AttendanceStatus: {},
+  Settings: {}
+}));
+
+jest.unstable_mockModule('../src/utils/workHourFormatter.js', () => ({
+  formatWorkHour: jest.fn(),
+  calculateWorkHour: jest.fn(),
+  formatTimeOnly: jest.fn()
+}));
+
+jest.unstable_mockModule('../src/utils/logger.js', () => ({
+  default: { info: jest.fn(), error: jest.fn(), debug: jest.fn(), warn: jest.fn() }
+}));
+
+jest.unstable_mockModule('../src/utils/fuzzyAhpEngine.js', () => ({
+  default: {}
+}));
+
+jest.unstable_mockModule('../src/utils/dashboardAnalytics.js', () => ({
+  buildDashboardAnalytics: mockBuildDashboardAnalytics
+}));
+
+const buildRes = () => ({
+  status: jest.fn().mockReturnThis(),
+  json: jest.fn().mockReturnThis()
+});
+
+const responseShell = {
+  meta: {
+    generated_at: null,
+    timezone: 'Asia/Jakarta',
+    requested_window: {
+      period: 'custom',
+      from: '2026-04-01',
+      to: '2026-04-15'
+    },
+    section_windows: {
+      executive_kpis: { from: '2026-04-01', to: '2026-04-15' },
+      historical_trend: { from: '2026-04-01', to: '2026-04-15' },
+      mode_mix: { from: '2026-04-01', to: '2026-04-15' },
+      fuzzy_ahp_snapshot: { from: '2026-04-01', to: '2026-04-15' },
+      today_locations: { mode: 'jakarta_today' }
+    },
+    sources: ['Attendance', 'AttendanceCategory', 'AttendanceStatus', 'Location', 'User']
+  },
+  executive_kpis: {
+    total_attendance_records: 0,
+    total_present: 0,
+    total_alpha: 0,
+    total_wfo: 0,
+    total_wfh: 0,
+    total_wfa: 0,
+    discipline_average: null,
+    discipline_users_analyzed: 0
+  },
+  historical_trend: {
+    points: []
+  },
+  mode_mix: {
+    totals: {
+      wfo: 0,
+      wfh: 0,
+      wfa: 0
+    },
+    percentages: {
+      wfo: 0,
+      wfh: 0,
+      wfa: 0
+    }
+  },
+  today_locations: {
+    date: '2026-05-03',
+    timezone: 'Asia/Jakarta',
+    total_users: 0,
+    locations: []
+  },
+  fuzzy_ahp_snapshot: {
+    discipline: {
+      generated_at: null,
+      window: { from: '2026-04-01', to: '2026-04-15' },
+      weights: {},
+      consistency: null,
+      top_rank: null,
+      distribution: {}
+    },
+    wfa: {
+      generated_at: null,
+      window: { from: '2026-04-01', to: '2026-04-15' },
+      weights: {},
+      consistency: null,
+      top_rank: null,
+      distribution: {}
+    },
+    smart_ac: {
+      generated_at: null,
+      window: { from: '2026-04-01', to: '2026-04-15' },
+      weights: {},
+      consistency: null,
+      top_rank: null,
+      distribution: {}
+    }
+  },
+  insights: {
+    items: []
+  }
+};
+
+describe('summary dashboard analytics controller contract', () => {
+  beforeEach(() => {
+    mockBuildDashboardAnalytics.mockReset();
+  });
+
+  it('delegates validated query values to the dashboard analytics helper', async () => {
+    mockBuildDashboardAnalytics.mockResolvedValueOnce(responseShell);
+
+    const { getDashboardAnalytics } = await import('../src/controllers/summary.controller.js');
+    const req = {
+      query: {
+        period: 'custom',
+        from: '2026-04-01',
+        to: '2026-04-15'
+      }
+    };
+    const res = buildRes();
+    const next = jest.fn();
+
+    await getDashboardAnalytics(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(mockBuildDashboardAnalytics).toHaveBeenCalledWith({
+      period: 'custom',
+      from: '2026-04-01',
+      to: '2026-04-15'
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      data: responseShell,
+      message: 'Dashboard analytics retrieved successfully'
+    });
+  });
+
+  it('uses controller defaults without duplicating validation', async () => {
+    mockBuildDashboardAnalytics.mockResolvedValueOnce({
+      ...responseShell,
+      meta: {
+        generated_at: null,
+        timezone: 'Asia/Jakarta',
+        requested_window: { period: '30d', from: null, to: null },
+        section_windows: {
+          executive_kpis: { from: '2026-04-04', to: '2026-05-03' },
+          historical_trend: { from: '2026-04-04', to: '2026-05-03' },
+          mode_mix: { from: '2026-04-04', to: '2026-05-03' },
+          fuzzy_ahp_snapshot: { from: '2026-04-04', to: '2026-05-03' },
+          today_locations: { mode: 'jakarta_today' }
+        },
+        sources: ['Attendance', 'AttendanceCategory', 'AttendanceStatus', 'Location', 'User']
+      }
+    });
+
+    const { getDashboardAnalytics } = await import('../src/controllers/summary.controller.js');
+    const req = { query: {} };
+    const res = buildRes();
+    const next = jest.fn();
+
+    await getDashboardAnalytics(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(mockBuildDashboardAnalytics).toHaveBeenCalledWith({
+      period: '30d',
+      from: null,
+      to: null
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('passes helper failures to the error handler', async () => {
+    const error = new Error('helper failed');
+    mockBuildDashboardAnalytics.mockRejectedValueOnce(error);
+
+    const { getDashboardAnalytics } = await import('../src/controllers/summary.controller.js');
+    const req = { query: { period: '7d' } };
+    const res = buildRes();
+    const next = jest.fn();
+
+    await getDashboardAnalytics(req, res, next);
+
+    expect(next).toHaveBeenCalledWith(error);
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
+  });
+});

--- a/tests/summaryDashboardAnalyticsContract.test.js
+++ b/tests/summaryDashboardAnalyticsContract.test.js
@@ -41,7 +41,7 @@ const buildRes = () => ({
 
 const responseShell = {
   meta: {
-    generated_at: null,
+    generated_at: '2026-05-03T02:30:00.000Z',
     timezone: 'Asia/Jakarta',
     requested_window: {
       period: 'custom',
@@ -53,19 +53,27 @@ const responseShell = {
       historical_trend: { from: '2026-04-01', to: '2026-04-15' },
       mode_mix: { from: '2026-04-01', to: '2026-04-15' },
       fuzzy_ahp_snapshot: { from: '2026-04-01', to: '2026-04-15' },
+      geofence_evidence_context: { from: '2026-04-01', to: '2026-04-15' },
       today_locations: { mode: 'jakarta_today' }
     },
-    sources: ['Attendance', 'AttendanceCategory', 'AttendanceStatus', 'Location', 'User']
+    sources: ['Attendance', 'AttendanceCategory', 'AttendanceStatus', 'Location', 'LocationEvent', 'User']
   },
   executive_kpis: {
-    total_attendance_records: 0,
-    total_present: 0,
-    total_alpha: 0,
-    total_wfo: 0,
-    total_wfh: 0,
-    total_wfa: 0,
-    discipline_average: null,
-    discipline_users_analyzed: 0
+    attendance_rate: 0,
+    late_alpha_risk: 0,
+    avg_discipline: null,
+    needs_attention: 0,
+    raw_counts: {
+      total_attendance_records: 0,
+      total_present: 0,
+      total_alpha: 0,
+      total_late: 0,
+      total_on_time: 0,
+      total_wfo: 0,
+      total_wfh: 0,
+      total_wfa: 0,
+      discipline_users_analyzed: 0
+    }
   },
   historical_trend: {
     points: []
@@ -85,12 +93,27 @@ const responseShell = {
   today_locations: {
     date: '2026-05-03',
     timezone: 'Asia/Jakarta',
+    snapshot_type: 'attendance_checkin_snapshot',
+    is_live_tracking: false,
     total_users: 0,
     locations: []
   },
+  geofence_evidence_context: {
+    status: 'no_events',
+    authority: 'context_only',
+    final_attendance_authority: 'attendance_records',
+    window: { from: '2026-04-01', to: '2026-04-15' },
+    raw_counts: {
+      total_events: 0,
+      enter_events: 0,
+      exit_events: 0,
+      unique_users: 0
+    }
+  },
   fuzzy_ahp_snapshot: {
     discipline: {
-      generated_at: null,
+      status: 'no_data',
+      generated_at: '2026-05-03T02:30:00.000Z',
       window: { from: '2026-04-01', to: '2026-04-15' },
       weights: {},
       consistency: null,
@@ -98,7 +121,8 @@ const responseShell = {
       distribution: {}
     },
     wfa: {
-      generated_at: null,
+      status: 'no_data',
+      generated_at: '2026-05-03T02:30:00.000Z',
       window: { from: '2026-04-01', to: '2026-04-15' },
       weights: {},
       consistency: null,
@@ -106,7 +130,8 @@ const responseShell = {
       distribution: {}
     },
     smart_ac: {
-      generated_at: null,
+      status: 'no_data',
+      generated_at: '2026-05-03T02:30:00.000Z',
       window: { from: '2026-04-01', to: '2026-04-15' },
       weights: {},
       consistency: null,
@@ -158,7 +183,7 @@ describe('summary dashboard analytics controller contract', () => {
     mockBuildDashboardAnalytics.mockResolvedValueOnce({
       ...responseShell,
       meta: {
-        generated_at: null,
+        generated_at: '2026-05-03T02:30:00.000Z',
         timezone: 'Asia/Jakarta',
         requested_window: { period: '30d', from: null, to: null },
         section_windows: {
@@ -166,9 +191,10 @@ describe('summary dashboard analytics controller contract', () => {
           historical_trend: { from: '2026-04-04', to: '2026-05-03' },
           mode_mix: { from: '2026-04-04', to: '2026-05-03' },
           fuzzy_ahp_snapshot: { from: '2026-04-04', to: '2026-05-03' },
+          geofence_evidence_context: { from: '2026-04-04', to: '2026-05-03' },
           today_locations: { mode: 'jakarta_today' }
         },
-        sources: ['Attendance', 'AttendanceCategory', 'AttendanceStatus', 'Location', 'User']
+        sources: ['Attendance', 'AttendanceCategory', 'AttendanceStatus', 'Location', 'LocationEvent', 'User']
       }
     });
 

--- a/tests/summaryDashboardAnalyticsRoute.test.js
+++ b/tests/summaryDashboardAnalyticsRoute.test.js
@@ -1,0 +1,200 @@
+import express from 'express';
+import { jest } from '@jest/globals';
+import request from 'supertest';
+
+let authMode = 'allow';
+let currentRole = 'Admin';
+
+const mockVerifyToken = jest.fn((req, res, next) => {
+  if (authMode === 'reject') {
+    return res.status(401).json({
+      success: false,
+      message: 'No token provided'
+    });
+  }
+
+  req.user = { id: 1, role_name: currentRole };
+  next();
+});
+
+const mockGetSummaryReport = jest.fn((_req, res) => {
+  res.status(200).json({ success: true, message: 'legacy summary ok' });
+});
+
+const mockGetDashboardAnalytics = jest.fn((req, res) => {
+  res.status(200).json({
+    success: true,
+    data: {
+      period: req.query.period || '30d'
+    },
+    message: 'Dashboard analytics endpoint is not implemented yet'
+  });
+});
+
+jest.unstable_mockModule('../src/middlewares/authJwt.js', () => ({
+  verifyToken: mockVerifyToken
+}));
+
+jest.unstable_mockModule('../src/controllers/summary.controller.js', () => ({
+  getSummaryReport: mockGetSummaryReport,
+  getDashboardAnalytics: mockGetDashboardAnalytics
+}));
+
+const { default: summaryRoutes } = await import('../src/routes/summary.routes.js');
+
+const app = express();
+app.use(express.json());
+app.use('/api/summary', summaryRoutes);
+
+describe('summary dashboard analytics route', () => {
+  beforeEach(() => {
+    authMode = 'allow';
+    currentRole = 'Admin';
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('runs auth middleware before the dashboard analytics handler', async () => {
+    authMode = 'reject';
+
+    const res = await request(app).get('/api/summary/dashboard-analytics');
+
+    expect(res.status).toBe(401);
+    expect(mockVerifyToken).toHaveBeenCalled();
+    expect(mockGetDashboardAnalytics).not.toHaveBeenCalled();
+  });
+
+  it.each(['Admin', 'Management'])(
+    'allows %s access to dashboard analytics',
+    async (roleName) => {
+      currentRole = roleName;
+
+      const res = await request(app).get('/api/summary/dashboard-analytics');
+
+      expect(res.status).toBe(200);
+      expect(mockGetDashboardAnalytics).toHaveBeenCalled();
+    }
+  );
+
+  it('passes current_month through to the handler for a realistic dashboard filter', async () => {
+    const res = await request(app).get('/api/summary/dashboard-analytics?period=current_month');
+
+    expect(res.status).toBe(200);
+    expect(mockGetDashboardAnalytics).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({ period: 'current_month' })
+      }),
+      expect.anything(),
+      expect.anything()
+    );
+    expect(res.body).toEqual({
+      success: true,
+      data: { period: 'current_month' },
+      message: 'Dashboard analytics endpoint is not implemented yet'
+    });
+  });
+
+  it('accepts a custom range that is exactly 31 days long', async () => {
+    const res = await request(app).get(
+      '/api/summary/dashboard-analytics?period=custom&from=2026-05-01&to=2026-05-31'
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockGetDashboardAnalytics).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({
+          period: 'custom',
+          from: '2026-05-01',
+          to: '2026-05-31'
+        })
+      }),
+      expect.anything(),
+      expect.anything()
+    );
+  });
+
+  it('returns 403 for unauthorized roles', async () => {
+    currentRole = 'User';
+
+    const res = await request(app).get('/api/summary/dashboard-analytics');
+
+    expect(res.status).toBe(403);
+    expect(mockGetDashboardAnalytics).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 E_VALIDATION for an invalid period value', async () => {
+    const res = await request(app).get('/api/summary/dashboard-analytics?period=invalid');
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({
+      success: false,
+      code: 'E_VALIDATION'
+    });
+    expect(mockGetDashboardAnalytics).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 E_VALIDATION when from uses a non-ISO date format', async () => {
+    const res = await request(app).get(
+      '/api/summary/dashboard-analytics?period=custom&from=05-01-2026&to=2026-05-31'
+    );
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({
+      success: false,
+      code: 'E_VALIDATION'
+    });
+    expect(mockGetDashboardAnalytics).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 E_VALIDATION when custom dates are impossible calendar dates', async () => {
+    const res = await request(app).get(
+      '/api/summary/dashboard-analytics?period=custom&from=2026-04-01&to=2026-04-31'
+    );
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({
+      success: false,
+      code: 'E_VALIDATION'
+    });
+    expect(mockGetDashboardAnalytics).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 E_VALIDATION when custom period is missing from or to', async () => {
+    const res = await request(app).get('/api/summary/dashboard-analytics?period=custom&from=2026-05-01');
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({
+      success: false,
+      code: 'E_VALIDATION'
+    });
+    expect(mockGetDashboardAnalytics).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 E_VALIDATION when custom from is greater than to', async () => {
+    const res = await request(app).get(
+      '/api/summary/dashboard-analytics?period=custom&from=2026-05-10&to=2026-05-01'
+    );
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({
+      success: false,
+      code: 'E_VALIDATION'
+    });
+    expect(mockGetDashboardAnalytics).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 E_VALIDATION when the custom range exceeds 31 days', async () => {
+    const res = await request(app).get(
+      '/api/summary/dashboard-analytics?period=custom&from=2026-05-01&to=2026-06-02'
+    );
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({
+      success: false,
+      code: 'E_VALIDATION'
+    });
+    expect(mockGetDashboardAnalytics).not.toHaveBeenCalled();
+  });
+});

--- a/tests/summaryDashboardAnalyticsRoute.test.js
+++ b/tests/summaryDashboardAnalyticsRoute.test.js
@@ -27,7 +27,7 @@ const mockGetDashboardAnalytics = jest.fn((req, res) => {
     data: {
       period: req.query.period || '30d'
     },
-    message: 'Dashboard analytics endpoint is not implemented yet'
+    message: 'Dashboard analytics retrieved successfully'
   });
 });
 
@@ -92,7 +92,7 @@ describe('summary dashboard analytics route', () => {
     expect(res.body).toEqual({
       success: true,
       data: { period: 'current_month' },
-      message: 'Dashboard analytics endpoint is not implemented yet'
+      message: 'Dashboard analytics retrieved successfully'
     });
   });
 

--- a/tests/summaryDashboardAnalyticsSeam.test.js
+++ b/tests/summaryDashboardAnalyticsSeam.test.js
@@ -1,0 +1,325 @@
+import express from 'express';
+import { Op } from 'sequelize';
+import { jest } from '@jest/globals';
+import request from 'supertest';
+
+const mockGetJakartaDateString = jest.fn(() => '2026-05-03');
+const mockAttendanceFindAll = jest.fn();
+const mockLocationEventFindAll = jest.fn();
+const mockBuildDisciplineAnalysis = jest.fn();
+const mockBuildWfaAnalysis = jest.fn();
+const mockBuildSmartAcAnalysis = jest.fn();
+const mockBuildTodayLocationsSnapshot = jest.fn();
+const mockVerifyToken = jest.fn((req, _res, next) => {
+  req.user = { id: 1, role_name: 'Admin' };
+  next();
+});
+
+jest.unstable_mockModule('../src/config/database.js', () => ({
+  default: {}
+}));
+
+jest.unstable_mockModule('../src/models/index.js', () => ({
+  Attendance: { findAll: mockAttendanceFindAll },
+  User: {},
+  Role: {},
+  Location: {},
+  AttendanceCategory: {},
+  AttendanceStatus: {},
+  Settings: {},
+  LocationEvent: { findAll: mockLocationEventFindAll }
+}));
+
+jest.unstable_mockModule('../src/models/user.model.js', () => ({
+  default: { findOne: jest.fn() }
+}));
+
+jest.unstable_mockModule('../src/utils/logger.js', () => ({
+  default: { info: jest.fn(), error: jest.fn(), debug: jest.fn(), warn: jest.fn() }
+}));
+
+jest.unstable_mockModule('../src/utils/workHourFormatter.js', () => ({
+  formatWorkHour: jest.fn(),
+  calculateWorkHour: jest.fn(),
+  formatTimeOnly: jest.fn()
+}));
+
+jest.unstable_mockModule('../src/utils/fuzzyAhpEngine.js', () => ({
+  default: {}
+}));
+
+jest.unstable_mockModule('../src/utils/geofence.js', () => ({
+  getJakartaDateString: mockGetJakartaDateString
+}));
+
+jest.unstable_mockModule('../src/controllers/analysis.controller.js', () => ({
+  buildDisciplineAnalysis: mockBuildDisciplineAnalysis,
+  buildWfaAnalysis: mockBuildWfaAnalysis,
+  buildSmartAcAnalysis: mockBuildSmartAcAnalysis
+}));
+
+jest.unstable_mockModule('../src/utils/todayLocationsSnapshot.js', () => ({
+  buildTodayLocationsSnapshot: mockBuildTodayLocationsSnapshot
+}));
+
+jest.unstable_mockModule('../src/middlewares/authJwt.js', () => ({
+  verifyToken: mockVerifyToken
+}));
+
+const { default: summaryRoutes } = await import('../src/routes/summary.routes.js');
+
+const app = express();
+app.use(express.json());
+app.use('/api/summary', summaryRoutes);
+
+describe('summary dashboard analytics seam', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('serves a real dashboard analytics payload through the route-controller-helper seam', async () => {
+    mockAttendanceFindAll.mockResolvedValueOnce([
+      {
+        attendance_date: '2026-04-01',
+        user_id: 7,
+        status: { attendance_status_name: 'Tepat Waktu' },
+        attendance_category: { category_name: 'Work From Office' }
+      },
+      {
+        attendance_date: '2026-04-02',
+        user_id: 8,
+        status: { attendance_status_name: 'Alpha' },
+        attendance_category: { category_name: 'Work From Home' }
+      },
+      {
+        attendance_date: '2026-04-03',
+        user_id: 8,
+        status: { attendance_status_name: 'Terlambat' },
+        attendance_category: { category_name: 'Work From Anywhere' }
+      }
+    ]);
+
+    mockLocationEventFindAll.mockResolvedValueOnce([
+      { user_id: 7, event_type: 'ENTER' },
+      { user_id: 8, event_type: 'EXIT' },
+      { user_id: 8, event_type: 'EXIT' }
+    ]);
+
+    mockBuildDisciplineAnalysis.mockResolvedValueOnce({
+      consistency: { CR: 0.021, threshold: 0.1, is_consistent: true },
+      weights: {
+        criteria: ['alpha_rate', 'lateness_severity'],
+        values: [0.6, 0.4]
+      },
+      ranking: [
+        { id: 9, name: 'Outsider', score: 99, label: 'Sangat Tinggi' },
+        { id: 7, name: 'Febri', score: 84, label: 'Tinggi' },
+        { id: 8, name: 'Diana', score: 80, label: 'Sedang' }
+      ]
+    });
+
+    mockBuildWfaAnalysis.mockResolvedValueOnce({
+      consistency: { CR: 0.018, threshold: 0.1, is_consistent: true },
+      weights: {
+        criteria: ['location_type', 'distance_factor'],
+        values: [0.55, 0.45]
+      },
+      ranking: [
+        { id: 31, name: 'Cafe Satu', score: 90, label: 'Sangat Tinggi' },
+        { id: 32, name: 'Library Dua', score: 70, label: 'Tinggi' }
+      ]
+    });
+
+    mockBuildSmartAcAnalysis.mockResolvedValueOnce({
+      consistency: { CR: 0, threshold: 0.1, is_consistent: true },
+      weights: {
+        criteria: ['history', 'context'],
+        values: [0.4, 0.6]
+      },
+      ranking: [
+        { id: 99, name: 'Untracked User', score: 95, label: 'Sangat Tinggi' },
+        { id: 8, name: 'Diana', score: 72, label: 'Tinggi' },
+        { id: 7, name: 'Febri', score: 65, label: 'Sedang' }
+      ]
+    });
+
+    mockBuildTodayLocationsSnapshot.mockResolvedValueOnce({
+      date: '2026-05-03',
+      timezone: 'Asia/Jakarta',
+      snapshot_type: 'attendance_checkin_snapshot',
+      is_live_tracking: false,
+      total_users: 2,
+      locations: [
+        {
+          user_id: 7,
+          full_name: 'Febri',
+          status: 'WFO',
+          check_in_time: '08:15',
+          latitude: -0.8917,
+          longitude: 119.8707,
+          photo: null
+        },
+        {
+          user_id: 8,
+          full_name: 'Diana',
+          status: 'WFA',
+          check_in_time: '08:45',
+          latitude: -0.901,
+          longitude: 119.875,
+          photo: null
+        }
+      ]
+    });
+
+    const res = await request(app).get(
+      '/api/summary/dashboard-analytics?period=custom&from=2026-04-01&to=2026-04-03'
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockVerifyToken).toHaveBeenCalled();
+    expect(mockAttendanceFindAll).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          attendance_date: {
+            [Op.between]: ['2026-04-01', '2026-04-03']
+          }
+        }
+      })
+    );
+    expect(mockLocationEventFindAll).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          event_timestamp: {
+            [Op.gte]: new Date('2026-03-31T17:00:00.000Z'),
+            [Op.lt]: new Date('2026-04-03T17:00:00.000Z')
+          }
+        }
+      })
+    );
+    expect(res.body).toMatchObject({
+      success: true,
+      message: 'Dashboard analytics retrieved successfully',
+      data: {
+        meta: {
+          timezone: 'Asia/Jakarta',
+          requested_window: {
+            period: 'custom',
+            from: '2026-04-01',
+            to: '2026-04-03'
+          }
+        },
+        executive_kpis: {
+          attendance_rate: 66.67,
+          late_alpha_risk: 66.67,
+          avg_discipline: 82,
+          needs_attention: 1,
+          raw_counts: {
+            total_attendance_records: 3,
+            total_present: 2,
+            total_alpha: 1,
+            total_late: 1,
+            total_on_time: 1,
+            total_wfo: 1,
+            total_wfh: 1,
+            total_wfa: 1,
+            discipline_users_analyzed: 2
+          }
+        },
+        mode_mix: {
+          totals: {
+            wfo: 1,
+            wfh: 1,
+            wfa: 1
+          },
+          percentages: {
+            wfo: 33.33,
+            wfh: 33.33,
+            wfa: 33.33
+          }
+        },
+        today_locations: {
+          snapshot_type: 'attendance_checkin_snapshot',
+          is_live_tracking: false,
+          total_users: 2
+        },
+        geofence_evidence_context: {
+          status: 'available',
+          authority: 'context_only',
+          final_attendance_authority: 'attendance_records',
+          raw_counts: {
+            total_events: 3,
+            enter_events: 1,
+            exit_events: 2,
+            unique_users: 2
+          }
+        },
+        fuzzy_ahp_snapshot: {
+          discipline: {
+            status: 'ready',
+            top_rank: {
+              id: 7,
+              name: 'Febri',
+              label: 'Tinggi'
+            }
+          },
+          wfa: {
+            status: 'ready',
+            top_rank: {
+              id: 31,
+              name: 'Cafe Satu',
+              label: 'Sangat Tinggi'
+            }
+          },
+          smart_ac: {
+            status: 'ready',
+            top_rank: {
+              id: 8,
+              name: 'Diana',
+              label: 'Tinggi'
+            }
+          }
+        },
+        insights: {
+          items: [
+            {
+              type: 'alpha_spike',
+              severity: 'high'
+            }
+          ]
+        }
+      }
+    });
+    expect(res.body.data.historical_trend.points).toEqual([
+      {
+        date: '2026-04-01',
+        on_time: 1,
+        late: 0,
+        present: 1,
+        alpha: 0,
+        wfo: 1,
+        wfh: 0,
+        wfa: 0
+      },
+      {
+        date: '2026-04-02',
+        on_time: 0,
+        late: 0,
+        present: 0,
+        alpha: 1,
+        wfo: 0,
+        wfh: 1,
+        wfa: 0
+      },
+      {
+        date: '2026-04-03',
+        on_time: 0,
+        late: 1,
+        present: 1,
+        alpha: 0,
+        wfo: 0,
+        wfh: 0,
+        wfa: 1
+      }
+    ]);
+  });
+});

--- a/tests/summarySettingsCache.test.js
+++ b/tests/summarySettingsCache.test.js
@@ -21,6 +21,8 @@ jest.unstable_mockModule('../src/models/index.js', () => ({
   User: {},
   Role: {},
   Location: {},
+  Photo: {},
+  LocationEvent: {},
   AttendanceCategory: {},
   AttendanceStatus: {},
   Settings: {


### PR DESCRIPTION
## Summary
- add and finalize the dedicated `/api/summary/dashboard-analytics` endpoint while preserving the legacy `/api/summary` route
- aggregate dashboard cockpit data from backend source-of-truth surfaces: executive KPIs, historical trend, WFO/WFH/WFA mode mix, today locations, geofence evidence context, and discipline/WFA/smart AC snapshots
- align runtime, OpenAPI, route validation, helper contract, and route-controller-helper seam coverage, including Jakarta-day geofence boundaries and public OpenAPI exclusion for debug/test routes such as `/api/wfa/test-ahp`

## Verification evidence
- [x] Commit included final seam test: `650163f INF-159 finalize dashboard analytics contract`
- [x] Focused local suite: `npm test -- --runInBand tests/dashboardAnalyticsHelper.test.js tests/summaryDashboardAnalyticsSeam.test.js tests/summaryDashboardAnalyticsRoute.test.js tests/summaryDashboardAnalyticsContract.test.js tests/clientCriticalOpenApiContract.test.js tests/openApiMountedRoutesContract.test.js`
- [x] Result: 6 test suites passed, 33 tests passed
- [x] Working tree clean after commit and push

## Risk / notes
- API-significant change: public OpenAPI contract and dashboard response shape changed intentionally for INF-160 dashboard cockpit consumption.
- Docs update: `docs/openapi.yaml` updated in this PR.
- Runtime authority: geofence evidence remains `context_only`; final attendance authority remains attendance records.

Generated with [Claude Code](https://claude.com/code)