### PR TITLE
Document bookings invalid filter contract

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1215,6 +1215,8 @@ paths:
                           $ref: '#/components/schemas/Booking'
                       pagination:
                         $ref: '#/components/schemas/Pagination'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':

--- a/tests/bookingsReadinessContract.test.js
+++ b/tests/bookingsReadinessContract.test.js
@@ -100,7 +100,8 @@ describe('bookings route contract', () => {
 describe('bookings validator contract', () => {
   test('missing schedule_date returns 400', async () => {
     const app = buildValidatorApp();
-    const { schedule_date, ...payload } = validBookingPayload;
+    const payload = { ...validBookingPayload };
+    delete payload.schedule_date;
 
     await request(app).post('/bookings').send(payload).expect(400);
   });

--- a/tests/clientCriticalOpenApiContract.test.js
+++ b/tests/clientCriticalOpenApiContract.test.js
@@ -153,12 +153,15 @@ describe('client-critical OpenAPI contract', () => {
   });
 
   test('documents booking admin list query filters exposed to clients', () => {
-    const bookingListParameters = openapi.paths['/api/bookings'].get.parameters;
-    const parameterNames = bookingListParameters.map((parameter) => parameter.name);
+    const bookingListOperation = openapi.paths['/api/bookings'].get;
+    const parameterNames = bookingListOperation.parameters.map((parameter) => parameter.name);
 
     expect(parameterNames).toEqual(
       expect.arrayContaining(['page', 'limit', 'status', 'date_from', 'date_to', 'user_id'])
     );
+    expect(bookingListOperation.responses).toHaveProperty('400');
+    expect(bookingListOperation.responses).toHaveProperty('401');
+    expect(bookingListOperation.responses).toHaveProperty('403');
   });
 
   test('documents booking creation success response shape from the runtime controller', () => {


### PR DESCRIPTION
## Summary
- document `400 Bad Request` for invalid `GET /api/bookings` admin-list filters in `docs/openapi.yaml`
- tighten the client-critical OpenAPI contract test so the published bookings list operation must expose `400`, `401`, and `403`
- keep the existing bookings readiness regression aligned after the contract clarification

## Impact
- restores runtime/OpenAPI consistency for the published bookings admin list contract
- touches an API-significant surface, so the OpenAPI source of truth is updated in the same change
- ADR update not required because this is a contract restore, not a behavior redesign

## Risk
- low runtime risk because the change is docs/tests only
- clients that relied on the old spec now have an explicit invalid-filter failure contract

## Verification
- `npm test` ✅ (42 suites, 212 tests passed)
- `npm run lint` ✅ with existing warning at `src/controllers/attendance.controller.js:16` (`Photo` unused), unchanged by this PR

## Test plan
- [x] Run full Jest suite
- [x] Run ESLint
- [x] Verify diff against `origin/develop` only changes:
  - `docs/openapi.yaml`
  - `tests/bookingsReadinessContract.test.js`
  - `tests/clientCriticalOpenApiContract.test.js`