### PR TITLE
INF-158 add operational settings admin API

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2108,6 +2108,119 @@ paths:
         '403':
           $ref: '#/components/responses/Forbidden'
 
+  /api/settings/operational:
+    get:
+      tags:
+        - Settings
+      summary: Get operational settings (Admin/Management only)
+      description: |
+        Retrieve the current operational attendance settings as the backend-authoritative typed object.
+
+        Only the approved operational settings are exposed by this endpoint. It does not expose arbitrary settings rows,
+        secrets, or analysis configuration such as `AHP_CR_THRESHOLD`.
+
+        This endpoint is strict about storage integrity. If any approved operational setting row is missing or contains an
+        invalid persisted value, the request fails instead of silently substituting defaults.
+      responses:
+        '200':
+          description: Operational settings retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OperationalSettings'
+        '401':
+          description: Unauthorized - Invalid or missing authentication token
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: 'Invalid token'
+                required:
+                  - message
+                additionalProperties: false
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/OperationalSettingsIntegrityError'
+    patch:
+      tags:
+        - Settings
+      summary: Partially update operational settings (Admin/Management only)
+      description: |
+        Partially update the approved operational attendance settings.
+
+        Request input accepts `defaultShiftEnd` in `HH:mm` or `HH:mm:ss` format, and successful responses always normalize
+        `defaultShiftEnd` to `HH:mm:ss`.
+
+        The PATCH write path mutates only explicitly provided fields. The success response is returned only when the
+        full post-update operational settings state is valid; otherwise the request fails instead of masking unrelated
+        storage corruption with defaults.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OperationalSettingsPatchRequest'
+            examples:
+              updateIdleAndShiftEnd:
+                summary: Update idle timeout and fallback shift end
+                value:
+                  autoCheckoutIdleMin: 12
+                  defaultShiftEnd: '18:00'
+      responses:
+        '200':
+          description: Operational settings updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OperationalSettings'
+        '400':
+          description: Validation error for rejected operational settings payloads
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  code:
+                    type: string
+                    example: 'E_VALIDATION'
+                  message:
+                    type: string
+                    example: 'Unknown operational setting field: ahpCrThreshold'
+                  errors:
+                    type: array
+                    items:
+                      type: object
+                required:
+                  - success
+                  - code
+                  - message
+                  - errors
+                additionalProperties: false
+        '401':
+          description: Unauthorized - Invalid or missing authentication token
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: 'Invalid token'
+                required:
+                  - message
+                additionalProperties: false
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/OperationalSettingsIntegrityError'
+
   # Reference Data Endpoints
   /api/roles:
     get:
@@ -2258,6 +2371,78 @@ components:
           type: string
           format: date-time
           example: '2025-07-01T10:00:00.000Z'
+
+    OperationalSettings:
+      type: object
+      description: |
+        Backend-authoritative operational attendance settings.
+
+        This schema intentionally exposes only the approved operational settings. It does not include arbitrary
+        settings-table rows or analysis configuration such as `AHP_CR_THRESHOLD`.
+      properties:
+        geofenceRadiusDefaultM:
+          type: integer
+          minimum: 1
+          example: 100
+          description: Default geofence radius in meters for attendance enforcement.
+        autoCheckoutIdleMin:
+          type: integer
+          minimum: 1
+          example: 10
+          description: Idle threshold in minutes before auto checkout is considered.
+        autoCheckoutTBufferMin:
+          type: integer
+          minimum: 1
+          example: 30
+          description: Time buffer in minutes used by auto-checkout evaluation logic.
+        lateCheckoutToleranceMin:
+          type: integer
+          minimum: 1
+          example: 15
+          description: Late-checkout tolerance in minutes before fallback handling applies.
+        defaultShiftEnd:
+          type: string
+          pattern: '^(?:[01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d$'
+          example: '17:00:00'
+          description: Default fallback shift end time normalized to HH:mm:ss.
+      required:
+        - geofenceRadiusDefaultM
+        - autoCheckoutIdleMin
+        - autoCheckoutTBufferMin
+        - lateCheckoutToleranceMin
+        - defaultShiftEnd
+      additionalProperties: false
+
+    OperationalSettingsPatchRequest:
+      type: object
+      description: |
+        Partial update payload for operational attendance settings.
+
+        Only the approved operational settings may be sent. `defaultShiftEnd` accepts `HH:mm` or `HH:mm:ss` on input
+        and is normalized to `HH:mm:ss` in the success response.
+      properties:
+        geofenceRadiusDefaultM:
+          type: integer
+          minimum: 1
+          example: 150
+        autoCheckoutIdleMin:
+          type: integer
+          minimum: 1
+          example: 12
+        autoCheckoutTBufferMin:
+          type: integer
+          minimum: 1
+          example: 45
+        lateCheckoutToleranceMin:
+          type: integer
+          minimum: 1
+          example: 20
+        defaultShiftEnd:
+          type: string
+          pattern: '^(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d)?$'
+          example: '18:00'
+      minProperties: 1
+      additionalProperties: false
 
     Role:
       type: object
@@ -2837,9 +3022,17 @@ components:
               success:
                 type: boolean
                 example: false
+              code:
+                type: string
+                example: 'E_FORBIDDEN'
               message:
                 type: string
-                example: 'Access forbidden - insufficient permissions'
+                example: 'Forbidden: Insufficient role'
+            required:
+              - success
+              - code
+              - message
+            additionalProperties: false
 
     NotFound:
       description: Resource not found
@@ -2885,6 +3078,50 @@ components:
               error:
                 type: string
                 example: 'Database connection failed'
+
+    OperationalSettingsIntegrityError:
+      description: Operational settings storage is incomplete or contains invalid persisted values
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              success:
+                type: boolean
+                example: false
+              code:
+                type: string
+                example: 'E_OPERATIONAL_SETTINGS_INVALID'
+              message:
+                type: string
+                example: 'Operational settings are incomplete or invalid: geofenceRadiusDefaultM (missing)'
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    field:
+                      type: string
+                      example: 'geofenceRadiusDefaultM'
+                    issue:
+                      type: string
+                      enum:
+                        - missing
+                        - invalid
+                    value:
+                      oneOf:
+                        - type: string
+                        - type: number
+                        - type: integer
+                  required:
+                    - field
+                    - issue
+            required:
+              - success
+              - code
+              - message
+              - details
+            additionalProperties: false
 
     ValidationError:
       description: Validation error with detailed field errors
@@ -3113,6 +3350,8 @@ tags:
     description: Summary reports and analytics for management
   - name: Discipline Management
     description: Employee discipline index calculation and management
+  - name: Settings
+    description: Operational settings management endpoints for Admin and Management
   - name: Reference Data
     description: Master data for roles, positions, divisions, etc.
   - name: Development & Testing

--- a/src/controllers/settings.controller.js
+++ b/src/controllers/settings.controller.js
@@ -1,0 +1,22 @@
+import {
+  readOperationalSettings,
+  updateOperationalSettings
+} from '../services/operationalSettings.service.js';
+
+export const getOperationalSettings = async (_req, res, next) => {
+  try {
+    const settings = await readOperationalSettings();
+    return res.status(200).json(settings);
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const patchOperationalSettings = async (req, res, next) => {
+  try {
+    const settings = await updateOperationalSettings(req.body);
+    return res.status(200).json(settings);
+  } catch (error) {
+    return next(error);
+  }
+};

--- a/src/middlewares/errorHandler.js
+++ b/src/middlewares/errorHandler.js
@@ -1,15 +1,23 @@
 import logger from '../utils/logger.js';
 import config from '../config/index.js';
 
+const PUBLIC_ERROR_CODES = new Set(['E_OPERATIONAL_SETTINGS_INVALID']);
+
 export const errorHandler = (err, req, res, _next) => {
-  // Log error with context
-  logger.error({
+  const logPayload = {
     message: err.message,
+    code: err.code,
     stack: err.stack,
     path: req.path,
     method: req.method,
     ip: req.ip
-  });
+  };
+
+  if (err.code === 'E_OPERATIONAL_SETTINGS_INVALID' && Array.isArray(err.details)) {
+    logPayload.details = err.details;
+  }
+
+  logger.error(logPayload);
 
   // Sequelize validation errors
   if (err.name === 'SequelizeValidationError') {
@@ -53,6 +61,14 @@ export const errorHandler = (err, req, res, _next) => {
         ? 'Internal server error'
         : err.message || 'Internal server error'
   };
+
+  if (PUBLIC_ERROR_CODES.has(err.code)) {
+    response.code = err.code;
+  }
+
+  if (err.code === 'E_OPERATIONAL_SETTINGS_INVALID' && Array.isArray(err.details)) {
+    response.details = err.details;
+  }
 
   // Only include stack trace in development
   if (config.env === 'development') {

--- a/src/middlewares/roleGuard.js
+++ b/src/middlewares/roleGuard.js
@@ -13,13 +13,6 @@ export default (allowedRoles) => {
     } // Get role name from JWT token - support both old and new format
     const userRole = req.user.role_name || req.user.role?.name;
 
-    // Debug logging untuk troubleshooting
-    console.log('🔍 Role Guard Debug Info:');
-    console.log('- req.user:', req.user);
-    console.log('- User Role from token:', userRole);
-    console.log('- Required Roles:', allowedRoles);
-    console.log('- Role check result:', allowedRoles.includes(userRole));
-
     if (!userRole || !allowedRoles.includes(userRole)) {
       logger.warn(
         `Role check failed - User role: "${userRole}", Required: ${allowedRoles.join(', ')}`
@@ -27,7 +20,7 @@ export default (allowedRoles) => {
       return res.status(403).json({
         success: false,
         code: 'E_FORBIDDEN',
-        message: `Forbidden: Insufficient role. User role: ${userRole}, Required roles: ${allowedRoles.join(', ')} [DEBUG: ${new Date().toISOString()}]`
+        message: 'Forbidden: Insufficient role'
       });
     }
 

--- a/src/middlewares/settings.validator.js
+++ b/src/middlewares/settings.validator.js
@@ -1,0 +1,60 @@
+import { body } from 'express-validator';
+
+import {
+  OPERATIONAL_SETTING_FIELDS,
+  OPERATIONAL_SETTING_INTEGER_FIELDS,
+  OPERATIONAL_SETTING_TIME_FIELDS,
+  isOperationalSettingField,
+  normalizeOperationalSettingTime
+} from '../utils/settings.js';
+import { validate } from './validator.js';
+
+const hasAllowedOperationalSettingField = (payload) => {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return false;
+  }
+
+  return OPERATIONAL_SETTING_FIELDS.some((field) => Object.hasOwn(payload, field));
+};
+
+export const operationalSettingsPatchValidation = [
+  body()
+    .custom((value) => {
+      if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        throw new Error('Body must be an object');
+      }
+
+      return true;
+    })
+    .bail()
+    .custom((value) => {
+      const unknownFields = Object.keys(value).filter((field) => !isOperationalSettingField(field));
+
+      if (unknownFields.length > 0) {
+        throw new Error(`Unknown operational setting field: ${unknownFields[0]}`);
+      }
+
+      return true;
+    })
+    .bail()
+    .custom((value) => {
+      if (!hasAllowedOperationalSettingField(value)) {
+        throw new Error(`At least one of these fields is required: ${OPERATIONAL_SETTING_FIELDS.join(', ')}`);
+      }
+
+      return true;
+    }),
+  ...OPERATIONAL_SETTING_INTEGER_FIELDS.map((field) =>
+    body(field)
+      .optional()
+      .custom((value) => Number.isInteger(value) && value > 0)
+      .withMessage(`${field} must be a positive integer`)
+  ),
+  ...OPERATIONAL_SETTING_TIME_FIELDS.map((field) =>
+    body(field)
+      .optional()
+      .custom((value) => typeof value === 'string' && normalizeOperationalSettingTime(value) !== null)
+      .withMessage(`${field} must use HH:mm or HH:mm:ss format`)
+  ),
+  validate
+];

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -9,6 +9,7 @@ import summaryRoutes from './summary.routes.js';
 import wfaRoutes from './wfa.routes.js';
 import disciplineRoutes from './discipline.routes.js';
 import analysisRoutes from './analysis.routes.js';
+import settingsRoutes from './settings.routes.js';
 
 const router = express.Router();
 
@@ -22,6 +23,7 @@ router.use('/api/bookings', bookingRoutes);
 router.use('/api/wfa', wfaRoutes);
 router.use('/api/discipline', disciplineRoutes);
 router.use('/api/analysis', analysisRoutes);
+router.use('/api/settings', settingsRoutes);
 
 // Health check
 router.get('/health', (req, res) => {

--- a/src/routes/settings.routes.js
+++ b/src/routes/settings.routes.js
@@ -1,0 +1,23 @@
+import express from 'express';
+
+import {
+  getOperationalSettings,
+  patchOperationalSettings
+} from '../controllers/settings.controller.js';
+import { verifyToken } from '../middlewares/authJwt.js';
+import roleGuard from '../middlewares/roleGuard.js';
+import { operationalSettingsPatchValidation } from '../middlewares/settings.validator.js';
+
+const router = express.Router();
+
+router.use(verifyToken);
+
+router.get('/operational', roleGuard(['Admin', 'Management']), getOperationalSettings);
+router.patch(
+  '/operational',
+  roleGuard(['Admin', 'Management']),
+  operationalSettingsPatchValidation,
+  patchOperationalSettings
+);
+
+export default router;

--- a/src/services/operationalSettings.service.js
+++ b/src/services/operationalSettings.service.js
@@ -1,0 +1,116 @@
+import { sequelize, Settings } from '../models/index.js';
+import {
+  OPERATIONAL_SETTING_FIELDS,
+  OPERATIONAL_SETTING_INTEGER_FIELDS,
+  OPERATIONAL_SETTING_KEYS,
+  OPERATIONAL_SETTING_TIME_FIELDS,
+  assertOperationalSettingsIntegrity,
+  getOperationalSettingsStoredValues,
+  getOperationalSettingsStrict,
+  normalizeOperationalSettingValue,
+  normalizeOperationalSettings,
+  serializeOperationalSettingValue
+} from '../utils/settings.js';
+
+const createValidationError = (message) => {
+  const error = new Error(message);
+  error.status = 400;
+  return error;
+};
+
+const assertValidOperationalSettingsPayload = (payload) => {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    throw createValidationError('Body must be an object');
+  }
+
+  const unknownFields = Object.keys(payload).filter((field) => !OPERATIONAL_SETTING_FIELDS.includes(field));
+  if (unknownFields.length > 0) {
+    throw createValidationError(`Unknown operational setting field: ${unknownFields[0]}`);
+  }
+
+  const providedFields = OPERATIONAL_SETTING_FIELDS.filter((field) => Object.hasOwn(payload, field));
+  if (providedFields.length === 0) {
+    throw createValidationError(
+      `At least one of these fields is required: ${OPERATIONAL_SETTING_FIELDS.join(', ')}`
+    );
+  }
+
+  for (const field of providedFields) {
+    if (normalizeOperationalSettingValue(field, payload[field]) !== null) {
+      continue;
+    }
+
+    if (OPERATIONAL_SETTING_INTEGER_FIELDS.includes(field)) {
+      throw createValidationError(`${field} must be a positive integer`);
+    }
+
+    if (OPERATIONAL_SETTING_TIME_FIELDS.includes(field)) {
+      throw createValidationError(`${field} must use HH:mm or HH:mm:ss format`);
+    }
+  }
+};
+
+const mapPayloadToCurrentState = (currentSettings, payload) => {
+  return OPERATIONAL_SETTING_FIELDS.reduce((nextSettings, field) => {
+    nextSettings[field] = Object.hasOwn(payload, field) ? payload[field] : currentSettings[field];
+    return nextSettings;
+  }, {});
+};
+
+const getProvidedOperationalSettingsFields = (payload) => {
+  return OPERATIONAL_SETTING_FIELDS.filter((field) => Object.hasOwn(payload, field));
+};
+
+export const readOperationalSettings = async () => {
+  return getOperationalSettingsStrict();
+};
+
+export const updateOperationalSettings = async (payload) => {
+  assertValidOperationalSettingsPayload(payload);
+
+  return sequelize.transaction(async (transaction) => {
+    const currentStoredSettings = await getOperationalSettingsStoredValues(transaction);
+    const providedFields = getProvidedOperationalSettingsFields(payload);
+    const currentSettings = normalizeOperationalSettings(currentStoredSettings);
+    const mergedSettings = mapPayloadToCurrentState(currentSettings, payload);
+    const normalizedSettings = normalizeOperationalSettings(mergedSettings);
+    const updatedAt = new Date();
+
+    for (const field of providedFields) {
+      const settingKey = OPERATIONAL_SETTING_KEYS[field];
+      const nextValue = serializeOperationalSettingValue(field, normalizedSettings[field]);
+      const currentStoredValue = currentStoredSettings[field];
+
+      if (nextValue === currentStoredValue) {
+        continue;
+      }
+
+      const existingSetting = await Settings.findByPk(settingKey, { transaction });
+
+      if (existingSetting) {
+        await existingSetting.update(
+          {
+            setting_value: nextValue,
+            updated_at: updatedAt
+          },
+          { transaction }
+        );
+        continue;
+      }
+
+      await Settings.create(
+        {
+          setting_key: settingKey,
+          setting_value: nextValue,
+          description: null,
+          updated_at: updatedAt
+        },
+        { transaction }
+      );
+    }
+
+    const latestStoredSettings = await getOperationalSettingsStoredValues(transaction);
+    assertOperationalSettingsIntegrity(latestStoredSettings);
+    return normalizeOperationalSettings(latestStoredSettings);
+  });
+};

--- a/src/utils/settings.js
+++ b/src/utils/settings.js
@@ -18,9 +18,28 @@ export const OPERATIONAL_SETTING_DEFAULTS = {
   defaultShiftEnd: '17:00:00'
 };
 
-const normalizeTimeOrDefault = (value, fallback) => {
+export const OPERATIONAL_SETTING_FIELDS = Object.freeze(Object.keys(OPERATIONAL_SETTING_KEYS));
+
+export const OPERATIONAL_SETTING_FIELDS_BY_DB_KEY = Object.freeze(
+  Object.fromEntries(
+    Object.entries(OPERATIONAL_SETTING_KEYS).map(([field, settingKey]) => [settingKey, field])
+  )
+);
+
+export const OPERATIONAL_SETTING_INTEGER_FIELDS = Object.freeze([
+  'geofenceRadiusDefaultM',
+  'autoCheckoutIdleMin',
+  'autoCheckoutTBufferMin',
+  'lateCheckoutToleranceMin'
+]);
+
+export const OPERATIONAL_SETTING_TIME_FIELDS = Object.freeze(['defaultShiftEnd']);
+
+export const isOperationalSettingField = (field) => OPERATIONAL_SETTING_FIELDS.includes(field);
+
+export const normalizeOperationalSettingTime = (value) => {
   if (typeof value !== 'string') {
-    return fallback;
+    return null;
   }
 
   const withSecondsMatch = value.match(/^([01]\d|2[0-3]):([0-5]\d):([0-5]\d)$/);
@@ -33,59 +52,110 @@ const normalizeTimeOrDefault = (value, fallback) => {
     return `${value}:00`;
   }
 
-  return fallback;
+  return null;
 };
 
-const toPositiveIntOrDefault = (value, fallback) => {
-  const parsed = Number.parseInt(value, 10);
-  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+export const normalizeOperationalSettingValue = (field, value) => {
+  if (OPERATIONAL_SETTING_INTEGER_FIELDS.includes(field)) {
+    const parsed =
+      typeof value === 'number'
+        ? value
+        : typeof value === 'string' && value.trim() !== ''
+          ? Number(value)
+          : Number.NaN;
+
+    return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+  }
+
+  if (OPERATIONAL_SETTING_TIME_FIELDS.includes(field)) {
+    return normalizeOperationalSettingTime(value);
+  }
+
+  return null;
+};
+
+export const serializeOperationalSettingValue = (field, value) => {
+  const normalizedValue = normalizeOperationalSettingValue(field, value);
+  return normalizedValue === null ? null : String(normalizedValue);
+};
+
+export const normalizeOperationalSettings = (settings = {}) => {
+  return OPERATIONAL_SETTING_FIELDS.reduce((normalizedSettings, field) => {
+    const normalizedValue = normalizeOperationalSettingValue(field, settings[field]);
+
+    normalizedSettings[field] = normalizedValue ?? OPERATIONAL_SETTING_DEFAULTS[field];
+    return normalizedSettings;
+  }, {});
+};
+
+export const getOperationalSettingsIntegrityIssues = (settings = {}) => {
+  return OPERATIONAL_SETTING_FIELDS.reduce((issues, field) => {
+    if (!Object.hasOwn(settings, field)) {
+      issues.push({ field, issue: 'missing' });
+      return issues;
+    }
+
+    if (normalizeOperationalSettingValue(field, settings[field]) !== null) {
+      return issues;
+    }
+
+    issues.push({ field, issue: 'invalid', value: settings[field] });
+    return issues;
+  }, []);
+};
+
+export const createOperationalSettingsIntegrityError = (issues) => {
+  const error = new Error(
+    `Operational settings are incomplete or invalid: ${issues.map(({ field, issue }) => `${field} (${issue})`).join(', ')}`
+  );
+  error.status = 500;
+  error.code = 'E_OPERATIONAL_SETTINGS_INVALID';
+  error.details = issues;
+  return error;
+};
+
+export const assertOperationalSettingsIntegrity = (settings = {}) => {
+  const issues = getOperationalSettingsIntegrityIssues(settings);
+
+  if (issues.length > 0) {
+    throw createOperationalSettingsIntegrityError(issues);
+  }
+};
+
+const mapOperationalSettingsRowsToStoredValues = (settings = []) => {
+  return settings.reduce((result, setting) => {
+    const field = OPERATIONAL_SETTING_FIELDS_BY_DB_KEY[setting.setting_key];
+
+    if (field) {
+      result[field] = setting.setting_value;
+    }
+
+    return result;
+  }, {});
+};
+
+export const getOperationalSettingsStoredValues = async (transaction = null) => {
+  const settings = await Settings.findAll({
+    where: {
+      setting_key: {
+        [Op.in]: Object.values(OPERATIONAL_SETTING_KEYS)
+      }
+    },
+    transaction
+  });
+
+  return mapOperationalSettingsRowsToStoredValues(settings);
 };
 
 export const getOperationalSettings = async (transaction = null) => {
-  try {
-    const keys = Object.values(OPERATIONAL_SETTING_KEYS);
+  const settingsByField = await getOperationalSettingsStoredValues(transaction);
+  return normalizeOperationalSettings(settingsByField);
+};
 
-    const settings = await Settings.findAll({
-      where: {
-        setting_key: {
-          [Op.in]: keys
-        }
-      },
-      transaction
-    });
-
-    const settingsMap = {};
-    settings.forEach((setting) => {
-      settingsMap[setting.setting_key] = setting.setting_value;
-    });
-
-    const defaultShiftEnd = settingsMap[OPERATIONAL_SETTING_KEYS.defaultShiftEnd];
-
-    return {
-      geofenceRadiusDefaultM: toPositiveIntOrDefault(
-        settingsMap[OPERATIONAL_SETTING_KEYS.geofenceRadiusDefaultM],
-        OPERATIONAL_SETTING_DEFAULTS.geofenceRadiusDefaultM
-      ),
-      autoCheckoutIdleMin: toPositiveIntOrDefault(
-        settingsMap[OPERATIONAL_SETTING_KEYS.autoCheckoutIdleMin],
-        OPERATIONAL_SETTING_DEFAULTS.autoCheckoutIdleMin
-      ),
-      autoCheckoutTBufferMin: toPositiveIntOrDefault(
-        settingsMap[OPERATIONAL_SETTING_KEYS.autoCheckoutTBufferMin],
-        OPERATIONAL_SETTING_DEFAULTS.autoCheckoutTBufferMin
-      ),
-      lateCheckoutToleranceMin: toPositiveIntOrDefault(
-        settingsMap[OPERATIONAL_SETTING_KEYS.lateCheckoutToleranceMin],
-        OPERATIONAL_SETTING_DEFAULTS.lateCheckoutToleranceMin
-      ),
-      defaultShiftEnd: normalizeTimeOrDefault(
-        defaultShiftEnd,
-        OPERATIONAL_SETTING_DEFAULTS.defaultShiftEnd
-      )
-    };
-  } catch (error) {
-    throw new Error(`Failed to get operational settings: ${error.message}`);
-  }
+export const getOperationalSettingsStrict = async (transaction = null) => {
+  const settingsByField = await getOperationalSettingsStoredValues(transaction);
+  assertOperationalSettingsIntegrity(settingsByField);
+  return normalizeOperationalSettings(settingsByField);
 };
 
 /**
@@ -95,46 +165,42 @@ export const getOperationalSettings = async (transaction = null) => {
  * @returns {Object} Settings object with key-value pairs
  */
 export const getAttendanceSettings = async (settingKeys = [], transaction = null) => {
-  try {
-    // Default setting keys if none provided
-    const defaultKeys = [
-      'attendance.checkin.start_time',
-      'attendance.checkin.end_time',
-      'attendance.checkin.late_time',
-      'workday.holiday_checkin_enabled',
-      'workday.weekend_checkin_enabled',
-      'workday.holiday_region'
-    ];
+  // Default setting keys if none provided
+  const defaultKeys = [
+    'attendance.checkin.start_time',
+    'attendance.checkin.end_time',
+    'attendance.checkin.late_time',
+    'workday.holiday_checkin_enabled',
+    'workday.weekend_checkin_enabled',
+    'workday.holiday_region'
+  ];
 
-    const keysToFetch = settingKeys.length > 0 ? settingKeys : defaultKeys;
+  const keysToFetch = settingKeys.length > 0 ? settingKeys : defaultKeys;
 
-    const settings = await Settings.findAll({
-      where: {
-        setting_key: {
-          [Op.in]: keysToFetch
-        }
-      },
-      transaction
-    });
+  const settings = await Settings.findAll({
+    where: {
+      setting_key: {
+        [Op.in]: keysToFetch
+      }
+    },
+    transaction
+  });
 
-    // Convert settings array to object for easy access
-    const settingsMap = {};
-    settings.forEach((setting) => {
-      settingsMap[setting.setting_key] = setting.setting_value;
-    });
+  // Convert settings array to object for easy access
+  const settingsMap = {};
+  settings.forEach((setting) => {
+    settingsMap[setting.setting_key] = setting.setting_value;
+  });
 
-    // Set default values if settings not found
-    return {
-      checkinStartTime: settingsMap['attendance.checkin.start_time'] || '08:00:00',
-      checkinEndTime: settingsMap['attendance.checkin.end_time'] || '18:00:00',
-      checkinLateTime: settingsMap['attendance.checkin.late_time'] || '09:00:00',
-      holidayCheckinEnabled: settingsMap['workday.holiday_checkin_enabled'] === 'true',
-      weekendCheckinEnabled: settingsMap['workday.weekend_checkin_enabled'] === 'true',
-      holidayRegion: settingsMap['workday.holiday_region'] || 'ID'
-    };
-  } catch (error) {
-    throw new Error(`Failed to get attendance settings: ${error.message}`);
-  }
+  // Set default values if settings not found
+  return {
+    checkinStartTime: settingsMap['attendance.checkin.start_time'] || '08:00:00',
+    checkinEndTime: settingsMap['attendance.checkin.end_time'] || '18:00:00',
+    checkinLateTime: settingsMap['attendance.checkin.late_time'] || '09:00:00',
+    holidayCheckinEnabled: settingsMap['workday.holiday_checkin_enabled'] === 'true',
+    weekendCheckinEnabled: settingsMap['workday.weekend_checkin_enabled'] === 'true',
+    holidayRegion: settingsMap['workday.holiday_region'] || 'ID'
+  };
 };
 
 /**

--- a/tests/errorHandler.test.js
+++ b/tests/errorHandler.test.js
@@ -1,0 +1,98 @@
+import { jest } from '@jest/globals';
+
+const mockLoggerError = jest.fn();
+
+jest.unstable_mockModule('../src/utils/logger.js', () => ({
+  __esModule: true,
+  default: {
+    error: mockLoggerError
+  }
+}));
+
+jest.unstable_mockModule('../src/config/index.js', () => ({
+  __esModule: true,
+  default: {
+    env: 'test'
+  }
+}));
+
+const { errorHandler } = await import('../src/middlewares/errorHandler.js');
+
+const createResponse = () => {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+describe('errorHandler middleware', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does not log arbitrary details arrays for non-operational-settings errors', () => {
+    const err = Object.assign(new Error('Unexpected downstream failure'), {
+      status: 500,
+      code: 'E_INTERNAL_TEST',
+      details: [{ internal: 'should-not-log' }],
+      stack: 'stack-trace'
+    });
+    const req = {
+      path: '/api/settings/operational',
+      method: 'GET',
+      ip: '127.0.0.1'
+    };
+    const res = createResponse();
+
+    errorHandler(err, req, res, jest.fn());
+
+    expect(mockLoggerError).toHaveBeenCalledWith({
+      message: 'Unexpected downstream failure',
+      code: 'E_INTERNAL_TEST',
+      stack: 'stack-trace',
+      path: '/api/settings/operational',
+      method: 'GET',
+      ip: '127.0.0.1'
+    });
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Unexpected downstream failure'
+    });
+  });
+
+  it('keeps operational settings integrity details in logs and responses', () => {
+    const details = [{ field: 'geofenceRadiusDefaultM', issue: 'missing' }];
+    const err = Object.assign(new Error('Operational settings are incomplete or invalid: geofenceRadiusDefaultM (missing)'), {
+      status: 500,
+      code: 'E_OPERATIONAL_SETTINGS_INVALID',
+      details,
+      stack: 'stack-trace'
+    });
+    const req = {
+      path: '/api/settings/operational',
+      method: 'GET',
+      ip: '127.0.0.1'
+    };
+    const res = createResponse();
+
+    errorHandler(err, req, res, jest.fn());
+
+    expect(mockLoggerError).toHaveBeenCalledWith({
+      message: 'Operational settings are incomplete or invalid: geofenceRadiusDefaultM (missing)',
+      code: 'E_OPERATIONAL_SETTINGS_INVALID',
+      details,
+      stack: 'stack-trace',
+      path: '/api/settings/operational',
+      method: 'GET',
+      ip: '127.0.0.1'
+    });
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Operational settings are incomplete or invalid: geofenceRadiusDefaultM (missing)',
+      code: 'E_OPERATIONAL_SETTINGS_INVALID',
+      details
+    });
+  });
+});

--- a/tests/operationalSettings.test.js
+++ b/tests/operationalSettings.test.js
@@ -1,20 +1,43 @@
 import { jest } from '@jest/globals';
 
 const mockSettingsFindAll = jest.fn();
+const mockSettingsFindByPk = jest.fn();
+const mockSettingsCreate = jest.fn();
+const mockTransaction = jest.fn();
 
 jest.unstable_mockModule('../src/models/index.js', () => ({
-  Settings: { findAll: mockSettingsFindAll }
+  Settings: {
+    findAll: mockSettingsFindAll,
+    findByPk: mockSettingsFindByPk,
+    create: mockSettingsCreate
+  },
+  sequelize: {
+    transaction: mockTransaction
+  }
 }));
 
 const {
   OPERATIONAL_SETTING_KEYS,
   OPERATIONAL_SETTING_DEFAULTS,
-  getOperationalSettings
+  OPERATIONAL_SETTING_FIELDS,
+  OPERATIONAL_SETTING_INTEGER_FIELDS,
+  OPERATIONAL_SETTING_TIME_FIELDS,
+  normalizeOperationalSettingTime,
+  normalizeOperationalSettingValue,
+  normalizeOperationalSettings,
+  serializeOperationalSettingValue,
+  getOperationalSettings,
+  getOperationalSettingsStrict,
+  getAttendanceSettings
 } = await import('../src/utils/settings.js');
+const { updateOperationalSettings } = await import('../src/services/operationalSettings.service.js');
 
 describe('operational settings accessor', () => {
   beforeEach(() => {
     mockSettingsFindAll.mockReset();
+    mockSettingsFindByPk.mockReset();
+    mockSettingsCreate.mockReset();
+    mockTransaction.mockReset();
   });
 
   it('fetches operational settings in one DB query and returns typed values', async () => {
@@ -70,6 +93,41 @@ describe('operational settings accessor', () => {
     expect(settings.defaultShiftEnd).toBe('18:30:00');
   });
 
+  it('fails strict reads when an approved operational setting row is missing or invalid', async () => {
+    mockSettingsFindAll.mockResolvedValueOnce([
+      { setting_key: 'attendance.auto_checkout.idle_min', setting_value: '10' },
+      { setting_key: 'attendance.auto_checkout.tbuffer_min', setting_value: '30' },
+      { setting_key: 'attendance.auto_checkout.late_tolerance_min', setting_value: 'invalid' },
+      { setting_key: 'checkout.fallback_time', setting_value: '17:00:00' }
+    ]);
+
+    await expect(getOperationalSettingsStrict()).rejects.toMatchObject({
+      message: expect.stringContaining('Operational settings are incomplete or invalid'),
+      status: 500,
+      code: 'E_OPERATIONAL_SETTINGS_INVALID',
+      details: expect.arrayContaining([
+        expect.objectContaining({ field: 'geofenceRadiusDefaultM', issue: 'missing' }),
+        expect.objectContaining({ field: 'lateCheckoutToleranceMin', issue: 'invalid' })
+      ])
+    });
+  });
+
+  it('keeps permissive reads for legacy consumers when settings rows are incomplete', async () => {
+    mockSettingsFindAll.mockResolvedValueOnce([
+      { setting_key: 'attendance.auto_checkout.idle_min', setting_value: '10' },
+      { setting_key: 'attendance.auto_checkout.late_tolerance_min', setting_value: 'invalid' },
+      { setting_key: 'checkout.fallback_time', setting_value: '17:00:00' }
+    ]);
+
+    await expect(getOperationalSettings()).resolves.toEqual({
+      geofenceRadiusDefaultM: 100,
+      autoCheckoutIdleMin: 10,
+      autoCheckoutTBufferMin: 30,
+      lateCheckoutToleranceMin: 15,
+      defaultShiftEnd: '17:00:00'
+    });
+  });
+
   it('exports stable DB keys and defaults for consumers', () => {
     expect(OPERATIONAL_SETTING_KEYS).toEqual({
       geofenceRadiusDefaultM: 'attendance.geofence.radius_default_m',
@@ -86,5 +144,249 @@ describe('operational settings accessor', () => {
       lateCheckoutToleranceMin: 15,
       defaultShiftEnd: '17:00:00'
     });
+
+    expect(OPERATIONAL_SETTING_FIELDS).toEqual([
+      'geofenceRadiusDefaultM',
+      'autoCheckoutIdleMin',
+      'autoCheckoutTBufferMin',
+      'lateCheckoutToleranceMin',
+      'defaultShiftEnd'
+    ]);
+    expect(OPERATIONAL_SETTING_INTEGER_FIELDS).toEqual([
+      'geofenceRadiusDefaultM',
+      'autoCheckoutIdleMin',
+      'autoCheckoutTBufferMin',
+      'lateCheckoutToleranceMin'
+    ]);
+    expect(OPERATIONAL_SETTING_TIME_FIELDS).toEqual(['defaultShiftEnd']);
+  });
+
+  it('normalizes and serializes operational setting values consistently', () => {
+    expect(normalizeOperationalSettingTime('18:00')).toBe('18:00:00');
+    expect(normalizeOperationalSettingTime('18:00:30')).toBe('18:00:30');
+    expect(normalizeOperationalSettingTime('18')).toBeNull();
+
+    expect(normalizeOperationalSettingValue('geofenceRadiusDefaultM', '120')).toBe(120);
+    expect(normalizeOperationalSettingValue('geofenceRadiusDefaultM', 0)).toBeNull();
+    expect(normalizeOperationalSettingValue('defaultShiftEnd', '19:15')).toBe('19:15:00');
+    expect(normalizeOperationalSettingValue('defaultShiftEnd', '19:15:30')).toBe('19:15:30');
+    expect(normalizeOperationalSettingValue('defaultShiftEnd', '19')).toBeNull();
+
+    expect(serializeOperationalSettingValue('autoCheckoutIdleMin', 12)).toBe('12');
+    expect(serializeOperationalSettingValue('defaultShiftEnd', '19:15')).toBe('19:15:00');
+    expect(serializeOperationalSettingValue('defaultShiftEnd', '19')).toBeNull();
+  });
+
+  it('fills defaults when normalizing partial operational settings objects', () => {
+    expect(
+      normalizeOperationalSettings({
+        autoCheckoutIdleMin: '22',
+        defaultShiftEnd: '19:30'
+      })
+    ).toEqual({
+      geofenceRadiusDefaultM: 100,
+      autoCheckoutIdleMin: 22,
+      autoCheckoutTBufferMin: 30,
+      lateCheckoutToleranceMin: 15,
+      defaultShiftEnd: '19:30:00'
+    });
+  });
+
+  it('rejects invalid payloads at the service boundary before starting a transaction', async () => {
+    await expect(updateOperationalSettings({ unknownField: 1 })).rejects.toMatchObject({
+      message: 'Unknown operational setting field: unknownField',
+      status: 400
+    });
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+
+  it('only persists fields explicitly provided in the patch payload', async () => {
+    const transaction = {};
+    const existingGeofenceSetting = { update: jest.fn().mockResolvedValue(undefined) };
+    const existingIdleSetting = { update: jest.fn().mockResolvedValue(undefined) };
+    const existingBufferSetting = { update: jest.fn().mockResolvedValue(undefined) };
+    const existingLateToleranceSetting = { update: jest.fn().mockResolvedValue(undefined) };
+    const existingShiftEndSetting = { update: jest.fn().mockResolvedValue(undefined) };
+
+    mockTransaction.mockImplementation(async (callback) => callback(transaction));
+    mockSettingsFindAll
+      .mockResolvedValueOnce([
+        { setting_key: 'attendance.geofence.radius_default_m', setting_value: 'not-a-number' },
+        { setting_key: 'attendance.auto_checkout.idle_min', setting_value: '10' },
+        { setting_key: 'attendance.auto_checkout.tbuffer_min', setting_value: '30' },
+        { setting_key: 'attendance.auto_checkout.late_tolerance_min', setting_value: '15' },
+        { setting_key: 'checkout.fallback_time', setting_value: '17:00:00' }
+      ])
+      .mockResolvedValueOnce([
+        { setting_key: 'attendance.geofence.radius_default_m', setting_value: 'not-a-number' },
+        { setting_key: 'attendance.auto_checkout.idle_min', setting_value: '12' },
+        { setting_key: 'attendance.auto_checkout.tbuffer_min', setting_value: '30' },
+        { setting_key: 'attendance.auto_checkout.late_tolerance_min', setting_value: '15' },
+        { setting_key: 'checkout.fallback_time', setting_value: '17:00:00' }
+      ]);
+
+    mockSettingsFindByPk.mockImplementation(async (settingKey) => {
+      switch (settingKey) {
+        case OPERATIONAL_SETTING_KEYS.geofenceRadiusDefaultM:
+          return existingGeofenceSetting;
+        case OPERATIONAL_SETTING_KEYS.autoCheckoutIdleMin:
+          return existingIdleSetting;
+        case OPERATIONAL_SETTING_KEYS.autoCheckoutTBufferMin:
+          return existingBufferSetting;
+        case OPERATIONAL_SETTING_KEYS.lateCheckoutToleranceMin:
+          return existingLateToleranceSetting;
+        case OPERATIONAL_SETTING_KEYS.defaultShiftEnd:
+          return existingShiftEndSetting;
+        default:
+          return null;
+      }
+    });
+
+    await expect(updateOperationalSettings({ autoCheckoutIdleMin: 12 })).rejects.toMatchObject({
+      message: expect.stringContaining('Operational settings are incomplete or invalid'),
+      status: 500,
+      code: 'E_OPERATIONAL_SETTINGS_INVALID',
+      details: expect.arrayContaining([
+        expect.objectContaining({ field: 'geofenceRadiusDefaultM', issue: 'invalid' })
+      ])
+    });
+
+    expect(existingGeofenceSetting.update).not.toHaveBeenCalled();
+    expect(existingIdleSetting.update).toHaveBeenCalledWith(
+      expect.objectContaining({ setting_value: '12' }),
+      expect.objectContaining({ transaction })
+    );
+    expect(existingBufferSetting.update).not.toHaveBeenCalled();
+    expect(existingLateToleranceSetting.update).not.toHaveBeenCalled();
+    expect(existingShiftEndSetting.update).not.toHaveBeenCalled();
+    expect(mockSettingsCreate).not.toHaveBeenCalled();
+  });
+
+  it('returns the latest full typed state when the post-update settings are fully valid', async () => {
+    const transaction = {};
+    const existingIdleSetting = { update: jest.fn().mockResolvedValue(undefined) };
+
+    mockTransaction.mockImplementation(async (callback) => callback(transaction));
+    mockSettingsFindAll
+      .mockResolvedValueOnce([
+        { setting_key: 'attendance.geofence.radius_default_m', setting_value: '100' },
+        { setting_key: 'attendance.auto_checkout.idle_min', setting_value: '10' },
+        { setting_key: 'attendance.auto_checkout.tbuffer_min', setting_value: '30' },
+        { setting_key: 'attendance.auto_checkout.late_tolerance_min', setting_value: '15' },
+        { setting_key: 'checkout.fallback_time', setting_value: '17:00:00' }
+      ])
+      .mockResolvedValueOnce([
+        { setting_key: 'attendance.geofence.radius_default_m', setting_value: '100' },
+        { setting_key: 'attendance.auto_checkout.idle_min', setting_value: '12' },
+        { setting_key: 'attendance.auto_checkout.tbuffer_min', setting_value: '30' },
+        { setting_key: 'attendance.auto_checkout.late_tolerance_min', setting_value: '15' },
+        { setting_key: 'checkout.fallback_time', setting_value: '17:00:00' }
+      ]);
+
+    mockSettingsFindByPk.mockImplementation(async (settingKey) => {
+      if (settingKey === OPERATIONAL_SETTING_KEYS.autoCheckoutIdleMin) {
+        return existingIdleSetting;
+      }
+
+      return null;
+    });
+
+    await expect(updateOperationalSettings({ autoCheckoutIdleMin: 12 })).resolves.toEqual({
+      geofenceRadiusDefaultM: 100,
+      autoCheckoutIdleMin: 12,
+      autoCheckoutTBufferMin: 30,
+      lateCheckoutToleranceMin: 15,
+      defaultShiftEnd: '17:00:00'
+    });
+
+    expect(existingIdleSetting.update).toHaveBeenCalledWith(
+      expect.objectContaining({ setting_value: '12' }),
+      expect.objectContaining({ transaction })
+    );
+  });
+
+  it('creates a missing approved setting row when that field is explicitly patched', async () => {
+    const transaction = {};
+
+    mockTransaction.mockImplementation(async (callback) => callback(transaction));
+    mockSettingsFindAll
+      .mockResolvedValueOnce([
+        { setting_key: 'attendance.geofence.radius_default_m', setting_value: '100' },
+        { setting_key: 'attendance.auto_checkout.idle_min', setting_value: '10' },
+        { setting_key: 'attendance.auto_checkout.tbuffer_min', setting_value: '30' },
+        { setting_key: 'attendance.auto_checkout.late_tolerance_min', setting_value: '15' }
+      ])
+      .mockResolvedValueOnce([
+        { setting_key: 'attendance.geofence.radius_default_m', setting_value: '100' },
+        { setting_key: 'attendance.auto_checkout.idle_min', setting_value: '10' },
+        { setting_key: 'attendance.auto_checkout.tbuffer_min', setting_value: '30' },
+        { setting_key: 'attendance.auto_checkout.late_tolerance_min', setting_value: '15' },
+        { setting_key: 'checkout.fallback_time', setting_value: '18:00:00' }
+      ]);
+
+    mockSettingsFindByPk.mockResolvedValueOnce(null);
+    mockSettingsCreate.mockResolvedValueOnce(undefined);
+
+    await expect(updateOperationalSettings({ defaultShiftEnd: '18:00' })).resolves.toEqual({
+      geofenceRadiusDefaultM: 100,
+      autoCheckoutIdleMin: 10,
+      autoCheckoutTBufferMin: 30,
+      lateCheckoutToleranceMin: 15,
+      defaultShiftEnd: '18:00:00'
+    });
+
+    expect(mockSettingsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        setting_key: OPERATIONAL_SETTING_KEYS.defaultShiftEnd,
+        setting_value: '18:00:00',
+        description: null
+      }),
+      expect.objectContaining({ transaction })
+    );
+  });
+
+  it('skips writes when an explicitly patched payload does not change stored values', async () => {
+    const transaction = {};
+
+    mockTransaction.mockImplementation(async (callback) => callback(transaction));
+    mockSettingsFindAll
+      .mockResolvedValueOnce([
+        { setting_key: 'attendance.geofence.radius_default_m', setting_value: '100' },
+        { setting_key: 'attendance.auto_checkout.idle_min', setting_value: '10' },
+        { setting_key: 'attendance.auto_checkout.tbuffer_min', setting_value: '30' },
+        { setting_key: 'attendance.auto_checkout.late_tolerance_min', setting_value: '15' },
+        { setting_key: 'checkout.fallback_time', setting_value: '17:00:00' }
+      ])
+      .mockResolvedValueOnce([
+        { setting_key: 'attendance.geofence.radius_default_m', setting_value: '100' },
+        { setting_key: 'attendance.auto_checkout.idle_min', setting_value: '10' },
+        { setting_key: 'attendance.auto_checkout.tbuffer_min', setting_value: '30' },
+        { setting_key: 'attendance.auto_checkout.late_tolerance_min', setting_value: '15' },
+        { setting_key: 'checkout.fallback_time', setting_value: '17:00:00' }
+      ]);
+
+    await expect(
+      updateOperationalSettings({ autoCheckoutIdleMin: 10, defaultShiftEnd: '17:00:00' })
+    ).resolves.toEqual({
+      geofenceRadiusDefaultM: 100,
+      autoCheckoutIdleMin: 10,
+      autoCheckoutTBufferMin: 30,
+      lateCheckoutToleranceMin: 15,
+      defaultShiftEnd: '17:00:00'
+    });
+
+    expect(mockSettingsFindByPk).not.toHaveBeenCalled();
+    expect(mockSettingsCreate).not.toHaveBeenCalled();
+  });
+
+  it('preserves the original attendance settings error instead of wrapping it', async () => {
+    const dbError = Object.assign(new Error('database unavailable'), {
+      code: 'E_DB_DOWN',
+      status: 503
+    });
+
+    mockSettingsFindAll.mockRejectedValueOnce(dbError);
+
+    await expect(getAttendanceSettings()).rejects.toBe(dbError);
   });
 });

--- a/tests/roleGuard.test.js
+++ b/tests/roleGuard.test.js
@@ -1,0 +1,102 @@
+import { jest } from '@jest/globals';
+
+const mockLoggerWarn = jest.fn();
+const mockLoggerInfo = jest.fn();
+
+jest.unstable_mockModule('../src/utils/logger.js', () => ({
+  __esModule: true,
+  default: {
+    warn: mockLoggerWarn,
+    info: mockLoggerInfo
+  }
+}));
+
+const { default: roleGuard } = await import('../src/middlewares/roleGuard.js');
+
+const createResponse = () => {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+describe('roleGuard middleware', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 401 when req.user is missing', () => {
+    const req = {};
+    const res = createResponse();
+    const next = jest.fn();
+
+    roleGuard(['Admin'])(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      code: 'E_UNAUTHORIZED',
+      message: 'Unauthorized: No user data'
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('allows access when role_name matches an allowed role', () => {
+    const req = { user: { role_name: 'Admin' } };
+    const res = createResponse();
+    const next = jest.fn();
+
+    roleGuard(['Admin', 'Management'])(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+    expect(mockLoggerInfo).toHaveBeenCalledWith('Role check passed - User role: Admin');
+  });
+
+  it('allows access when nested role.name matches an allowed role', () => {
+    const req = { user: { role: { name: 'Management' } } };
+    const res = createResponse();
+    const next = jest.fn();
+
+    roleGuard(['Admin', 'Management'])(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+    expect(mockLoggerInfo).toHaveBeenCalledWith('Role check passed - User role: Management');
+  });
+
+  it('returns 403 with stable contract when user role is not allowed', () => {
+    const req = { user: { role_name: 'User' } };
+    const res = createResponse();
+    const next = jest.fn();
+
+    roleGuard(['Admin', 'Management'])(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      code: 'E_FORBIDDEN',
+      message: 'Forbidden: Insufficient role'
+    });
+    expect(next).not.toHaveBeenCalled();
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      'Role check failed - User role: "User", Required: Admin, Management'
+    );
+  });
+
+  it('returns 403 when no supported role field is present', () => {
+    const req = { user: { id: 1 } };
+    const res = createResponse();
+    const next = jest.fn();
+
+    roleGuard(['Admin'])(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      code: 'E_FORBIDDEN',
+      message: 'Forbidden: Insufficient role'
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/tests/settingsOperationalRoutesContract.test.js
+++ b/tests/settingsOperationalRoutesContract.test.js
@@ -1,0 +1,335 @@
+import express from 'express';
+import { jest } from '@jest/globals';
+import request from 'supertest';
+
+const mockVerifyToken = jest.fn((req, _res, next) => {
+  req.user = { id: 1, role_name: 'Admin' };
+  next();
+});
+
+let currentRole = 'Admin';
+const mockRoleGuard = (allowedRoles) => (req, res, next) => {
+  req.user = { ...(req.user || {}), role_name: currentRole };
+
+  if (!allowedRoles.includes(currentRole)) {
+    return res.status(403).json({
+      success: false,
+      code: 'E_FORBIDDEN',
+      message: 'Forbidden: Insufficient role'
+    });
+  }
+
+  next();
+};
+
+const mockReadOperationalSettings = jest.fn();
+const mockUpdateOperationalSettings = jest.fn();
+
+jest.unstable_mockModule('../src/services/operationalSettings.service.js', () => ({
+  readOperationalSettings: mockReadOperationalSettings,
+  updateOperationalSettings: mockUpdateOperationalSettings
+}));
+
+jest.unstable_mockModule('../src/middlewares/authJwt.js', () => ({
+  verifyToken: mockVerifyToken
+}));
+
+jest.unstable_mockModule('../src/middlewares/roleGuard.js', () => ({
+  __esModule: true,
+  default: mockRoleGuard
+}));
+
+const { default: settingsRoutes } = await import('../src/routes/settings.routes.js');
+const { default: mainRoutes } = await import('../src/routes/index.js');
+const { errorHandler } = await import('../src/middlewares/errorHandler.js');
+
+const scopedApp = express();
+scopedApp.use(express.json());
+scopedApp.use('/api/settings', settingsRoutes);
+scopedApp.use(errorHandler);
+
+const mainApp = express();
+mainApp.use(express.json());
+mainApp.use(mainRoutes);
+mainApp.use(errorHandler);
+
+const buildOperationalSettings = (overrides = {}) => ({
+  geofenceRadiusDefaultM: 100,
+  autoCheckoutIdleMin: 10,
+  autoCheckoutTBufferMin: 30,
+  lateCheckoutToleranceMin: 15,
+  defaultShiftEnd: '17:00:00',
+  ...overrides
+});
+
+describe('settings operational routes contract', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    currentRole = 'Admin';
+
+    mockReadOperationalSettings.mockResolvedValue(buildOperationalSettings());
+    mockUpdateOperationalSettings.mockResolvedValue(buildOperationalSettings());
+  });
+
+  it('allows admin to read operational settings as a raw typed object', async () => {
+    const res = await request(scopedApp).get('/api/settings/operational');
+
+    expect(res.status).toBe(200);
+    expect(mockVerifyToken).toHaveBeenCalled();
+    expect(mockReadOperationalSettings).toHaveBeenCalledTimes(1);
+    expect(res.body).toEqual(buildOperationalSettings());
+    expect(res.body.success).toBeUndefined();
+    expect(res.body.data).toBeUndefined();
+    expect(res.body.AHP_CR_THRESHOLD).toBeUndefined();
+  });
+
+  it('allows management to read operational settings', async () => {
+    currentRole = 'Management';
+
+    const res = await request(scopedApp).get('/api/settings/operational');
+
+    expect(res.status).toBe(200);
+    expect(mockReadOperationalSettings).toHaveBeenCalledTimes(1);
+    expect(res.body).toEqual(buildOperationalSettings());
+  });
+
+  it('allows admin to partially update operational settings and returns latest full state', async () => {
+    mockUpdateOperationalSettings.mockResolvedValue(
+      buildOperationalSettings({
+        autoCheckoutIdleMin: 12,
+        defaultShiftEnd: '18:00:00'
+      })
+    );
+
+    const payload = {
+      autoCheckoutIdleMin: 12,
+      defaultShiftEnd: '18:00'
+    };
+
+    const res = await request(scopedApp).patch('/api/settings/operational').send(payload);
+
+    expect(res.status).toBe(200);
+    expect(mockUpdateOperationalSettings).toHaveBeenCalledWith(payload);
+    expect(res.body).toEqual(
+      buildOperationalSettings({
+        autoCheckoutIdleMin: 12,
+        defaultShiftEnd: '18:00:00'
+      })
+    );
+  });
+
+  it('allows admin to send a no-op patch and still returns the latest full state', async () => {
+    const payload = {
+      autoCheckoutIdleMin: 10,
+      defaultShiftEnd: '17:00:00'
+    };
+
+    const res = await request(scopedApp).patch('/api/settings/operational').send(payload);
+
+    expect(res.status).toBe(200);
+    expect(mockUpdateOperationalSettings).toHaveBeenCalledWith(payload);
+    expect(res.body).toEqual(buildOperationalSettings());
+  });
+
+  it('allows management to partially update operational settings', async () => {
+    currentRole = 'Management';
+    mockUpdateOperationalSettings.mockResolvedValue(
+      buildOperationalSettings({
+        geofenceRadiusDefaultM: 150
+      })
+    );
+
+    const res = await request(scopedApp)
+      .patch('/api/settings/operational')
+      .send({ geofenceRadiusDefaultM: 150 });
+
+    expect(res.status).toBe(200);
+    expect(mockUpdateOperationalSettings).toHaveBeenCalledWith({ geofenceRadiusDefaultM: 150 });
+    expect(res.body).toEqual(
+      buildOperationalSettings({
+        geofenceRadiusDefaultM: 150
+      })
+    );
+  });
+
+  it('returns 401 when authentication fails before the handler', async () => {
+    mockVerifyToken.mockImplementationOnce((_req, res, _next) => {
+      res.status(401).json({ message: 'Invalid token' });
+    });
+
+    const res = await request(scopedApp).get('/api/settings/operational');
+
+    expect(res.status).toBe(401);
+    expect(mockReadOperationalSettings).not.toHaveBeenCalled();
+    expect(res.body).toEqual({ message: 'Invalid token' });
+  });
+
+  it('returns 403 for callers outside Admin and Management', async () => {
+    currentRole = 'User';
+
+    const res = await request(scopedApp).get('/api/settings/operational');
+
+    expect(res.status).toBe(403);
+    expect(mockReadOperationalSettings).not.toHaveBeenCalled();
+    expect(res.body.success).toBe(false);
+    expect(res.body.code).toBe('E_FORBIDDEN');
+  });
+
+  it('rejects empty patch body with validation error shape', async () => {
+    const res = await request(scopedApp).patch('/api/settings/operational').send({});
+
+    expect(res.status).toBe(400);
+    expect(mockUpdateOperationalSettings).not.toHaveBeenCalled();
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        success: false,
+        code: 'E_VALIDATION',
+        message: expect.stringContaining('At least one of these fields is required'),
+        errors: expect.any(Array)
+      })
+    );
+  });
+
+  it('rejects non-object patch bodies', async () => {
+    const res = await request(scopedApp).patch('/api/settings/operational').send([]);
+
+    expect(res.status).toBe(400);
+    expect(mockUpdateOperationalSettings).not.toHaveBeenCalled();
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        success: false,
+        code: 'E_VALIDATION',
+        message: 'Body must be an object',
+        errors: expect.any(Array)
+      })
+    );
+  });
+
+  it('rejects unknown patch fields', async () => {
+    const res = await request(scopedApp)
+      .patch('/api/settings/operational')
+      .send({ ahpCrThreshold: 0.2 });
+
+    expect(res.status).toBe(400);
+    expect(mockUpdateOperationalSettings).not.toHaveBeenCalled();
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        success: false,
+        code: 'E_VALIDATION',
+        message: 'Unknown operational setting field: ahpCrThreshold',
+        errors: expect.any(Array)
+      })
+    );
+  });
+
+  it('rejects invalid numeric patch values', async () => {
+    const res = await request(scopedApp)
+      .patch('/api/settings/operational')
+      .send({ autoCheckoutIdleMin: 0 });
+
+    expect(res.status).toBe(400);
+    expect(mockUpdateOperationalSettings).not.toHaveBeenCalled();
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        success: false,
+        code: 'E_VALIDATION',
+        message: 'autoCheckoutIdleMin must be a positive integer',
+        errors: expect.any(Array)
+      })
+    );
+  });
+
+  it('rejects invalid time patch values', async () => {
+    const res = await request(scopedApp)
+      .patch('/api/settings/operational')
+      .send({ defaultShiftEnd: '6pm' });
+
+    expect(res.status).toBe(400);
+    expect(mockUpdateOperationalSettings).not.toHaveBeenCalled();
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        success: false,
+        code: 'E_VALIDATION',
+        message: 'defaultShiftEnd must use HH:mm or HH:mm:ss format',
+        errors: expect.any(Array)
+      })
+    );
+  });
+
+  it('returns 500 when the stored operational settings state is incomplete or invalid', async () => {
+    mockReadOperationalSettings.mockRejectedValueOnce(
+      Object.assign(new Error('Operational settings are incomplete or invalid: geofenceRadiusDefaultM (missing)'), {
+        status: 500,
+        code: 'E_OPERATIONAL_SETTINGS_INVALID',
+        details: [{ field: 'geofenceRadiusDefaultM', issue: 'missing' }]
+      })
+    );
+
+    const res = await request(scopedApp).get('/api/settings/operational');
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        success: false,
+        code: 'E_OPERATIONAL_SETTINGS_INVALID',
+        message: 'Operational settings are incomplete or invalid: geofenceRadiusDefaultM (missing)',
+        details: [{ field: 'geofenceRadiusDefaultM', issue: 'missing' }]
+      })
+    );
+  });
+
+  it('returns 500 when a patch leaves the full stored operational settings state invalid', async () => {
+    mockUpdateOperationalSettings.mockRejectedValueOnce(
+      Object.assign(new Error('Operational settings are incomplete or invalid: geofenceRadiusDefaultM (invalid)'), {
+        status: 500,
+        code: 'E_OPERATIONAL_SETTINGS_INVALID',
+        details: [{ field: 'geofenceRadiusDefaultM', issue: 'invalid', value: 'not-a-number' }]
+      })
+    );
+
+    const res = await request(scopedApp)
+      .patch('/api/settings/operational')
+      .send({ autoCheckoutIdleMin: 12 });
+
+    expect(res.status).toBe(500);
+    expect(mockUpdateOperationalSettings).toHaveBeenCalledWith({ autoCheckoutIdleMin: 12 });
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        success: false,
+        code: 'E_OPERATIONAL_SETTINGS_INVALID',
+        message: 'Operational settings are incomplete or invalid: geofenceRadiusDefaultM (invalid)',
+        details: [{ field: 'geofenceRadiusDefaultM', issue: 'invalid', value: 'not-a-number' }]
+      })
+    );
+  });
+
+  it('does not expose arbitrary details arrays for non-operational-settings errors', async () => {
+    mockReadOperationalSettings.mockRejectedValueOnce(
+      Object.assign(new Error('Unexpected downstream failure'), {
+        status: 500,
+        code: 'E_INTERNAL_TEST',
+        details: [{ internal: 'should-not-leak' }]
+      })
+    );
+
+    const res = await request(scopedApp).get('/api/settings/operational');
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        success: false,
+        message: 'Unexpected downstream failure'
+      })
+    );
+    expect(res.body.code).toBeUndefined();
+    expect(res.body.details).toBeUndefined();
+  });
+
+  it('mounts the settings route into the main router under /api/settings', async () => {
+    const res = await request(mainApp).get('/api/settings/operational');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(buildOperationalSettings());
+    expect(mockReadOperationalSettings).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add `GET /api/settings/operational` and `PATCH /api/settings/operational` with Admin/Management RBAC and contract-first request validation
- centralize operational settings metadata/normalization and add a transactional allowlisted update service with full-state integrity checks
- align OpenAPI and add regression coverage for route contracts, RBAC behavior, operational settings persistence, and error exposure rules

## Test plan
- [x] `npm test -- --runTestsByPath tests/errorHandler.test.js tests/settingsOperationalRoutesContract.test.js tests/operationalSettings.test.js tests/roleGuard.test.js`
- [x] `npx eslint . --ext .js --no-eslintrc --config .eslintrc.cjs --resolve-plugins-relative-to .`
- [x] `npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)