### PR TITLE
Harden published route readiness contract

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,4 +1,5 @@
 module.exports = {
+	root: true,
 	env: {
 		node: true,
 		jest: true,

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/README.md
+++ b/README.md
@@ -150,8 +150,8 @@ curl http://localhost:3005/health
 # API documentation
 open http://localhost:3005/docs
 
-# Test timezone configuration
-curl http://localhost:3005/api/attendance/test-timezone
+# Published OpenAPI contract
+curl http://localhost:3005/docs/openapi.yaml
 ```
 
 ## 5. Dokumentasi API (Endpoint Utama)
@@ -181,27 +181,24 @@ Dokumentasi API interaktif yang lengkap tersedia melalui **Swagger UI** saat ser
 | **🧠 WFA Intelligence**      |
 | `GET`                        | `/api/wfa/recommendations`        | Rekomendasi lokasi WFA dengan Fuzzy AHP               | Pengguna         |
 | `GET`                        | `/api/wfa/ahp-config`             | Konfigurasi algoritma AHP                             | Admin            |
-| `POST`                       | `/api/wfa/test-ahp`               | Test AHP algorithm (debugging)                        | Admin            |
 | **📊 Analytics & Reports**   |
 | `GET`                        | `/api/summary`                    | **[ENHANCED]** Laporan komprehensif + Indeks Disiplin | Admin/Management |
 | `GET`                        | `/api/discipline/user/:id`        | Indeks kedisiplinan individual                        | Admin/Management |
 | `GET`                        | `/api/discipline/all`             | Overview disiplin semua karyawan                      | Admin            |
-| **🤖 Job Management**        |
-| `GET`                        | `/api/jobs/status`                | Status semua automated jobs                           | Admin            |
-| `POST`                       | `/api/jobs/trigger/general-alpha` | **[NEW]** Trigger manual alpha job                    | Admin            |
-| `POST`                       | `/api/jobs/trigger/wfa-bookings`  | **[NEW]** Trigger manual WFA resolution               | Admin            |
-| `POST`                       | `/api/jobs/trigger/auto-checkout` | **[NEW]** Trigger manual auto-checkout                | Admin            |
-| `POST`                       | `/api/jobs/trigger/all`           | **[NEW]** Trigger semua jobs sekaligus                | Admin            |
+| `GET`                        | `/api/analysis/fuzzy-ahp`         | Analisis bobot fuzzy AHP                              | Admin/Management |
+| **⚙️ Operational Settings**  |
+| `GET`                        | `/api/settings/operational`       | Membaca konfigurasi operasional aplikasi              | Admin/Management |
+| `PATCH`                      | `/api/settings/operational`       | Mengubah konfigurasi operasional aplikasi             | Admin/Management |
 | **👥 User Management**       |
 | `GET`                        | `/api/users`                      | Mengelola semua pengguna (CRUD)                       | Admin            |
 | `POST`                       | `/api/users`                      | Buat user baru                                        | Admin            |
 | `PATCH`                      | `/api/users/:id`                  | Update data user                                      | Admin            |
 | `DELETE`                     | `/api/users/:id`                  | Hapus user                                            | Admin            |
 | **📋 Reference Data**        |
-| `GET`                        | `/api/roles`                      | Daftar semua roles                                    | Authenticated    |
-| `GET`                        | `/api/positions`                  | Daftar semua positions                                | Authenticated    |
-| `GET`                        | `/api/divisions`                  | Daftar semua divisions                                | Authenticated    |
-| `GET`                        | `/api/locations`                  | Daftar office locations                               | Authenticated    |
+| `GET`                        | `/api/roles`                      | Daftar semua roles                                    | Admin/Management |
+| `GET`                        | `/api/programs`                   | Daftar semua program                                  | Admin/Management |
+| `GET`                        | `/api/positions`                  | Daftar semua positions                                | Admin/Management |
+| `GET`                        | `/api/divisions`                  | Daftar semua divisions                                | Admin/Management |
 
 ### **🎯 5.2 Featured Endpoints**
 
@@ -672,7 +669,7 @@ npm run migrate:undo         # Rollback last migration (dev only)
 
 # Production Monitoring
 curl https://api.yourdomain.com/health                  # Health check
-curl https://api.yourdomain.com/api/jobs/status         # Check cron jobs
+curl https://api.yourdomain.com/docs/openapi.yaml      # Published API contract
 ```
 
 ### **🎯 8.9 Development Workflow Best Practices**
@@ -771,9 +768,9 @@ npm run health:check
 
 ```bash
 # Health check endpoints
-GET /health                    # Basic server health
-GET /api/attendance/test-timezone  # Timezone configuration
-GET /api/jobs/status          # Automated jobs status
+GET /health              # Basic server health
+GET /docs                # Interactive API documentation
+GET /docs/openapi.yaml   # Published OpenAPI contract
 ```
 
 ### **📝 10.2 Logging System**
@@ -809,21 +806,21 @@ npm run db:reset
 #### Timezone Issues
 
 ```bash
-# Verify timezone configuration
-curl http://localhost:3005/api/attendance/test-timezone
+# Verify service contract is being served
+curl http://localhost:3005/health
+curl http://localhost:3005/docs/openapi.yaml
 
 # Check database timezone settings
 npm run db:timezone:check
 ```
 
-#### Job Processing Issues
+#### Operational Readiness Issues
 
 ```bash
-# Check cron job status
-GET /api/jobs/status
-
-# Manual trigger for debugging
-POST /api/jobs/trigger/all
+# Verify published contract and public operational surfaces
+GET /docs/openapi.yaml
+GET /api/settings/operational
+GET /api/attendance/today-locations
 ```
 
 ## 11. Contributing & Development Guidelines

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -3369,6 +3369,8 @@ tags:
     description: System health and status endpoints
   - name: Authentication
     description: User authentication and authorization
+  - name: Analysis
+    description: Dashboard-ready Fuzzy AHP analysis endpoints for management surfaces
   - name: Attendance
     description: Employee attendance tracking and management
   - name: User Management

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2226,8 +2226,8 @@ paths:
     get:
       tags:
         - Reference Data
-      summary: Get all roles
-      description: Retrieve all available user roles
+      summary: Get all roles (Admin/Management only)
+      description: Retrieve all available user roles for Admin and Management users
       responses:
         '200':
           description: Roles retrieved successfully
@@ -2242,16 +2242,21 @@ paths:
                   data:
                     type: array
                     items:
-                      $ref: '#/components/schemas/Role'
+                      $ref: '#/components/schemas/ReferenceRole'
+                  message:
+                    type: string
+                    example: Roles retrieved successfully
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
 
   /api/programs:
     get:
       tags:
         - Reference Data
-      summary: Get all programs
-      description: Retrieve all available programs
+      summary: Get all programs (Admin/Management only)
+      description: Retrieve all available programs for Admin and Management users
       responses:
         '200':
           description: Programs retrieved successfully
@@ -2279,13 +2284,23 @@ paths:
                     example: Programs retrieved successfully
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
 
   /api/positions:
     get:
       tags:
         - Reference Data
-      summary: Get all positions
-      description: Retrieve all available job positions
+      summary: Get all positions (Admin/Management only)
+      description: Retrieve all available job positions for Admin and Management users
+      parameters:
+        - in: query
+          name: program_id
+          schema:
+            type: integer
+          required: false
+          description: Filter positions by program ID
+          example: 1
       responses:
         '200':
           description: Positions retrieved successfully
@@ -2300,16 +2315,21 @@ paths:
                   data:
                     type: array
                     items:
-                      $ref: '#/components/schemas/Position'
+                      $ref: '#/components/schemas/ReferencePosition'
+                  message:
+                    type: string
+                    example: Positions retrieved successfully
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
 
   /api/divisions:
     get:
       tags:
         - Reference Data
-      summary: Get all divisions
-      description: Retrieve all available company divisions
+      summary: Get all divisions (Admin/Management only)
+      description: Retrieve all available company divisions for Admin and Management users
       responses:
         '200':
           description: Divisions retrieved successfully
@@ -2324,9 +2344,14 @@ paths:
                   data:
                     type: array
                     items:
-                      $ref: '#/components/schemas/Division'
+                      $ref: '#/components/schemas/ReferenceDivision'
+                  message:
+                    type: string
+                    example: Divisions retrieved successfully
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
 
 components:
   securitySchemes:
@@ -2482,6 +2507,46 @@ components:
         description:
           type: string
           example: 'Software development division'
+
+    ReferenceRole:
+      type: object
+      properties:
+        id_roles:
+          type: integer
+          example: 1
+        role_name:
+          type: string
+          example: 'Admin'
+
+    ReferencePosition:
+      type: object
+      properties:
+        id_positions:
+          type: integer
+          example: 1
+        position_name:
+          type: string
+          example: 'Software Engineer'
+        id_programs:
+          type: integer
+          example: 1
+        program:
+          type: object
+          nullable: true
+          properties:
+            program_name:
+              type: string
+              example: 'Kampus Merdeka'
+
+    ReferenceDivision:
+      type: object
+      properties:
+        id_divisions:
+          type: integer
+          example: 1
+        division_name:
+          type: string
+          example: 'Engineering'
 
     Attendance:
       type: object
@@ -2773,36 +2838,6 @@ components:
           nullable: true
           example: 5
           description: ID of admin/management who processed the booking
-
-    JobStatus:
-      type: object
-      properties:
-        name:
-          type: string
-          example: 'General Alpha Generation'
-        cron_schedule:
-          type: string
-          example: '45 23 * * *'
-        description:
-          type: string
-          example: 'Generates alpha attendance records for users without attendance'
-        last_execution:
-          type: string
-          format: date-time
-          nullable: true
-          example: '2025-07-04T23:45:00.000Z'
-        next_execution:
-          type: string
-          format: date-time
-          example: '2025-07-05T23:45:00.000Z'
-        status:
-          type: string
-          enum: [scheduled, running, completed, failed]
-          example: 'scheduled'
-        execution_count:
-          type: integer
-          example: 5
-          description: 'Number of times this job has been executed'
 
     WFARecommendation:
       type: object
@@ -3336,16 +3371,12 @@ tags:
     description: User authentication and authorization
   - name: Attendance
     description: Employee attendance tracking and management
-  - name: Advanced Attendance
-    description: Advanced attendance features like auto-checkout and smart predictions
   - name: User Management
     description: User account management (Admin/Management only)
   - name: WFA Bookings
     description: Work From Anywhere booking management
   - name: WFA System
     description: WFA recommendation engine using Fuzzy AHP
-  - name: Job Management
-    description: Cron job management and manual triggers (Admin only)
   - name: Reports & Analytics
     description: Summary reports and analytics for management
   - name: Discipline Management
@@ -3354,16 +3385,6 @@ tags:
     description: Operational settings management endpoints for Admin and Management
   - name: Reference Data
     description: Master data for roles, positions, divisions, etc.
-  - name: Development & Testing
-    description: Development and testing endpoints
-  - name: Reports & Analytics
-    description: Summary and report generation endpoints
-  - name: Discipline Management
-    description: Discipline index and management endpoints
-  - name: Advanced Attendance
-    description: Advanced attendance features like manual checkout and smart prediction
-  - name: Development & Testing
-    description: Development and testing utilities
 externalDocs:
   description: Find out more about Infinite Track Backend
   url: https://github.com/your-org/infinite-track-backend

--- a/src/app.js
+++ b/src/app.js
@@ -1,4 +1,5 @@
 import express from 'express';
+import path from 'path';
 import cors from 'cors';
 import cookieParser from 'cookie-parser';
 import YAML from 'yamljs';
@@ -49,7 +50,12 @@ app.use(cookieParser());
 app.use('/uploads', express.static('uploads'));
 
 // Swagger documentation
-const swaggerDoc = YAML.load('./docs/openapi.yaml');
+const openApiPath = path.resolve(process.cwd(), 'docs/openapi.yaml');
+const swaggerDoc = YAML.load(openApiPath);
+app.get('/docs/openapi.yaml', (_req, res) => {
+  res.type('application/yaml');
+  res.sendFile(openApiPath);
+});
 app.use('/docs', swaggerUi.serve, swaggerUi.setup(swaggerDoc));
 
 app.use(routes);

--- a/test-api-docs.sh
+++ b/test-api-docs.sh
@@ -115,16 +115,19 @@ print_info "Testing core API endpoints..."
 print_info "Testing authentication endpoints..."
 
 # Test login endpoint (should return validation error without data)
-LOGIN_RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$API_BASE/api/auth/login" \
-    -H "Content-Type: application/json" || echo "failed")
+LOGIN_RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$API_BASE/api/auth/login" -H "Content-Type: application/json" || echo "failed")
 
-if [ "$LOGIN_RESPONSE" = "400" ] || [ "$LOGIN_RESPONSE" = "422" ]; then
-    print_success "Login endpoint accessible (validation error expected)"
-elif [ "$LOGIN_RESPONSE" = "200" ]; then
-    print_warning "Login endpoint returned 200 (unexpected without credentials)"
-else
-    print_error "Login endpoint failed (HTTP $LOGIN_RESPONSE)"
-fi
+case "$LOGIN_RESPONSE" in
+    400|422)
+        print_success "Login endpoint accessible (validation error expected)"
+        ;;
+    200)
+        print_warning "Login endpoint returned 200 (unexpected without credentials)"
+        ;;
+    *)
+        print_error "Login endpoint failed (HTTP $LOGIN_RESPONSE)"
+        ;;
+esac
 
 # Test protected endpoints (should return 401 without auth)
 print_info "Testing protected endpoints..."
@@ -160,7 +163,7 @@ if [ -f "docs/openapi.yaml" ]; then
         "/api/attendance/checkout"
         "/api/bookings"
         "/api/wfa/recommendations"
-        "/api/jobs/trigger/general-alpha"
+        "/api/settings/operational"
         "/health"
     )
     
@@ -186,7 +189,7 @@ if [ -f "docs/openapi.yaml" ]; then
         "Attendance"
         "Booking"
         "WFARecommendation"
-        "JobStatus"
+        "OperationalSettings"
     )
     
     MISSING_COMPONENTS=()
@@ -263,7 +266,7 @@ echo "   - GET /api/roles (should return available roles)"
 echo ""
 echo "4. 🧪 Test Advanced Features:"
 echo "   - GET /api/wfa/recommendations (with lat/lng parameters)"
-echo "   - POST /api/jobs/trigger/general-alpha (Admin only)"
+echo "   - GET /api/settings/operational (Admin/Management only)"
 echo "   - GET /api/discipline/config (Admin/Management only)"
 echo ""
 

--- a/test-production.sh
+++ b/test-production.sh
@@ -35,21 +35,17 @@ api_request() {
     local method=$1
     local endpoint=$2
     local data=$3
-    local auth_header=""
-    
-    if [ ! -z "$ADMIN_TOKEN" ]; then
-        auth_header="-H 'Authorization: Bearer $ADMIN_TOKEN'"
+    local curl_args=(-s -X "$method" "$API_BASE$endpoint")
+
+    if [ -n "$ADMIN_TOKEN" ]; then
+        curl_args+=(-H "Authorization: Bearer $ADMIN_TOKEN")
     fi
-    
-    if [ ! -z "$data" ]; then
-        eval curl -s -X $method "$API_BASE$endpoint" \
-            -H "Content-Type: application/json" \
-            $auth_header \
-            -d "'$data'"
-    else
-        eval curl -s -X $method "$API_BASE$endpoint" \
-            $auth_header
+
+    if [ -n "$data" ]; then
+        curl_args+=(-H "Content-Type: application/json" -d "$data")
     fi
+
+    curl "${curl_args[@]}"
 }
 
 # Test health endpoint
@@ -80,7 +76,7 @@ test_basic_endpoints() {
     fi
     
     # Test authentication endpoint
-    response=$(curl -s -o /dev/null -w "%{http_code}" "$API_BASE/auth/signin")
+    response=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$API_BASE/auth/login" -H "Content-Type: application/json" -d "{}")
     if [ "$response" = "400" ] || [ "$response" = "422" ]; then
         print_success "Auth endpoint accessible (expected validation error)"
     else
@@ -88,55 +84,34 @@ test_basic_endpoints() {
     fi
 }
 
-# Test manual job triggers (requires admin token)
-test_job_triggers() {
+# Test read-only admin operational endpoints (requires admin token)
+test_admin_operational_endpoints() {
     if [ -z "$ADMIN_TOKEN" ]; then
-        print_warning "Skipping job trigger tests (no admin token provided)"
+        print_warning "Skipping admin operational endpoint tests (no admin token provided)"
         return 0
     fi
-    
-    print_info "Testing manual job triggers..."
-    
-    # Test job status endpoint
-    local response=$(api_request "GET" "/jobs/status")
-    if echo "$response" | grep -q "status"; then
-        print_success "Job status endpoint working"
-    else
-        print_warning "Job status endpoint may have issues"
-    fi
-    
-    # Test general alpha trigger
-    print_info "Testing general alpha trigger..."
-    response=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$API_BASE/jobs/trigger/general-alpha" \
-        -H "Authorization: Bearer $ADMIN_TOKEN")
-    
-    if [ "$response" = "200" ]; then
-        print_success "General alpha trigger working"
-    else
-        print_warning "General alpha trigger returned HTTP $response"
-    fi
-    
-    # Test WFA resolver trigger
-    print_info "Testing WFA resolver trigger..."
-    response=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$API_BASE/jobs/trigger/resolve-wfa" \
-        -H "Authorization: Bearer $ADMIN_TOKEN")
-    
-    if [ "$response" = "200" ]; then
-        print_success "WFA resolver trigger working"
-    else
-        print_warning "WFA resolver trigger returned HTTP $response"
-    fi
-    
-    # Test auto checkout trigger
-    print_info "Testing auto checkout trigger..."
-    response=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$API_BASE/jobs/trigger/auto-checkout" \
-        -H "Authorization: Bearer $ADMIN_TOKEN")
-    
-    if [ "$response" = "200" ]; then
-        print_success "Auto checkout trigger working"
-    else
-        print_warning "Auto checkout trigger returned HTTP $response"
-    fi
+
+    print_info "Testing read-only admin operational endpoints..."
+
+    ADMIN_ENDPOINTS=(
+        "/settings/operational"
+        "/attendance/auto-checkout-settings"
+        "/attendance/smart-config"
+        "/attendance/enhanced-auto-checkout-settings"
+        "/attendance/today-locations"
+    )
+
+    for endpoint in "${ADMIN_ENDPOINTS[@]}"; do
+        local response=$(curl -s -o /dev/null -w "%{http_code}" "$API_BASE$endpoint" -H "Authorization: Bearer $ADMIN_TOKEN")
+
+        if [ "$response" = "200" ]; then
+            print_success "Admin endpoint $endpoint working"
+        elif [ "$response" = "401" ] || [ "$response" = "403" ]; then
+            print_warning "Admin endpoint $endpoint rejected credentials (HTTP $response)"
+        else
+            print_warning "Admin endpoint $endpoint returned HTTP $response"
+        fi
+    done
 }
 
 # Test database connectivity
@@ -266,7 +241,7 @@ run_tests() {
     test_ssl
     
     # Admin functionality tests
-    test_job_triggers
+    test_admin_operational_endpoints
     
     echo ""
     echo "🎯 Test Summary"

--- a/tests/clientCriticalOpenApiContract.test.js
+++ b/tests/clientCriticalOpenApiContract.test.js
@@ -2,11 +2,17 @@ import fs from 'fs';
 import path from 'path';
 import yaml from 'yamljs';
 
-const schemaAt = (operation, statusCode = '200') =>
-  operation.responses[statusCode].content['application/json'].schema;
+function schemaAt(operation, statusCode = '200') {
+  return operation.responses[statusCode].content['application/json'].schema;
+}
 
-const jsonRequestSchema = (operation) =>
-  operation.requestBody.content['application/json'].schema;
+function jsonRequestSchema(operation) {
+  return operation.requestBody.content['application/json'].schema;
+}
+
+function componentSchema(openapi, name) {
+  return openapi.components.schemas[name];
+}
 
 describe('client-critical OpenAPI contract', () => {
   const openapi = yaml.parse(
@@ -164,5 +170,71 @@ describe('client-critical OpenAPI contract', () => {
         nullable: true
       }
     });
+  });
+
+  test('documents reference data endpoints as Admin/Management-only surfaces', () => {
+    const referenceDataPaths = [
+      '/api/roles',
+      '/api/programs',
+      '/api/positions',
+      '/api/divisions'
+    ];
+
+    for (const referenceDataPath of referenceDataPaths) {
+      const operation = openapi.paths[referenceDataPath].get;
+
+      expect(operation.summary).toContain('(Admin/Management only)');
+      expect(operation.responses).toHaveProperty('401');
+      expect(operation.responses).toHaveProperty('403');
+    }
+  });
+
+  test('documents reference data response items and filters from the live controllers', () => {
+    const rolesItemSchema = schemaAt(openapi.paths['/api/roles'].get).properties.data.items;
+    const programsItemSchema = schemaAt(openapi.paths['/api/programs'].get).properties.data.items;
+    const positionsOperation = openapi.paths['/api/positions'].get;
+    const positionsItemSchema = schemaAt(positionsOperation).properties.data.items;
+    const divisionsItemSchema = schemaAt(openapi.paths['/api/divisions'].get).properties.data.items;
+    const roleProperties = componentSchema(openapi, 'ReferenceRole').properties;
+    const positionProperties = componentSchema(openapi, 'ReferencePosition').properties;
+    const divisionProperties = componentSchema(openapi, 'ReferenceDivision').properties;
+
+    expect(rolesItemSchema).toEqual({ $ref: '#/components/schemas/ReferenceRole' });
+    expect(roleProperties).toMatchObject({
+      id_roles: { type: 'integer' },
+      role_name: { type: 'string' }
+    });
+    expect(roleProperties).not.toHaveProperty('id');
+    expect(roleProperties).not.toHaveProperty('name');
+
+    expect(programsItemSchema.properties).toMatchObject({
+      id_programs: { type: 'integer' },
+      program_name: { type: 'string' }
+    });
+
+    expect(positionsOperation.parameters.map((parameter) => parameter.name)).toContain('program_id');
+    expect(positionsItemSchema).toEqual({ $ref: '#/components/schemas/ReferencePosition' });
+    expect(positionProperties).toMatchObject({
+      id_positions: { type: 'integer' },
+      position_name: { type: 'string' },
+      id_programs: { type: 'integer' },
+      program: {
+        type: 'object',
+        nullable: true
+      }
+    });
+    expect(positionProperties.program.properties).toMatchObject({
+      program_name: { type: 'string' }
+    });
+    expect(positionProperties).not.toHaveProperty('id');
+    expect(positionProperties).not.toHaveProperty('name');
+
+    expect(divisionsItemSchema).toEqual({ $ref: '#/components/schemas/ReferenceDivision' });
+    expect(divisionProperties).toMatchObject({
+      id_divisions: { type: 'integer' },
+      division_name: { type: 'string' }
+    });
+    expect(divisionProperties).not.toHaveProperty('id');
+    expect(divisionProperties).not.toHaveProperty('name');
   });
 });

--- a/tests/clientCriticalOpenApiContract.test.js
+++ b/tests/clientCriticalOpenApiContract.test.js
@@ -172,6 +172,16 @@ describe('client-critical OpenAPI contract', () => {
     });
   });
 
+  test('defines the Analysis tag used by published analysis endpoints', () => {
+    expect(openapi.tags).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'Analysis'
+        })
+      ])
+    );
+  });
+
   test('documents reference data endpoints as Admin/Management-only surfaces', () => {
     const referenceDataPaths = [
       '/api/roles',

--- a/tests/openApiMountedRoutesContract.test.js
+++ b/tests/openApiMountedRoutesContract.test.js
@@ -6,25 +6,22 @@ describe('OpenAPI mounted route inventory contract', () => {
   const openapi = yaml.parse(
     fs.readFileSync(path.resolve(process.cwd(), 'docs/openapi.yaml'), 'utf8')
   );
+  const publicPaths = Object.keys(openapi.paths);
 
   test('documents mounted reference data dropdown endpoints', () => {
-    expect(Object.keys(openapi.paths)).toEqual(
+    expect(publicPaths).toEqual(
       expect.arrayContaining(['/api/roles', '/api/programs', '/api/positions', '/api/divisions'])
     );
   });
 
   test('documents mounted production-facing bookings endpoints', () => {
-    expect(Object.keys(openapi.paths)).toEqual(
-      expect.arrayContaining([
-        '/api/bookings',
-        '/api/bookings/history',
-        '/api/bookings/{id}'
-      ])
+    expect(publicPaths).toEqual(
+      expect.arrayContaining(['/api/bookings', '/api/bookings/history', '/api/bookings/{id}'])
     );
   });
 
   test('documents mounted production-facing discipline endpoints', () => {
-    expect(Object.keys(openapi.paths)).toEqual(
+    expect(publicPaths).toEqual(
       expect.arrayContaining([
         '/api/discipline/user/{userId}',
         '/api/discipline/all',
@@ -33,22 +30,32 @@ describe('OpenAPI mounted route inventory contract', () => {
     );
   });
 
+  test('documents mounted analysis and operational settings endpoints', () => {
+    expect(publicPaths).toEqual(
+      expect.arrayContaining(['/api/analysis/fuzzy-ahp', '/api/settings/operational'])
+    );
+  });
+
   test('excludes debug, test, internal ops, and legacy endpoints from public OpenAPI', () => {
-    const publicPaths = Object.keys(openapi.paths);
     const excludedPaths = [
       '/api/wfa/debug-geoapify',
       '/api/wfa/recommendations-test',
       '/api/wfa/test-ahp',
       '/api/discipline/test-ahp',
       '/api/attendance/debug-checkin-time',
-      '/api/attendance/test-weighted-prediction',
       '/api/attendance/manual-auto-checkout',
-      '/api/attendance/setup-auto-checkout',
-      '/api/attendance/smart-prediction',
-      '/api/attendance/test-timezone',
+      '/api/attendance/auto-checkout-settings',
+      '/api/attendance/manual-resolve-wfa-bookings',
+      '/api/attendance/manual-general-alpha',
+      '/api/attendance/manual-resolve-wfa-for-date',
+      '/api/attendance/manual-smart-auto-checkout',
+      '/api/attendance/test-weighted-prediction',
+      '/api/attendance/smart-config',
+      '/api/attendance/enhanced-auto-checkout-settings',
       '/api/jobs/status',
       '/api/jobs/trigger/general-alpha',
       '/api/jobs/trigger/wfa-bookings',
+      '/api/jobs/trigger/resolve-wfa',
       '/api/jobs/trigger/auto-checkout',
       '/api/jobs/trigger/all',
       '/api/attendance-categories',

--- a/tests/openApiPublicSpecRoute.test.js
+++ b/tests/openApiPublicSpecRoute.test.js
@@ -1,0 +1,16 @@
+import fs from 'fs';
+import path from 'path';
+import request from 'supertest';
+
+const { default: app } = await import('../src/app.js');
+
+describe('published OpenAPI spec route', () => {
+  test('serves the raw OpenAPI YAML contract', async () => {
+    const expectedSpec = fs.readFileSync(path.resolve(process.cwd(), 'docs/openapi.yaml'), 'utf8');
+    const response = await request(app).get('/docs/openapi.yaml');
+
+    expect(response.status).toBe(200);
+    expect(response.text).toBe(expectedSpec);
+    expect(response.headers['content-type']).toMatch(/yaml|text\/plain/i);
+  });
+});


### PR DESCRIPTION
## Summary
- align README and published OpenAPI with the production-facing route surface
- lock reference-data endpoints to the Admin/Management contract and live runtime response shapes
- update smoke checks, route-inventory tests, and shell/lint guardrails used for readiness verification

## Test plan
- [x] `npm test`
- [x] `npm run lint` *(1 existing warning remains in `tests/bookingsReadinessContract.test.js:103`)*
- [x] `bash -n ./test-api-docs.sh`
- [x] `bash -n ./test-production.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)