### PR TITLE
Restore bookings readiness contract

### DIFF
--- a/src/controllers/booking.controller.js
+++ b/src/controllers/booking.controller.js
@@ -432,6 +432,13 @@ export const getAllBookings = async (req, res, next) => {
 
     const pageNum = parseInt(pageValue, 10);
     const limitNum = parseInt(limitValue, 10);
+    if (limitNum > 100) {
+      return res.status(400).json({
+        success: false,
+        message: 'Parameter pagination tidak valid. Limit maksimum adalah 100.'
+      });
+    }
+
     const offset = (pageNum - 1) * limitNum;
 
     // Buat objek whereClause untuk Sequelize
@@ -464,6 +471,7 @@ export const getAllBookings = async (req, res, next) => {
 
     const dateFromValue = String(date_from);
     const dateToValue = String(date_to);
+    const strictDatePattern = /^\d{4}-\d{2}-\d{2}$/;
     const hasDateFromFilter = hasQueryParam('date_from');
     const hasDateToFilter = hasQueryParam('date_to');
     const scheduleDateFilter = {};
@@ -471,6 +479,13 @@ export const getAllBookings = async (req, res, next) => {
     let parsedDateTo = null;
 
     if (hasDateFromFilter) {
+      if (!strictDatePattern.test(dateFromValue)) {
+        return res.status(400).json({
+          success: false,
+          message: 'Parameter date_from tidak valid. Gunakan format YYYY-MM-DD.'
+        });
+      }
+
       parsedDateFrom = parseISO(dateFromValue);
       if (!isValid(parsedDateFrom)) {
         return res.status(400).json({
@@ -482,6 +497,13 @@ export const getAllBookings = async (req, res, next) => {
     }
 
     if (hasDateToFilter) {
+      if (!strictDatePattern.test(dateToValue)) {
+        return res.status(400).json({
+          success: false,
+          message: 'Parameter date_to tidak valid. Gunakan format YYYY-MM-DD.'
+        });
+      }
+
       parsedDateTo = parseISO(dateToValue);
       if (!isValid(parsedDateTo)) {
         return res.status(400).json({

--- a/src/controllers/booking.controller.js
+++ b/src/controllers/booking.controller.js
@@ -412,19 +412,98 @@ export const updateBookingStatus = async (req, res, next) => {
 export const getAllBookings = async (req, res, next) => {
   try {
     // Dapatkan Parameter Query
-    const { status, page = 1, limit = 10 } = req.query;
-    const offset = (page - 1) * limit;
+    const { status, page = 1, limit = 10, user_id, date_from, date_to } = req.query;
+    const positiveIntegerPattern = /^[1-9]\d*$/;
+    const statusMap = {
+      approved: 1,
+      rejected: 2,
+      pending: 3
+    };
+    const hasQueryParam = (key) => Object.prototype.hasOwnProperty.call(req.query, key);
+
+    const pageValue = String(page);
+    const limitValue = String(limit);
+    if (!positiveIntegerPattern.test(pageValue) || !positiveIntegerPattern.test(limitValue)) {
+      return res.status(400).json({
+        success: false,
+        message: 'Parameter pagination tidak valid. Page dan limit harus bilangan bulat positif.'
+      });
+    }
+
+    const pageNum = parseInt(pageValue, 10);
+    const limitNum = parseInt(limitValue, 10);
+    const offset = (pageNum - 1) * limitNum;
 
     // Buat objek whereClause untuk Sequelize
     const whereClause = {};
-    if (status) {
-      const statusMap = {
-        approved: 1,
-        rejected: 2,
-        pending: 3
-      };
-      whereClause.status = statusMap[status];
-    } // Lakukan Query ke Database dengan include yang lengkap
+
+    if (hasQueryParam('status')) {
+      const statusValue = String(status);
+      const mappedStatus = statusMap[statusValue];
+      if (!mappedStatus) {
+        return res.status(400).json({
+          success: false,
+          message: 'Status filter tidak valid. Pilihan: approved, rejected, pending.'
+        });
+      }
+
+      whereClause.status = mappedStatus;
+    }
+
+    if (hasQueryParam('user_id')) {
+      const userIdValue = String(user_id);
+      if (!positiveIntegerPattern.test(userIdValue)) {
+        return res.status(400).json({
+          success: false,
+          message: 'Parameter user_id tidak valid. user_id harus bilangan bulat positif.'
+        });
+      }
+
+      whereClause.user_id = parseInt(userIdValue, 10);
+    }
+
+    const dateFromValue = String(date_from);
+    const dateToValue = String(date_to);
+    const hasDateFromFilter = hasQueryParam('date_from');
+    const hasDateToFilter = hasQueryParam('date_to');
+    const scheduleDateFilter = {};
+    let parsedDateFrom = null;
+    let parsedDateTo = null;
+
+    if (hasDateFromFilter) {
+      parsedDateFrom = parseISO(dateFromValue);
+      if (!isValid(parsedDateFrom)) {
+        return res.status(400).json({
+          success: false,
+          message: 'Parameter date_from tidak valid. Gunakan tanggal yang valid.'
+        });
+      }
+      scheduleDateFilter[Op.gte] = dateFromValue;
+    }
+
+    if (hasDateToFilter) {
+      parsedDateTo = parseISO(dateToValue);
+      if (!isValid(parsedDateTo)) {
+        return res.status(400).json({
+          success: false,
+          message: 'Parameter date_to tidak valid. Gunakan tanggal yang valid.'
+        });
+      }
+      scheduleDateFilter[Op.lte] = dateToValue;
+    }
+
+    if (parsedDateFrom && parsedDateTo && parsedDateFrom > parsedDateTo) {
+      return res.status(400).json({
+        success: false,
+        message: 'Parameter date_from tidak boleh lebih lambat dari date_to.'
+      });
+    }
+
+    if (hasDateFromFilter || hasDateToFilter) {
+      whereClause.schedule_date = scheduleDateFilter;
+    }
+
+    // Lakukan Query ke Database dengan include yang lengkap
     const bookings = await Booking.findAndCountAll({
       where: whereClause,
       include: [
@@ -462,8 +541,8 @@ export const getAllBookings = async (req, res, next) => {
         // Urutan sekunder: data terbaru di atas dalam setiap grup status
         ['created_at', 'DESC']
       ],
-      limit: parseInt(limit),
-      offset: parseInt(offset),
+      limit: limitNum,
+      offset,
       distinct: true // Important for correct count with includes
     }); // Transform data dengan struktur location yang grouped
     const transformedBookings = bookings.rows.map((booking) => ({
@@ -497,10 +576,10 @@ export const getAllBookings = async (req, res, next) => {
       data: {
         bookings: transformedBookings,
         pagination: {
-          current_page: parseInt(page),
-          total_pages: Math.ceil(bookings.count / limit),
+          current_page: pageNum,
+          total_pages: Math.ceil(bookings.count / limitNum),
           total_items: bookings.count,
-          items_per_page: parseInt(limit)
+          items_per_page: limitNum
         }
       },
       message: 'Daftar booking berhasil diambil'
@@ -612,24 +691,13 @@ export const deleteBooking = async (req, res, next) => {
       });
     }
 
-    // Langkah 4: Simpan location_id Terkait
-    const locationIdToDelete = bookingRecord.location_id;
-
-    // Langkah 5: Hapus Record Booking
+    // Langkah 4: Hapus Record Booking
     await bookingRecord.destroy({ transaction: t });
 
-    // Langkah 6: Hapus Record Lokasi Terkait
-    if (locationIdToDelete) {
-      await Location.destroy({
-        where: { location_id: locationIdToDelete },
-        transaction: t
-      });
-    }
-
-    // Langkah 7: Commit Transaksi
+    // Langkah 5: Commit Transaksi
     await t.commit();
 
-    // Langkah 8: Kirim Respons Sukses
+    // Langkah 6: Kirim Respons Sukses
     res.status(200).json({
       success: true,
       message: 'Data booking berhasil dihapus.'

--- a/tests/bookingsControllerReadiness.test.js
+++ b/tests/bookingsControllerReadiness.test.js
@@ -1,0 +1,249 @@
+import { jest } from '@jest/globals';
+import { Op } from 'sequelize';
+
+describe('booking controller readiness regressions', () => {
+  function buildRes() {
+    const res = {};
+    res.status = jest.fn(() => res);
+    res.json = jest.fn(() => res);
+    return res;
+  }
+
+  function buildTransaction() {
+    return {
+      commit: jest.fn().mockResolvedValue(),
+      rollback: jest.fn().mockResolvedValue()
+    };
+  }
+
+  function buildSequelizeMock(transaction = buildTransaction()) {
+    return {
+      transaction: jest.fn().mockResolvedValue(transaction),
+      fn: jest.fn((...args) => ({ args })),
+      col: jest.fn((value) => value)
+    };
+  }
+
+  function buildModelsMock({ findAndCountAllResult = { count: 0, rows: [] }, bookingRecord = null } = {}) {
+    return {
+      Booking: {
+        findAndCountAll: jest.fn().mockResolvedValue(findAndCountAllResult),
+        findByPk: jest.fn().mockResolvedValue(bookingRecord)
+      },
+      Location: {
+        destroy: jest.fn()
+      },
+      BookingStatus: {},
+      User: {},
+      Position: {},
+      Role: {}
+    };
+  }
+
+  function mockControllerDependencies({ models, sequelizeMock }) {
+    jest.unstable_mockModule('../src/config/database.js', () => ({
+      default: sequelizeMock
+    }));
+
+    jest.unstable_mockModule('../src/models/index.js', () => models);
+
+    jest.unstable_mockModule('../src/utils/fuzzyAhpEngine.js', () => ({
+      default: {}
+    }));
+
+    jest.unstable_mockModule('../src/utils/logger.js', () => ({
+      default: {
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+        debug: jest.fn()
+      }
+    }));
+  }
+
+  async function importBookingController(models, sequelizeMock = buildSequelizeMock()) {
+    mockControllerDependencies({ models, sequelizeMock });
+    return import('../src/controllers/booking.controller.js');
+  }
+
+  async function expectListValidationError(query, expectedMessageFragment) {
+    const models = buildModelsMock();
+    const { getAllBookings } = await importBookingController(models);
+    const res = buildRes();
+    const next = jest.fn();
+
+    await getAllBookings({ query }, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        message: expect.stringContaining(expectedMessageFragment)
+      })
+    );
+    expect(models.Booking.findAndCountAll).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  }
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it('applies documented bookings filters and pagination for admin listing', async () => {
+    const sequelizeMock = buildSequelizeMock();
+    const models = buildModelsMock({
+      findAndCountAllResult: {
+        count: 7,
+        rows: [
+          {
+            booking_id: 88,
+            user: {
+              id_users: 42,
+              full_name: 'Booking User',
+              role: { role_name: 'User' },
+              email: 'booking@example.com',
+              nip_nim: 'EMP-42',
+              position: { position_name: 'Engineer' }
+            },
+            schedule_date: '2026-05-15',
+            booking_status: { name_status: 'approved' },
+            location: {
+              location_id: 9,
+              latitude: '-0.8917',
+              longitude: '119.8707',
+              radius: '100',
+              description: 'Remote Hub'
+            },
+            notes: 'Needs review',
+            suitability_score: '80',
+            suitability_label: 'Tinggi',
+            created_at: new Date('2026-05-01T08:00:00.000Z'),
+            processed_at: null,
+            approved_by: null
+          }
+        ]
+      }
+    });
+
+    mockControllerDependencies({ models, sequelizeMock });
+
+    const { getAllBookings } = await import('../src/controllers/booking.controller.js');
+
+    const req = {
+      query: {
+        status: 'approved',
+        user_id: '42',
+        date_from: '2026-05-01',
+        date_to: '2026-05-31',
+        page: '2',
+        limit: '5'
+      }
+    };
+    const res = buildRes();
+    const next = jest.fn();
+
+    await getAllBookings(req, res, next);
+
+    expect(models.Booking.findAndCountAll).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          status: 1,
+          user_id: 42,
+          schedule_date: {
+            [Op.gte]: '2026-05-01',
+            [Op.lte]: '2026-05-31'
+          }
+        },
+        limit: 5,
+        offset: 5,
+        distinct: true
+      })
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        data: expect.objectContaining({
+          pagination: expect.objectContaining({
+            current_page: 2,
+            total_pages: 2,
+            total_items: 7,
+            items_per_page: 5
+          }),
+          bookings: expect.arrayContaining([
+            expect.objectContaining({
+              booking_id: 88,
+              user_id: 42,
+              status: 'approved'
+            })
+          ])
+        })
+      })
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid status filters before querying bookings', async () => {
+    await expectListValidationError({ status: 'archived' }, 'Status filter tidak valid');
+  });
+
+  it('rejects invalid pagination values before querying bookings', async () => {
+    await expectListValidationError(
+      {
+        page: '0',
+        limit: '-2'
+      },
+      'Parameter pagination tidak valid'
+    );
+  });
+
+  it('rejects invalid user_id filters before querying bookings', async () => {
+    await expectListValidationError({ user_id: '0' }, 'Parameter user_id tidak valid');
+  });
+
+  it('rejects date ranges where date_from is later than date_to', async () => {
+    await expectListValidationError(
+      {
+        date_from: '2026-05-31',
+        date_to: '2026-05-01'
+      },
+      'date_from tidak boleh lebih lambat dari date_to'
+    );
+  });
+
+  it('deletes only the booking record without deleting the shared location', async () => {
+    const transaction = buildTransaction();
+    const sequelizeMock = buildSequelizeMock(transaction);
+    const bookingRecord = {
+      destroy: jest.fn().mockResolvedValue()
+    };
+    const models = buildModelsMock({ bookingRecord });
+
+    mockControllerDependencies({ models, sequelizeMock });
+
+    const { deleteBooking } = await import('../src/controllers/booking.controller.js');
+
+    const req = {
+      params: { id: '55' }
+    };
+    const res = buildRes();
+    const next = jest.fn();
+
+    await deleteBooking(req, res, next);
+
+    expect(models.Booking.findByPk).toHaveBeenCalledWith('55', { transaction });
+    expect(bookingRecord.destroy).toHaveBeenCalledWith({ transaction });
+    expect(models.Location.destroy).not.toHaveBeenCalled();
+    expect(transaction.commit).toHaveBeenCalled();
+    expect(transaction.rollback).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        message: 'Data booking berhasil dihapus.'
+      })
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/tests/bookingsControllerReadiness.test.js
+++ b/tests/bookingsControllerReadiness.test.js
@@ -198,8 +198,21 @@ describe('booking controller readiness regressions', () => {
     );
   });
 
+  it('rejects pagination limits above the admin safety cap', async () => {
+    await expectListValidationError({ limit: '101' }, 'Limit maksimum adalah 100');
+  });
+
   it('rejects invalid user_id filters before querying bookings', async () => {
     await expectListValidationError({ user_id: '0' }, 'Parameter user_id tidak valid');
+  });
+
+  it('rejects datetime date filters that do not match the published date format', async () => {
+    await expectListValidationError(
+      {
+        date_from: '2026-05-01T12:00:00Z'
+      },
+      'Gunakan format YYYY-MM-DD'
+    );
   });
 
   it('rejects date ranges where date_from is later than date_to', async () => {

--- a/tests/clientCriticalOpenApiContract.test.js
+++ b/tests/clientCriticalOpenApiContract.test.js
@@ -126,6 +126,15 @@ describe('client-critical OpenAPI contract', () => {
     expect(bookingSchema.properties).not.toHaveProperty('reason');
   });
 
+  test('documents booking admin list query filters exposed to clients', () => {
+    const bookingListParameters = openapi.paths['/api/bookings'].get.parameters;
+    const parameterNames = bookingListParameters.map((parameter) => parameter.name);
+
+    expect(parameterNames).toEqual(
+      expect.arrayContaining(['page', 'limit', 'status', 'date_from', 'date_to', 'user_id'])
+    );
+  });
+
   test('documents booking creation success response shape from the runtime controller', () => {
     const bookingSuccessSchema = schemaAt(openapi.paths['/api/bookings'].post, '201');
     const dataSchema = bookingSuccessSchema.properties.data;


### PR DESCRIPTION
## Summary
- restore `/api/bookings` admin filters so runtime matches the published `status`, `page`, `limit`, `user_id`, `date_from`, and `date_to` contract
- stop `DELETE /api/bookings/{id}` from deleting shared `Location` rows when removing a booking
- add focused controller regressions and OpenAPI guardrails for the bookings readiness remediation

## Test plan
- [x] `npm test -- --runInBand --runTestsByPath tests/bookingsControllerReadiness.test.js tests/clientCriticalOpenApiContract.test.js`
- [x] `npm test -- --runInBand --runTestsByPath tests/bookingsControllerReadiness.test.js tests/clientCriticalOpenApiContract.test.js tests/attendanceStatusCurrentAttendance.test.js tests/attendanceTodayLocationsContract.test.js tests/attendanceTodayLocationsRoute.test.js tests/attendanceOperationalSettingsContract.test.js tests/attendanceDuplicateSafety.test.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)