### PR TITLE
Harden scheduler readiness recovery

### DIFF
--- a/.do/README.md
+++ b/.do/README.md
@@ -1,220 +1,72 @@
-# DigitalOcean App Platform Deployment
+# DigitalOcean App Platform Backend Specs (Legacy)
 
-## 📋 Overview
+## Overview
 
-Konfigurasi ini mendukung deployment otomatis aplikasi Infinit Track Backend ke DigitalOcean App Platform menggunakan GitOps-style deployment.
+File `.do/app.yaml` dan `.do/app-production.yaml` disimpan sebagai artefak legacy/historical untuk referensi konfigurasi backend lama. Jalur deploy backend yang aktif bukan lagi App Platform.
 
-## 🚀 Deployment Methods
+Canonical runtime backend saat ini adalah:
 
-### Method 1: Via DigitalOcean Dashboard (Manual)
+- DOCR image `registry.digitalocean.com/infinit-track/infinit-track-backend`
+- droplet-hosted Docker Compose runtime
+- host Nginx di depan container
+- managed MySQL di belakang runtime
 
-1. **Login ke DigitalOcean Dashboard**
+Gunakan workflow GitHub Actions droplet rollout sebagai source of truth operasional:
 
-   - Buka https://cloud.digitalocean.com/
-   - Navigate ke "Apps"
+- `.github/workflows/deploy-staging.yml`
+- `.github/workflows/deploy-production.yml`
+- `deploy/scripts/verify-droplet-api.sh`
+- `scripts/smoke-test.js`
 
-2. **Create New App**
+Contoh env penting yang tetap harus konsisten dengan runtime canonical saat ini:
 
-   - Click "Create App"
-   - Pilih "GitHub" sebagai source
-   - Authorize GitHub dan pilih repository `Infinit_Track_BE`
-   - Pilih branch `master` (atau branch staging Anda)
-
-3. **Upload App Spec**
-
-   - Pilih opsi "Edit Your App Spec"
-   - Copy-paste isi dari `.do/app.yaml`
-   - Update `github.repo` dengan username GitHub Anda
-
-4. **Configure Environment Variables (CRITICAL)**
-
-   Set environment variables berikut di Dashboard → Apps → Settings → Environment Variables:
-
-   **Database (Required):**
-
-   ```
-   DB_HOST=<your-db-host>
-   DB_NAME=<your-db-name>
-   DB_USER=<your-db-user>
-   DB_PASS=<your-db-password>
-   ```
-
-   **JWT (Required):**
-
-   ```
-   JWT_SECRET=<generate-random-secure-string>
-   ```
-
-   **Optional Services:**
-
-   ```
-   GEOAPIFY_KEY=<your-geoapify-key>
-   ```
-
-   **Media Storage:**
-
-   ```env
-   SPACES_ENDPOINT=sgp1.digitaloceanspaces.com
-   SPACES_REGION=sgp1
-   SPACES_BUCKET=infinite-track-staging-sgp1
-   SPACES_ACCESS_KEY_ID=<your-spaces-access-key>
-   SPACES_SECRET_ACCESS_KEY=<your-spaces-secret-key>
-   ```
-
-   **Optional transitional legacy cleanup:**
-
-   ```env
-   CLOUDINARY_CLOUD_NAME=<your-cloudinary-cloud-name>
-   CLOUDINARY_API_KEY=<your-cloudinary-api-key>
-   CLOUDINARY_API_SECRET=<your-cloudinary-api-secret>
-   ```
-
-5. **Deploy**
-   - Review konfigurasi
-   - Click "Create Resources"
-   - Tunggu hingga deployment selesai (~5-10 menit)
-
-### Method 2: Via GitHub Actions (Automated CD)
-
-Lihat file `.github/workflows/deploy-staging.yml` untuk workflow otomatis.
-
-**Prerequisites:**
-
-1. Set GitHub Secrets:
-
-   - `DIGITALOCEAN_ACCESS_TOKEN` - Token API dari DO
-   - Environment-specific secrets di GitHub Environments
-
-2. Workflow akan otomatis trigger saat:
-   - Push ke branch `master`
-   - Atau manual trigger via GitHub Actions tab
-
-## 🔒 Environment Variables Security
-
-### ⚠️ JANGAN commit secrets ke repository!
-
-**Secrets harus diset di:**
-
-- ✅ DigitalOcean Dashboard (untuk manual deploy)
-- ✅ GitHub Environments Secrets (untuk CI/CD)
-- ❌ JANGAN di `.env` file yang di-commit
-- ❌ JANGAN di `app.yaml` langsung
-
-## 🏥 Health Check
-
-App Platform akan melakukan health check ke endpoint `/health` setiap 10 detik:
-
-- **Success Response:** `{"status":"OK","timestamp":"..."}`
-- **HTTP Status:** 200
-
-Jika health check gagal 3x berturut-turut, container akan di-restart otomatis.
-
-## 📊 Monitoring & Logs
-
-### Via DigitalOcean Dashboard
-
-1. **Runtime Logs:**
-
-   - Dashboard → Apps → Your App → Runtime Logs
-   - Lihat console output dari aplikasi
-
-2. **Build Logs:**
-
-   - Dashboard → Apps → Your App → Activity
-   - Lihat log build process
-
-3. **Metrics:**
-   - Dashboard → Apps → Your App → Insights
-   - Monitor CPU, Memory, Request rate
-
-## 🔄 Update Deployment
-
-### Auto Deploy (Recommended)
-
-Push perubahan ke branch `master`:
-
-```bash
-git add .
-git commit -m "Update feature XYZ"
-git push origin master
+```env
+GEOAPIFY_API_KEY=<your-geoapify-key>
 ```
 
-DO App Platform akan otomatis detect dan deploy.
+## What This Folder Is For
 
-### Manual Deploy via Dashboard
+- Menyimpan snapshot konfigurasi backend App Platform lama
+- Membantu audit drift antara topologi lama vs runtime canonical saat ini
+- Menjadi referensi historis bila perlu menelusuri konfigurasi environment lama
 
-1. Dashboard → Apps → Your App
-2. Click "Create Deployment"
-3. Pilih branch/commit
-4. Click "Deploy"
+## What This Folder Is Not
 
-## 🎯 Verifikasi Setelah Deploy
+Folder ini bukan panduan deploy backend aktif, bukan checklist verifikasi live host, dan bukan source of truth untuk host staging/production yang berjalan sekarang.
 
-Checklist yang harus dilakukan:
+## Current Health Semantics
 
-1. **Health Check**
+Walau spesifikasi App Platform ini legacy, kontrak health backend aktif tetap seperti berikut:
 
-   ```bash
-   curl https://your-app-url.ondigitalocean.app/health
-   ```
+- `/livez` = process liveness
+- `/health` = dependency readiness
 
-   Expected: `{"status":"OK",...}`
+Ready response contoh:
 
-2. **API Docs**
+```json
+{"status":"OK","ready":true,"components":{"database":"ready","scheduler":"ready"},"missing":[],"timestamp":"..."}
+```
 
-   ```bash
-   curl https://your-app-url.ondigitalocean.app/docs
-   ```
+Not ready response contoh:
 
-   Should return Swagger UI
+```json
+{"status":"NOT_READY","ready":false,"components":{"database":"not_ready","scheduler":"ready"},"missing":["database"],"timestamp":"..."}
+```
 
-3. **Database Connection**
+Artinya:
 
-   - Check Runtime Logs untuk "Database connected successfully"
-   - Jika error, verifikasi DB credentials di Environment Variables
+- `/health` mengembalikan HTTP `200` hanya saat dependency startup benar-benar siap
+- `/health` mengembalikan HTTP `503` saat ada dependency belum siap
+- payload readiness harus tetap memuat `"components"` dan `"missing"`
+- operator harus memperhatikan `missing` array untuk menentukan blocker startup
 
-4. **CORS Configuration**
+## Migration Note
 
-   - Test API call dari frontend staging
-   - Verifikasi `CORS_ORIGIN` sudah diset dengan benar
+Jika suatu saat file `.do/app*.yaml` dipakai lagi untuk eksperimen, perlakukan itu sebagai jalur baru yang harus diverifikasi ulang terhadap:
 
-5. **Automated Jobs**
-   - Check logs untuk "All automated attendance jobs have been scheduled"
+- `CLAUDE.md`
+- `README.md`
+- workflow deploy aktif
+- runtime evidence dari host canonical
 
-## 🐛 Troubleshooting
-
-### Deploy Failed - Build Error
-
-- Check Build Logs di Activity tab
-- Biasanya issue: dependency tidak terinstall atau syntax error
-- Fix: pastikan `package.json` up-to-date
-
-### Deploy Success tapi Health Check Failed
-
-- Check Runtime Logs
-- Kemungkinan:
-  - Database connection gagal (cek DB_HOST, DB_USER, DB_PASS)
-  - Missing environment variable (cek JWT_SECRET)
-  - Port binding issue (pastikan PORT=3000)
-
-### 500 Internal Server Error
-
-- Check Runtime Logs untuk error details
-- Common issues:
-  - Missing JWT_SECRET
-  - Database connection timeout
-  - Missing required environment variables
-
-## 📝 Notes
-
-- **Instance Size:** Staging menggunakan `basic-xxs` (cost-effective)
-- **Region:** Singapore (`sgp1`) - sesuaikan jika perlu
-- **Auto-scaling:** Disabled untuk staging (manual scale via dashboard jika perlu)
-- **Database:** Pastikan menggunakan managed database DO atau external DB yang accessible
-
-## 🔗 Useful Links
-
-- [DO App Platform Docs](https://docs.digitalocean.com/products/app-platform/)
-- [App Spec Reference](https://docs.digitalocean.com/products/app-platform/reference/app-spec/)
-- [Environment Variables](https://docs.digitalocean.com/products/app-platform/how-to/use-environment-variables/)
-
+Sampai ada bukti runtime yang berubah, droplet + DOCR tetap menjadi jalur deploy backend resmi.

--- a/.do/app-production.yaml
+++ b/.do/app-production.yaml
@@ -1,3 +1,7 @@
+# Legacy/historical backend artifact only.
+# Canonical backend runtime is the droplet-hosted Docker Compose stack that pulls
+# registry.digitalocean.com/infinit-track/infinit-track-backend behind host Nginx.
+# Do not treat this App Platform spec as the active backend deployment source of truth.
 name: infinit-track-production
 region: sgp1
 
@@ -99,7 +103,7 @@ services:
         type: GENERAL
 
       # Optional: Geoapify Key (if needed)
-      - key: GEOAPIFY_KEY
+      - key: GEOAPIFY_API_KEY
         scope: RUN_TIME
         type: SECRET
 
@@ -115,7 +119,7 @@ services:
         type: GENERAL
 
       - key: SPACES_BUCKET
-        value: infinite-track-staging-sgp1
+        value: <production-spaces-bucket>
         scope: RUN_TIME
         type: GENERAL
 

--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -1,3 +1,7 @@
+# Legacy/historical backend artifact only.
+# Canonical backend runtime is the droplet-hosted Docker Compose stack that pulls
+# registry.digitalocean.com/infinit-track/infinit-track-backend behind host Nginx.
+# Do not treat this App Platform spec as the active backend deployment source of truth.
 name: infinit-track-staging
 region: sgp1
 
@@ -83,7 +87,7 @@ services:
         type: GENERAL
       
       # Optional: Geoapify Key (if needed)
-      - key: GEOAPIFY_KEY
+      - key: GEOAPIFY_API_KEY
         scope: RUN_TIME
         type: SECRET
       

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,18 +1,27 @@
 name: Deploy to Production
 
 on:
-  workflow_dispatch: # Manual trigger only for production
+  workflow_dispatch:
     inputs:
       confirm:
         description: 'Type "deploy-to-production" to confirm'
         required: true
         default: ''
 
+permissions:
+  contents: read
+
 env:
   NODE_VERSION: '18'
+  DOCKER_IMAGE: registry.digitalocean.com/infinit-track/infinit-track-backend
+  PRODUCTION_SSH_HOST: ${{ vars.PRODUCTION_SSH_HOST }}
+  PRODUCTION_SSH_USER: ${{ vars.PRODUCTION_SSH_USER }}
+  PRODUCTION_DEPLOY_PATH: ${{ vars.PRODUCTION_DEPLOY_PATH }}
+  PRODUCTION_PUBLIC_DOMAIN: ${{ vars.PRODUCTION_PUBLIC_DOMAIN }}
+  PRODUCTION_PUBLIC_BASE_URL: ${{ vars.PRODUCTION_PUBLIC_BASE_URL }}
+  PRODUCTION_EXPECTED_IP: ${{ vars.PRODUCTION_EXPECTED_IP }}
 
 jobs:
-  # Job 1: Validate confirmation
   validate:
     name: Validate Deployment Request
     runs-on: ubuntu-latest
@@ -21,12 +30,10 @@ jobs:
       - name: Check confirmation
         run: |
           if [ "${{ github.event.inputs.confirm }}" != "deploy-to-production" ]; then
-            echo "❌ Deployment not confirmed. Please type 'deploy-to-production' exactly."
+            echo "Deployment not confirmed. Type 'deploy-to-production' exactly."
             exit 1
           fi
-          echo "✅ Deployment confirmed"
 
-  # Job 2: Run tests
   test:
     name: Lint & Test
     runs-on: ubuntu-latest
@@ -57,96 +64,135 @@ jobs:
           DB_USER: test_user
           DB_PASS: test_pass
           JWT_SECRET: test_secret_for_ci_only
+          CLOUDINARY_CLOUD_NAME: test_cloud
+          CLOUDINARY_API_KEY: test_key
+          CLOUDINARY_API_SECRET: test_secret
 
-  # Job 3: Deploy to production
-  deploy-production:
-    name: Deploy to Production
+  build-push:
+    name: Build & Push Docker Image
     runs-on: ubuntu-latest
     needs: test
-
-    environment:
-      name: production
-      url: https://infinit-track-api.yourdomain.com
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Install doctl
         uses: digitalocean/action-doctl@v2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
-      - name: Create manual backup reminder
-        run: |
-          echo "⚠️  PRODUCTION DEPLOYMENT"
-          echo "================================"
-          echo "Please confirm:"
-          echo "1. ✅ Manual database backup created"
-          echo "2. ✅ Team notified of deployment"
-          echo "3. ✅ Staging tests passed"
-          echo "4. ✅ Ready for potential rollback"
-          echo ""
-          echo "Proceeding with deployment in 10 seconds..."
-          sleep 10
+      - name: Login to DOCR
+        run: doctl registry login --expiry-seconds 1200
 
-      - name: Deploy to DigitalOcean App Platform
-        run: |
-          APP_ID="${{ secrets.DO_APP_ID_PRODUCTION }}"
+      - name: Build and push immutable image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.DOCKER_IMAGE }}:latest
+            ${{ env.DOCKER_IMAGE }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
-          if [ -z "$APP_ID" ]; then
-            echo "❌ DO_APP_ID_PRODUCTION secret is not set!"
-            exit 1
-          fi
-
-          echo "🚀 Deploying to PRODUCTION - App ID: $APP_ID"
-
-          # Trigger deployment
-          doctl apps create-deployment $APP_ID --wait
-
-          echo "✅ Production deployment triggered!"
-
-      - name: Wait for deployment
-        run: |
-          echo "⏳ Waiting for production deployment to be live..."
-          sleep 60  # Longer wait for production
-
-      - name: Get deployment status
-        run: |
-          APP_ID="${{ secrets.DO_APP_ID_PRODUCTION }}"
-          doctl apps get $APP_ID --format ID,Tier,Phase,ActiveDeployment.Phase
-
-      - name: Production deployment summary
-        run: |
-          echo "## 🎉 Production Deployment Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "✅ Production deployment completed successfully" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**App URL:** https://infinit-track-api.yourdomain.com" >> $GITHUB_STEP_SUMMARY
-          echo "**Health Check:** https://infinit-track-api.yourdomain.com/health" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**⚠️  Post-Deployment Checklist:**" >> $GITHUB_STEP_SUMMARY
-          echo "- [ ] Health endpoint returns 200 OK" >> $GITHUB_STEP_SUMMARY
-          echo "- [ ] Database connection successful (check logs)" >> $GITHUB_STEP_SUMMARY
-          echo "- [ ] Migrations ran successfully" >> $GITHUB_STEP_SUMMARY
-          echo "- [ ] Cron jobs are scheduled" >> $GITHUB_STEP_SUMMARY
-          echo "- [ ] Test critical API endpoints" >> $GITHUB_STEP_SUMMARY
-          echo "- [ ] Verify CORS from production frontend" >> $GITHUB_STEP_SUMMARY
-          echo "- [ ] Monitor error logs for 15 minutes" >> $GITHUB_STEP_SUMMARY
-
-  # Job 4: Notify team
-  notify:
-    name: Notify Deployment Complete
+  deploy-production:
+    name: Deploy to Production Droplet
     runs-on: ubuntu-latest
-    needs: deploy-production
-    if: always()
+    needs: build-push
+
+    environment:
+      name: production
+      url: ${{ vars.PRODUCTION_PUBLIC_BASE_URL }}
 
     steps:
-      - name: Deployment result
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate production runtime contract
         run: |
-          if [ "${{ needs.deploy-production.result }}" == "success" ]; then
-            echo "✅ Production deployment completed successfully!"
-          else
-            echo "❌ Production deployment failed! Check logs immediately."
-            exit 1
-          fi
+          for value in \
+            "$PRODUCTION_SSH_HOST" \
+            "$PRODUCTION_SSH_USER" \
+            "$PRODUCTION_DEPLOY_PATH" \
+            "$PRODUCTION_PUBLIC_DOMAIN" \
+            "$PRODUCTION_PUBLIC_BASE_URL" \
+            "$PRODUCTION_EXPECTED_IP"
+          do
+            if [ -z "$value" ]; then
+              echo "Missing required production runtime variable. Check GitHub environment vars."
+              exit 1
+            fi
+          done
+
+      - name: Configure SSH key
+        run: |
+          mkdir -p "$HOME/.ssh"
+          printf '%s\n' '${{ secrets.PRODUCTION_SSH_PRIVATE_KEY }}' > "$HOME/.ssh/production.key"
+          chmod 600 "$HOME/.ssh/production.key"
+          ssh-keyscan -H "$PRODUCTION_SSH_HOST" >> "$HOME/.ssh/known_hosts"
+
+      - name: Deploy selected image on production droplet
+        run: |
+          ssh -i "$HOME/.ssh/production.key" -o IdentitiesOnly=yes "$PRODUCTION_SSH_USER@$PRODUCTION_SSH_HOST" "
+            set -euo pipefail
+            cd '$PRODUCTION_DEPLOY_PATH'
+            echo '${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}' | docker login registry.digitalocean.com -u doctl --password-stdin
+            export BACKEND_IMAGE='$DOCKER_IMAGE'
+            export BACKEND_IMAGE_TAG='${GITHUB_SHA}'
+            docker compose pull app
+            docker compose up -d --force-recreate app
+            docker compose exec -T app npm run migrate
+            chmod +x ./deploy/scripts/verify-droplet-api.sh
+            DOMAIN='$PRODUCTION_PUBLIC_DOMAIN' EXPECTED_IP='$PRODUCTION_EXPECTED_IP' ./deploy/scripts/verify-droplet-api.sh
+            docker compose exec -T app npm run migrate:status
+          "
+
+      - name: Run blocking smoke gate against production host
+        run: npm run smoke-test "$PRODUCTION_PUBLIC_BASE_URL"
+
+      - name: Deployment summary
+        run: |
+          echo "## Production Deployment Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Immutable image published: \`${DOCKER_IMAGE}:${GITHUB_SHA}\`" >> $GITHUB_STEP_SUMMARY
+          echo "Droplet runtime updated via Docker Compose" >> $GITHUB_STEP_SUMMARY
+          echo "Migrations executed on production runtime" >> $GITHUB_STEP_SUMMARY
+          echo "Remote readiness verification passed" >> $GITHUB_STEP_SUMMARY
+          echo "Smoke gate passed against ${PRODUCTION_PUBLIC_BASE_URL}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Canonical host: ${PRODUCTION_PUBLIC_BASE_URL}" >> $GITHUB_STEP_SUMMARY
+          echo "Health endpoint: ${PRODUCTION_PUBLIC_BASE_URL}/health" >> $GITHUB_STEP_SUMMARY
+          echo "Liveness endpoint: ${PRODUCTION_PUBLIC_BASE_URL}/livez" >> $GITHUB_STEP_SUMMARY
+          echo "API docs: ${PRODUCTION_PUBLIC_BASE_URL}/docs" >> $GITHUB_STEP_SUMMARY
+
+  notify-failure:
+    name: Notify on Failure
+    runs-on: ubuntu-latest
+    needs: [validate, test, build-push, deploy-production]
+    if: failure()
+
+    steps:
+      - name: Deployment failed
+        run: |
+          echo "## Production Deployment Failed" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "The production release path is blocked until confirmation, lint, test, image publication, droplet rollout, migrations, and smoke verification all pass." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Investigate:" >> $GITHUB_STEP_SUMMARY
+          echo "- DOCR image publication logs" >> $GITHUB_STEP_SUMMARY
+          echo "- Production droplet rollout command output" >> $GITHUB_STEP_SUMMARY
+          echo "- ./deploy/scripts/verify-droplet-api.sh result" >> $GITHUB_STEP_SUMMARY
+          echo "- npm run smoke-test ${PRODUCTION_PUBLIC_BASE_URL}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -3,17 +3,26 @@ name: Deploy to Staging
 on:
   push:
     branches:
-      - master # Trigger on push to master branch
+      - master
   pull_request:
     branches:
-      - master # Also run on PR to master (for testing)
-  workflow_dispatch: # Allow manual trigger from GitHub Actions tab
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 env:
-  NODE_VERSION: '18' # Match your Node.js version
+  NODE_VERSION: '18'
+  DOCKER_IMAGE: registry.digitalocean.com/infinit-track/infinit-track-backend
+  STAGING_SSH_HOST: ${{ vars.STAGING_SSH_HOST }}
+  STAGING_SSH_USER: ${{ vars.STAGING_SSH_USER }}
+  STAGING_DEPLOY_PATH: ${{ vars.STAGING_DEPLOY_PATH }}
+  STAGING_PUBLIC_DOMAIN: ${{ vars.STAGING_PUBLIC_DOMAIN }}
+  STAGING_PUBLIC_BASE_URL: ${{ vars.STAGING_PUBLIC_BASE_URL }}
+  STAGING_EXPECTED_IP: ${{ vars.STAGING_EXPECTED_IP }}
 
 jobs:
-  # Job 1: Lint and Test
   test:
     name: Lint & Test
     runs-on: ubuntu-latest
@@ -33,7 +42,6 @@ jobs:
 
       - name: Run linter
         run: npm run lint
-        continue-on-error: true # Don't fail build on lint warnings
 
       - name: Run tests
         run: npm test
@@ -47,96 +55,134 @@ jobs:
           CLOUDINARY_CLOUD_NAME: test_cloud
           CLOUDINARY_API_KEY: test_key
           CLOUDINARY_API_SECRET: test_secret
-        continue-on-error: false # Fail build on test failures
 
-  # Job 2: Deploy to DigitalOcean App Platform (Staging)
-  deploy-staging:
-    name: Deploy to Staging
+  build-push:
+    name: Build & Push Docker Image
     runs-on: ubuntu-latest
-    needs: test # Run only after tests pass
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-
-    environment:
-      name: staging
-      url: https://infinit-track-staging.ondigitalocean.app
+    needs: test
+    if: github.event_name != 'pull_request'
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Install doctl
         uses: digitalocean/action-doctl@v2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
-      - name: Deploy to DigitalOcean App Platform
+      - name: Login to DOCR
+        run: doctl registry login --expiry-seconds 1200
+
+      - name: Build and push immutable image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.DOCKER_IMAGE }}:latest
+            ${{ env.DOCKER_IMAGE }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy-staging:
+    name: Deploy to Staging Droplet
+    runs-on: ubuntu-latest
+    needs: build-push
+    if: github.event_name != 'pull_request'
+
+    environment:
+      name: staging
+      url: ${{ vars.STAGING_PUBLIC_BASE_URL }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate staging runtime contract
         run: |
-          # Get app ID (you need to set this after creating the app)
-          APP_ID="${{ secrets.DO_APP_ID_STAGING }}"
+          for value in \
+            "$STAGING_SSH_HOST" \
+            "$STAGING_SSH_USER" \
+            "$STAGING_DEPLOY_PATH" \
+            "$STAGING_PUBLIC_DOMAIN" \
+            "$STAGING_PUBLIC_BASE_URL" \
+            "$STAGING_EXPECTED_IP"
+          do
+            if [ -z "$value" ]; then
+              echo "Missing required staging runtime variable. Check GitHub environment vars."
+              exit 1
+            fi
+          done
 
-          if [ -z "$APP_ID" ]; then
-            echo "❌ DO_APP_ID_STAGING secret is not set!"
-            echo "Please set it in GitHub Secrets after creating the app on DigitalOcean"
-            exit 1
-          fi
-
-          echo "🚀 Triggering deployment for App ID: $APP_ID"
-
-          # Trigger deployment
-          doctl apps create-deployment $APP_ID --wait
-
-          echo "✅ Deployment triggered successfully!"
-
-      - name: Wait for deployment to complete
+      - name: Configure SSH key
         run: |
-          echo "⏳ Waiting for deployment to be live..."
-          sleep 30  # Give it time to start
+          mkdir -p "$HOME/.ssh"
+          printf '%s\n' '${{ secrets.STAGING_SSH_PRIVATE_KEY }}' > "$HOME/.ssh/staging.key"
+          chmod 600 "$HOME/.ssh/staging.key"
+          ssh-keyscan -H "$STAGING_SSH_HOST" >> "$HOME/.ssh/known_hosts"
 
-      - name: Get deployment status
+      - name: Deploy selected image on staging droplet
         run: |
-          APP_ID="${{ secrets.DO_APP_ID_STAGING }}"
-          doctl apps get $APP_ID --format ID,Tier,Phase,ActiveDeployment.Phase
+          ssh -i "$HOME/.ssh/staging.key" -o IdentitiesOnly=yes "$STAGING_SSH_USER@$STAGING_SSH_HOST" "
+            set -euo pipefail
+            cd '$STAGING_DEPLOY_PATH'
+            echo '${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}' | docker login registry.digitalocean.com -u doctl --password-stdin
+            export BACKEND_IMAGE='$DOCKER_IMAGE'
+            export BACKEND_IMAGE_TAG='${GITHUB_SHA}'
+            docker compose pull app
+            docker compose up -d --force-recreate app
+            docker compose exec -T app npm run migrate
+            chmod +x ./deploy/scripts/verify-droplet-api.sh
+            DOMAIN='$STAGING_PUBLIC_DOMAIN' EXPECTED_IP='$STAGING_EXPECTED_IP' ./deploy/scripts/verify-droplet-api.sh
+            docker compose exec -T app npm run migrate:status
+          "
 
-      - name: Run smoke tests
-        run: |
-          npm run smoke-test https://infinit-track-staging.ondigitalocean.app
-        continue-on-error: true
+      - name: Run blocking smoke gate against staging host
+        run: npm run smoke-test "$STAGING_PUBLIC_BASE_URL"
 
       - name: Deployment summary
         run: |
           echo "## 🚀 Staging Deployment Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "✅ Deployment triggered successfully" >> $GITHUB_STEP_SUMMARY
+          echo "✅ Immutable image published: \\`${DOCKER_IMAGE}:${GITHUB_SHA}\\`" >> $GITHUB_STEP_SUMMARY
+          echo "✅ Droplet runtime updated via Docker Compose" >> $GITHUB_STEP_SUMMARY
+          echo "✅ Migrations executed on staging runtime" >> $GITHUB_STEP_SUMMARY
+          echo "✅ Remote readiness verification passed" >> $GITHUB_STEP_SUMMARY
+          echo "✅ Smoke gate passed against ${STAGING_PUBLIC_BASE_URL}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**App URL:** https://infinit-track-staging.ondigitalocean.app" >> $GITHUB_STEP_SUMMARY
-          echo "**Health Check:** https://infinit-track-staging.ondigitalocean.app/health" >> $GITHUB_STEP_SUMMARY
-          echo "**API Docs:** https://infinit-track-staging.ondigitalocean.app/docs" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Smoke Tests:** See step above for results" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Next Steps:**" >> $GITHUB_STEP_SUMMARY
-          echo "1. Verify smoke tests passed ✅" >> $GITHUB_STEP_SUMMARY
-          echo "2. Check database connection in logs" >> $GITHUB_STEP_SUMMARY
-          echo "3. Test critical user flows" >> $GITHUB_STEP_SUMMARY
-          echo "4. Monitor error logs for 15 minutes" >> $GITHUB_STEP_SUMMARY
+          echo "**Canonical host:** ${STAGING_PUBLIC_BASE_URL}" >> $GITHUB_STEP_SUMMARY
+          echo "**Health endpoint:** ${STAGING_PUBLIC_BASE_URL}/health" >> $GITHUB_STEP_SUMMARY
+          echo "**Liveness endpoint:** ${STAGING_PUBLIC_BASE_URL}/livez" >> $GITHUB_STEP_SUMMARY
+          echo "**API docs:** ${STAGING_PUBLIC_BASE_URL}/docs" >> $GITHUB_STEP_SUMMARY
 
-  # Job 3: Notify on failure
   notify-failure:
     name: Notify on Failure
     runs-on: ubuntu-latest
-    needs: [test, deploy-staging]
+    needs: [test, build-push, deploy-staging]
     if: failure()
 
     steps:
       - name: Deployment failed
         run: |
-          echo "## ❌ Deployment Failed" >> $GITHUB_STEP_SUMMARY
+          echo "## ❌ Staging Deployment Failed" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "The staging deployment has failed. Please check the logs above for details." >> $GITHUB_STEP_SUMMARY
+          echo "The staging release path is blocked until lint, test, image publication, droplet rollout, migrations, and smoke verification all pass." >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Common Issues:**" >> $GITHUB_STEP_SUMMARY
-          echo "- Tests failed" >> $GITHUB_STEP_SUMMARY
-          echo "- Linting errors" >> $GITHUB_STEP_SUMMARY
-          echo "- DO_APP_ID_STAGING secret not set" >> $GITHUB_STEP_SUMMARY
-          echo "- DIGITALOCEAN_ACCESS_TOKEN invalid" >> $GITHUB_STEP_SUMMARY
-          echo "- Migration errors" >> $GITHUB_STEP_SUMMARY
+          echo "**Investigate:**" >> $GITHUB_STEP_SUMMARY
+          echo "- DOCR image publication logs" >> $GITHUB_STEP_SUMMARY
+          echo "- Staging droplet rollout command output" >> $GITHUB_STEP_SUMMARY
+          echo "- ./deploy/scripts/verify-droplet-api.sh result" >> $GITHUB_STEP_SUMMARY
+          echo "- npm run smoke-test ${STAGING_PUBLIC_BASE_URL}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -1,22 +1,25 @@
-name: Build, Push & Deploy
+name: Publish Backend Image
 
 on:
-  push:
-    branches: [master]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
+  NODE_VERSION: '18'
   DOCKER_IMAGE: registry.digitalocean.com/infinit-track/infinit-track-backend
 
 jobs:
   test:
     name: Lint & Test
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: ${{ env.NODE_VERSION }}
           cache: npm
       - run: npm ci
       - run: npm run lint
@@ -28,11 +31,15 @@ jobs:
           DB_NAME: test_db
           DB_USER: test_user
           DB_PASS: test_pass
+          CLOUDINARY_CLOUD_NAME: test_cloud
+          CLOUDINARY_API_KEY: test_key
+          CLOUDINARY_API_SECRET: test_secret
 
   build-push:
     name: Build & Push Docker Image
     runs-on: ubuntu-latest
     needs: test
+
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
@@ -45,37 +52,16 @@ jobs:
         with:
           context: .
           push: true
-          # Publish both immutable SHA tags and latest; droplet runtime should pin SHA explicitly.
           tags: |
             ${{ env.DOCKER_IMAGE }}:latest
             ${{ env.DOCKER_IMAGE }}:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  deploy:
-    name: Deploy to Kubernetes
-    runs-on: ubuntu-latest
-    needs: build-push
-    environment:
-      name: production
-      url: https://api.your-domain.com
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up kubeconfig
+      - name: Publish summary
         run: |
-          mkdir -p $HOME/.kube
-          echo "${{ secrets.KUBECONFIG }}" | base64 -d > $HOME/.kube/config
-      - name: Apply Kubernetes manifests
-        run: kubectl apply -f k8s/
-
-      - name: Deploy to K8s
-        run: |
-          kubectl set image deployment/infinit-track-app \
-            app=${{ env.DOCKER_IMAGE }}:${{ github.sha }} \
-            -n infinit-track
-          kubectl rollout status deployment/infinit-track-app \
-            -n infinit-track --timeout=300s
-      - name: Verify deployment
-        run: |
-          kubectl get pods -n infinit-track
-          kubectl get svc -n infinit-track
+          echo "## Backend Image Published" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Published immutable image: \`${DOCKER_IMAGE}:${GITHUB_SHA}\`" >> $GITHUB_STEP_SUMMARY
+          echo "Published rolling tag: \`${DOCKER_IMAGE}:latest\`" >> $GITHUB_STEP_SUMMARY
+          echo "Use the immutable SHA tag for droplet rollout." >> $GITHUB_STEP_SUMMARY

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ CI: GitHub Actions (`.github/workflows/ci.yml`) — checkout → Node 18 → `np
 - `/api/users` → `user.controller.js` | `/api/bookings` → `booking.controller.js`
 - `/api/wfa` → `wfa.controller.js` | `/api/summary` → `summary.controller.js`
 - `/api/discipline` → `discipline.controller.js` | `/api` → `referenceData.controller.js`
-- `/health` — health check
+- `/livez` — process liveness | `/health` — dependency readiness
 
 **Database**: MySQL via Sequelize 6 (`src/config/database.js`, timezone `+07:00`). Models in `src/models/*.js`, associations in `src/models/index.js`.
 
@@ -51,7 +51,7 @@ CI: GitHub Actions (`.github/workflows/ci.yml`) — checkout → Node 18 → `np
 
 **Timezone**: All business logic uses **WIB (Asia/Jakarta, UTC+7)** — set in server.js, Sequelize config, and scheduled job runtime.
 
-**Deployment**: Repository-managed deployment configuration is defined in `.do/app*.yaml` rather than root-level `docker-compose.yml`/`Dockerfile` artifacts. Use `DB_HOST=localhost` for local development; in managed or containerized environments, set `DB_HOST` to the database service hostname provided by that platform.
+**Deployment**: Canonical backend runtime is the droplet-hosted Docker Compose stack that pulls `registry.digitalocean.com/infinit-track/infinit-track-backend` by immutable `BACKEND_IMAGE_TAG`, with host Nginx in front of the container and managed MySQL behind it. Treat `.do/app*.yaml` and `k8s/` as legacy or historical backend paths unless current runtime evidence explicitly says otherwise. Use `DB_HOST=localhost` for local development; on the canonical droplet runtime, set `DB_HOST` to the managed database hostname for that environment.
 
 ## Search & Research Routing
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Sistem ini memiliki empat pilar fungsionalitas utama yang membuatnya lebih dari 
 
 ### **🛠️ Development Tools**
 
-- **Swagger/OpenAPI**, **ESLint + Prettier**, **PM2**
+- **Swagger/OpenAPI**, **ESLint + Prettier**, **Docker Compose**
 
 ## 4. Panduan Setup & Instalasi
 
@@ -135,8 +135,8 @@ npm run dev
 # Production mode
 npm start
 
-# Dengan PM2 (production deployment)
-npm run prod:pm2
+# Local Docker Compose runtime verification
+bash ./test-production.sh --local-base-url http://127.0.0.1:3005 --public-base-url http://127.0.0.1:3005
 ```
 
 Server akan berjalan di `http://localhost:3005` (atau port yang ditentukan di `.env`).
@@ -419,101 +419,103 @@ const disciplineFactors = {
 
 ### **🚀 8.1 CD Architecture Overview**
 
-Infinit Track Backend menggunakan **GitOps-style deployment** dengan DigitalOcean App Platform dan GitHub Actions untuk continuous deployment otomatis.
+Infinit Track Backend menggunakan **GitOps-style deployment** berbasis **DigitalOcean Container Registry (DOCR) + droplet-hosted Docker Compose runtime + host Nginx**. Image backend dibangun di CI, dipush ke `registry.digitalocean.com/infinit-track/infinit-track-backend`, lalu runtime droplet menarik image immutable melalui `BACKEND_IMAGE_TAG`.
 
 ```
-Development → Staging (Auto) → Production (Manual)
-     ↓              ↓                    ↓
-  Feature      Integration         Live Users
-  Testing       Testing            Real Data
+Development → Image Build → Staging Droplet → Production Droplet
+     ↓             ↓              ↓                    ↓
+  Feature      Immutable SHA   Integration         Live Users
+  Testing        Artifact       Verification        Real Data
 ```
 
 **Key Features:**
 
-- ✅ Automated staging deployment on push to `master`
-- ✅ Manual production deployment dengan approval workflow
-- ✅ Automated migrations dengan rollback safety
-- ✅ Health checks dan smoke tests otomatis
-- ✅ Zero-downtime deployments
-- ✅ Instant rollback capabilities
+- ✅ Canonical runtime backend ada di droplet, bukan App Platform
+- ✅ Image release dipin oleh `BACKEND_IMAGE_TAG`
+- ✅ Manual/CI deploy harus diverifikasi lewat `/livez` dan `/health`
+- ✅ Managed MySQL tetap terpisah per environment
+- ✅ Smoke/readiness verification adalah release gate, bukan best-effort check
+- ✅ Rollback dilakukan dengan mengembalikan tag image terakhir yang sehat
 
 ### **📋 8.2 Quick Start - First Deployment**
 
-#### **Step 1: Setup DigitalOcean**
+#### **Step 1: Prepare Runtime Targets**
+
+- Siapkan droplet target yang menjalankan Docker Compose backend.
+- Siapkan host Nginx yang mengarah ke container backend di droplet tersebut.
+- Siapkan managed MySQL per environment.
+- Pastikan runtime target menarik image dari DOCR, bukan build lokal ad-hoc.
+
+#### **Step 2: Configure GitHub Secrets & Environment Variables**
 
 ```bash
-# 1. Create DO apps (via dashboard)
-# - Staging: infinit-track-staging
-# - Production: infinit-track-production
-
-# 2. Get App IDs
-doctl apps list
-
-# 3. Configure environment variables (via DO Dashboard)
-# See: docs/ENVIRONMENT_VARIABLES.md
-```
-
-#### **Step 2: Configure GitHub Secrets**
-
-```bash
-# Repository Secrets (Settings → Secrets → Actions)
+# Shared repository secret
 DIGITALOCEAN_ACCESS_TOKEN=<your-do-token>
 
-# Environment Secrets (Settings → Environments)
-# staging environment:
-DO_APP_ID_STAGING=<staging-app-id>
+# Staging workflow input
+STAGING_SSH_PRIVATE_KEY=<private-key-for-root@168.144.33.33>
 
-# production environment (with required reviewers):
-DO_APP_ID_PRODUCTION=<production-app-id>
+# Production workflow inputs
+PRODUCTION_SSH_PRIVATE_KEY=<private-key-for-production-host>
+PRODUCTION_SSH_HOST=<production-ssh-host>
+PRODUCTION_SSH_USER=<production-ssh-user>
+PRODUCTION_DEPLOY_PATH=<absolute-path-to-backend-compose-runtime>
+PRODUCTION_PUBLIC_DOMAIN=<production-public-domain>
+PRODUCTION_PUBLIC_BASE_URL=<production-public-base-url>
+PRODUCTION_EXPECTED_IP=<production-public-ip>
 ```
 
-#### **Step 3: Deploy!**
+#### **Step 3: Deploy**
 
 ```bash
-# Staging (automatic)
+# Staging / release-candidate flow
 git add .
-git commit -m "Add new feature"
+git commit -m "Deploy-ready change"
 git push origin master
-# → GitHub Actions automatically deploys to staging
+# → push ke master memicu workflow staging:
+#   lint + test + DOCR publish + droplet rollout + migrate + blocking smoke gate
 
-# Production (manual, requires approval)
-# Go to GitHub Actions → Deploy to Production → Run workflow
-# Type: deploy-to-production
-# → Requires reviewer approval → Deploys to production
+# Optional: run staging workflow manually from GitHub Actions
+# → workflow_dispatch pada "Deploy to Staging"
+
+# Production / approved release flow
+# Trigger workflow "Deploy to Production" secara manual,
+# isi konfirmasi deploy-to-production,
+# lalu workflow menjalankan lint + test + DOCR publish + droplet rollout + migrate + blocking smoke gate.
 ```
 
 ### **🎯 8.3 Deployment Workflows**
 
-#### **Staging Deployment (Automatic)**
+#### **Staging Deployment**
 
-Triggers on every push to `master`:
+Canonical staging release should do this in order:
 
 ```yaml
 1. ✅ Lint Code
 2. ✅ Run Tests
-3. ✅ Deploy to DO App Platform
-4. ✅ Run Database Migrations
-5. ✅ Execute Smoke Tests
-6. ✅ Health Check Verification
+3. ✅ Build and push immutable DOCR image
+4. ✅ Update droplet runtime to selected BACKEND_IMAGE_TAG
+5. ✅ Run migrations against staging database
+6. ✅ Verify /livez and /health as blocking checks
 ```
 
-**Staging URL:** `https://infinit-track-staging.ondigitalocean.app`
+Staging host is environment-specific and must come from the GitHub staging environment (`STAGING_PUBLIC_BASE_URL`, `STAGING_PUBLIC_DOMAIN`, `STAGING_EXPECTED_IP`). Never hard-code the canonical production host into the staging workflow.
 
-#### **Production Deployment (Manual)**
+#### **Production Deployment**
 
-Manual trigger with confirmation + approval:
+Canonical production release should do this in order:
 
 ```yaml
-1. ✅ Validate Confirmation ("deploy-to-production")
+1. ✅ Validate release input / approval gate
 2. ✅ Lint & Test
-3. ⏸️  Wait for Approval (required reviewers)
-4. ✅ Deploy to Production
-5. ✅ Run Migrations
-6. ✅ Smoke Tests
-7. ✅ 30-minute monitoring window
+3. ✅ Build or select immutable DOCR image
+4. ✅ Update production droplet runtime to selected BACKEND_IMAGE_TAG
+5. ✅ Run migrations against production database
+6. ✅ Verify /livez and /health as blocking checks
+7. ✅ Observe logs/metrics on the live host after release
 ```
 
-**Production URL:** `https://api.yourdomain.com`
+**Production host:** gunakan host canonical production yang benar-benar aktif di runtime; jangan treat placeholder domain sebagai source of truth.
 
 ### **🔒 8.4 Security & Environment Separation**
 
@@ -541,23 +543,28 @@ Manual trigger with confirmation + approval:
 Every deployment includes:
 
 ```bash
-# 1. Health Endpoint
-GET /health
-# Expected: {"status":"OK","timestamp":"..."}
+# 1. Process Liveness
+GET /livez
+# Expected: HTTP 200 with {"status":"OK","timestamp":"..."}
 
-# 2. Database Connection
+# 2. Dependency Readiness
+GET /health
+# Ready: HTTP 200 with {"status":"OK","ready":true,...}
+# Not ready: HTTP 503 with {"status":"NOT_READY","missing":[...],...}
+
+# 3. Database Connection
 # Logs: "Database connected successfully"
 
-# 3. Security Headers
+# 4. Security Headers
 # X-Content-Type-Options, X-Frame-Options, etc.
 
-# 4. Authentication
+# 5. Authentication
 # Protected endpoints return 401 without auth
 
-# 5. CORS Configuration
+# 6. CORS Configuration
 # Proper origin whitelisting
 
-# 6. Response Time
+# 7. Response Time
 # Average < 1 second
 ```
 
@@ -566,24 +573,29 @@ GET /health
 Automated tests after each deployment:
 
 ```bash
-# Run locally
-npm run smoke-test https://staging-api.app
+# Run locally against the current staging host
+npm run smoke-test "$STAGING_PUBLIC_BASE_URL"
 
 # Included in GitHub Actions automatically
-# Tests: Health, Docs, CORS, Security, Auth, Performance
+# Tests: Liveness, Readiness, Docs, CORS, Security, Auth, Performance
 ```
 
 #### **First 5 Things to Check Post-Deploy**
 
-1. **✅ Health Endpoint**
+1. **✅ Liveness & Readiness**
 
    ```bash
-   curl https://api.yourdomain.com/health
+   curl "$STAGING_PUBLIC_BASE_URL/livez"
+   curl "$STAGING_PUBLIC_BASE_URL/health"
    ```
+
+   - `/livez` should return HTTP `200`
+   - `/health` should return HTTP `200` only when startup dependencies are ready
+   - If dependencies are missing, `/health` should return HTTP `503` and a `missing` array
 
 2. **✅ Runtime Logs**
 
-   - Check DO Dashboard → Runtime Logs
+   - Check the droplet container logs (`docker compose logs app --tail=200`)
    - Look for "Database connected successfully"
    - No error logs
 
@@ -605,14 +617,13 @@ npm run smoke-test https://staging-api.app
 
 #### **Quick Rollback (5 minutes)**
 
-**Via DigitalOcean Dashboard:**
+**Via droplet runtime:**
 
-```
-1. Dashboard → Apps → Your App
-2. Deployments tab
-3. Find last good deployment
-4. Click "Redeploy"
-5. Monitor health checks
+```bash
+export BACKEND_IMAGE_TAG=<last-known-good-sha>
+docker compose pull app
+docker compose up -d --force-recreate app
+./deploy/scripts/verify-droplet-api.sh
 ```
 
 #### **Git Rollback**
@@ -635,7 +646,7 @@ git push origin master
 ```bash
 # Only if migration caused issues
 1. Stop application (prevent further writes)
-2. Restore from backup (DO Dashboard)
+2. Restore from managed database backup (DigitalOcean database tooling)
 3. Rollback application code
 4. Restart application
 5. Verify functionality
@@ -645,7 +656,7 @@ git push origin master
 
 Comprehensive guides tersedia di folder `docs/`:
 
-- **🏗️ [DigitalOcean Setup](./.do/README.md)** - App Platform configuration
+- **🏗️ [DigitalOcean Setup](./docs/droplet-docr-runtime.md)** - Canonical droplet + DOCR runtime procedure
 - **🔐 [Environment Variables](./docs/ENVIRONMENT_VARIABLES.md)** - Complete ENV guide
 - **🗄️ [Database Migrations](./docs/DATABASE_MIGRATION.md)** - Migration best practices
 - **🔒 [Security Checklist](./docs/SECURITY_CHECKLIST.md)** - Pre/post deploy security
@@ -668,8 +679,8 @@ npm run smoke-test <url>     # Test deployed instance
 npm run migrate:undo         # Rollback last migration (dev only)
 
 # Production Monitoring
-curl https://api.yourdomain.com/health                  # Health check
-curl https://api.yourdomain.com/docs/openapi.yaml      # Published API contract
+curl "$PRODUCTION_PUBLIC_BASE_URL/health"            # Health check
+curl "$PRODUCTION_PUBLIC_BASE_URL/docs/openapi.yaml" # Published API contract
 ```
 
 ### **🎯 8.9 Development Workflow Best Practices**
@@ -685,14 +696,14 @@ git push origin feature/new-feature
 # → Tests run automatically
 # → Code review by team
 
-# 3. Merge to Master
-# → Staging deploys automatically
-# → Verify in staging
+# 3. Promote reviewed code to master
+# → Push/merge to master triggers staging droplet rollout automatically
+# → Verify canonical staging host after rollout completes
 
 # 4. Production Deploy (when ready)
-# → Manual trigger via GitHub Actions
-# → Approval from reviewer
-# → Monitor for 30 minutes
+# → Manual trigger via GitHub Actions: "Deploy to Production"
+# → Type deploy-to-production for confirmation
+# → Monitor live host and logs after smoke gate passes
 ```
 
 ### **🔧 8.10 Troubleshooting Deployment Issues**
@@ -712,13 +723,13 @@ git push origin feature/new-feature
 #### **Production Health Check Failed**
 
 ```bash
-# Check DigitalOcean logs
-1. Dashboard → Apps → Runtime Logs
-2. Look for error messages
+# Check droplet/runtime logs
+1. SSH to the target droplet
+2. Review `docker compose logs app --tail=200`
 3. Common issues:
    - DB connection → Verify DB_HOST, DB_PASS
-   - Missing ENV → Check environment variables
-   - Migration failed → Check Build Logs
+   - Missing ENV → Check environment variables / env file
+   - Migration failed → Review deploy workflow and container command output
 ```
 
 #### **CORS Errors**
@@ -768,7 +779,8 @@ npm run health:check
 
 ```bash
 # Health check endpoints
-GET /health              # Basic server health
+GET /livez               # Process liveness
+GET /health              # Dependency readiness
 GET /docs                # Interactive API documentation
 GET /docs/openapi.yaml   # Published OpenAPI contract
 ```
@@ -887,7 +899,7 @@ try {
 - **🚀 CD & Deployment:**
   - [`docs/PRODUCTION_DEPLOYMENT.md`](docs/PRODUCTION_DEPLOYMENT.md) - Complete production deployment guide
   - [`docs/GITHUB_ACTIONS_SETUP.md`](docs/GITHUB_ACTIONS_SETUP.md) - GitHub Actions CI/CD setup
-  - [`.do/README.md`](.do/README.md) - DigitalOcean App Platform configuration
+  - [`docs/droplet-docr-runtime.md`](docs/droplet-docr-runtime.md) - Canonical droplet + DOCR runtime procedure
 - **🔐 Security & Configuration:**
   - [`docs/ENVIRONMENT_VARIABLES.md`](docs/ENVIRONMENT_VARIABLES.md) - Environment variables reference
   - [`docs/SECURITY_CHECKLIST.md`](docs/SECURITY_CHECKLIST.md) - Security best practices
@@ -901,7 +913,8 @@ try {
 
 ### **🔗 Quick Links**
 
-- **Health Check:** [`http://localhost:3005/health`](http://localhost:3005/health)
+- **Process Liveness:** [`http://localhost:3005/livez`](http://localhost:3005/livez)
+- **Dependency Readiness:** [`http://localhost:3005/health`](http://localhost:3005/health)
 - **API Documentation:** [`http://localhost:3005/docs`](http://localhost:3005/docs)
 - **OpenAPI Spec:** [`http://localhost:3005/docs/openapi.yaml`](http://localhost:3005/docs/openapi.yaml)
 

--- a/deploy/scripts/verify-droplet-api.sh
+++ b/deploy/scripts/verify-droplet-api.sh
@@ -1,13 +1,102 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DOMAIN="${DOMAIN:-api.infinite-track.tech}"
-EXPECTED_IP="${EXPECTED_IP:-168.144.33.33}"
-LOCAL_HEALTH_URL="${LOCAL_HEALTH_URL:-http://127.0.0.1:3005/health}"
-PUBLIC_HEALTH_URL="${PUBLIC_HEALTH_URL:-https://${DOMAIN}/health}"
+DOMAIN="${DOMAIN:?DOMAIN is required}"
+EXPECTED_IP="${EXPECTED_IP:?EXPECTED_IP is required}"
+LOCAL_LIVEZ_URL="${LOCAL_LIVEZ_URL:-http://127.0.0.1:3005/livez}"
+LOCAL_READINESS_URL="${LOCAL_READINESS_URL:-http://127.0.0.1:3005/health}"
+PUBLIC_LIVEZ_URL="${PUBLIC_LIVEZ_URL:-https://${DOMAIN}/livez}"
+PUBLIC_READINESS_URL="${PUBLIC_READINESS_URL:-https://${DOMAIN}/health}"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  printf 'DEPENDENCY_FAIL python3 is required for JSON readiness verification\n' >&2
+  exit 1
+fi
+
+check_json_endpoint() {
+  local url="$1"
+  local label="$2"
+  local mode="$3"
+  local response_file
+  local status
+
+  response_file="$(mktemp)"
+
+  if ! status="$(curl --silent --show-error --output "$response_file" --write-out '%{http_code}' "$url")"; then
+    rm -f "$response_file"
+    printf '%s_FAIL curl request failed for %s\n' "$label" "$url" >&2
+    exit 1
+  fi
+
+  python3 - "$response_file" "$status" "$label" "$url" "$mode" <<'PY'
+import json
+import sys
+
+response_file, status_code, label, url, mode = sys.argv[1:]
+status_code = int(status_code)
+
+with open(response_file, 'r', encoding='utf-8') as handle:
+    raw_body = handle.read()
+
+try:
+    data = json.loads(raw_body)
+except json.JSONDecodeError as exc:
+    print(f"{label}_FAIL invalid JSON from {url}: {exc}", file=sys.stderr)
+    print(raw_body, file=sys.stderr)
+    sys.exit(1)
+
+if status_code != 200:
+    print(f"{label}_FAIL unexpected HTTP {status_code} from {url}", file=sys.stderr)
+    print(json.dumps(data, ensure_ascii=False), file=sys.stderr)
+    sys.exit(1)
+
+if data.get('status') != 'OK':
+    print(f"{label}_FAIL unexpected status field from {url}", file=sys.stderr)
+    print(json.dumps(data, ensure_ascii=False), file=sys.stderr)
+    sys.exit(1)
+
+if mode == 'readiness':
+    if data.get('ready') is not True:
+        print(f"{label}_FAIL readiness flag is not true for {url}", file=sys.stderr)
+        print(json.dumps(data, ensure_ascii=False), file=sys.stderr)
+        sys.exit(1)
+    if not isinstance(data.get('components'), dict):
+        print(f"{label}_FAIL readiness components missing for {url}", file=sys.stderr)
+        print(json.dumps(data, ensure_ascii=False), file=sys.stderr)
+        sys.exit(1)
+    if not isinstance(data.get('missing'), list):
+        print(f"{label}_FAIL readiness missing array absent for {url}", file=sys.stderr)
+        print(json.dumps(data, ensure_ascii=False), file=sys.stderr)
+        sys.exit(1)
+
+print(json.dumps(data, ensure_ascii=False))
+print(f"{label}_OK")
+PY
+
+  rm -f "$response_file"
+}
 
 printf 'Checking DNS for %s...\n' "$DOMAIN"
-RESOLVED_IPS="$(getent ahostsv4 "$DOMAIN" | awk '{print $1}' | sort -u | tr '\n' ' ')"
+RESOLVED_IPS="$(python3 - "$DOMAIN" <<'PY'
+import socket
+import sys
+
+domain = sys.argv[1]
+
+try:
+    infos = socket.getaddrinfo(domain, None, socket.AF_INET, socket.SOCK_STREAM)
+except socket.gaierror as exc:
+    print(f"DNS_FAIL lookup failed for {domain}: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+addresses = sorted({info[4][0] for info in infos})
+if not addresses:
+    print(f"DNS_FAIL no IPv4 addresses resolved for {domain}", file=sys.stderr)
+    sys.exit(1)
+
+print(' '.join(addresses))
+PY
+)"
 printf 'Resolved IPv4: %s\n' "$RESOLVED_IPS"
 case " $RESOLVED_IPS " in
   *" $EXPECTED_IP "*) printf 'DNS_OK\n' ;;
@@ -19,9 +108,11 @@ if command -v docker >/dev/null 2>&1; then
   docker ps --filter name=infinit-track-app --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'
 fi
 
-printf 'Checking local backend health at %s...\n' "$LOCAL_HEALTH_URL"
-curl --fail --silent --show-error "$LOCAL_HEALTH_URL"
-printf '\nLOCAL_HEALTH_OK\n'
+printf 'Checking local backend liveness at %s...\n' "$LOCAL_LIVEZ_URL"
+check_json_endpoint "$LOCAL_LIVEZ_URL" 'LOCAL_LIVEZ' 'liveness'
+
+printf 'Checking local backend readiness at %s...\n' "$LOCAL_READINESS_URL"
+check_json_endpoint "$LOCAL_READINESS_URL" 'LOCAL_READINESS' 'readiness'
 
 if command -v nginx >/dev/null 2>&1; then
   printf 'Checking Nginx config...\n'
@@ -29,6 +120,8 @@ if command -v nginx >/dev/null 2>&1; then
   printf 'NGINX_CONFIG_OK\n'
 fi
 
-printf 'Checking public HTTPS health at %s...\n' "$PUBLIC_HEALTH_URL"
-curl --fail --silent --show-error "$PUBLIC_HEALTH_URL"
-printf '\nPUBLIC_HEALTH_OK\n'
+printf 'Checking public HTTPS liveness at %s...\n' "$PUBLIC_LIVEZ_URL"
+check_json_endpoint "$PUBLIC_LIVEZ_URL" 'PUBLIC_LIVEZ' 'liveness'
+
+printf 'Checking public HTTPS readiness at %s...\n' "$PUBLIC_READINESS_URL"
+check_json_endpoint "$PUBLIC_READINESS_URL" 'PUBLIC_READINESS' 'readiness'

--- a/docs/audits/2026-05-03-bookings-readiness-audit.md
+++ b/docs/audits/2026-05-03-bookings-readiness-audit.md
@@ -1,12 +1,12 @@
 # Bookings Readiness Audit — 2026-05-03
 
-## Interim status (Task 5 live verification findings captured)
-- This document now captures **Task 4 repository evidence** for bookings readiness across runtime routes, OpenAPI inventory, validators, controllers, and automated contract coverage.
-- This document now also captures **Task 5 live verification findings** from the parent session.
+## Final status (Task 6 readiness assessment captured)
+- This document captures **Task 4 repository evidence**, **Task 5 live verification findings**, and the **Task 6 final readiness assessment** for bookings readiness.
+- Fact: current repository evidence closes the earlier `GET /api/bookings` filter-mismatch concern and the earlier `DELETE /api/bookings/{id}` shared-location deletion concern.
 - Fact: unauthenticated live `GET` access to the bookings read endpoints is blocked with `401`.
 - Fact: authenticated live `GET` verification was not completed from this session because no valid live token could be obtained from available local credential sources without guessing.
 - Fact: live mutation verification for `POST`/`PATCH`/`DELETE` remains intentionally not performed because mutating staging actions are disallowed under the current constraint.
-- Final readiness decision (`READY` or `NOT READY`) remains pending for Task 6 and is not issued by this Task 5 update.
+- Final readiness decision is now issued as `NOT READY` because the required live evidence for authenticated read behavior and mutation flows is still incomplete under this audit standard.
 
 ## Scope audited
 - `POST /api/bookings`
@@ -31,9 +31,9 @@
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | `POST /api/bookings` | Yes — `verifyToken`, authenticated users | Yes — `/api/bookings` `post` | Yes — repository evidence captured | Yes — focused contract tests present | No — live mutation verification disallowed by current constraint | Pending readiness | Safe live mutation path still required |
 | `PATCH /api/bookings/{id}` | Yes — `verifyToken` plus Admin/Management `roleGuard` | Yes — `/api/bookings/{id}` documents `patch` | Yes — repository evidence captured | Yes — focused contract tests present | No — live mutation verification disallowed by current constraint | Pending readiness | Safe live mutation path still required |
-| `GET /api/bookings` | Yes — `verifyToken` plus Admin/Management `roleGuard` | Partial — OpenAPI documents `date_from`, `date_to`, and `user_id` filters not implemented by `getAllBookings` | Partial — repository evidence captured, but query-filter contract gap remains | Yes — focused contract tests present | Partial — unauthenticated live access verified blocked with `401`; authenticated live verification not completed | Pending contract gap + authenticated live verification | OpenAPI/runtime filter mismatch and no authenticated live read evidence |
+| `GET /api/bookings` | Yes — `verifyToken` plus Admin/Management `roleGuard` | Yes — OpenAPI filter contract matches current `getAllBookings` implementation | Yes — repository evidence captured | Yes — focused contract tests present | Partial — unauthenticated live access verified blocked with `401`; authenticated live verification not completed | Pending authenticated live verification | No authenticated live read evidence |
 | `GET /api/bookings/history` | Yes — `verifyToken`, scoped to `req.user.id` | Yes — `/api/bookings/history` documents `get` with pagination/status/sort metadata | Yes — repository evidence captured | Yes — focused contract tests present | Partial — unauthenticated live access verified blocked with `401`; authenticated live verification not completed | Pending authenticated live verification | No authenticated live read evidence |
-| `DELETE /api/bookings/{id}` | Yes — `verifyToken` plus Admin/Management `roleGuard` | Yes — `/api/bookings/{id}` documents `delete` | Partial — repository evidence captured, but shared-location deletion risk remains needs-verification | Yes — focused contract tests present | No — live mutation verification disallowed by current constraint | Pending readiness + logic gap | Safe live mutation path and shared-location deletion evidence still required |
+| `DELETE /api/bookings/{id}` | Yes — `verifyToken` plus Admin/Management `roleGuard` | Yes — `/api/bookings/{id}` documents `delete` | Yes — repository evidence captured and current delete flow does not remove `Location` records | Yes — focused contract tests present | No — live mutation verification disallowed by current constraint | Pending live mutation verification | Safe live mutation path still required |
 
 ## Findings by endpoint
 
@@ -113,7 +113,9 @@
 - No route-level request validator is mounted for `GET /api/bookings`.
 
 #### Controller evidence
-- `getAllBookings` reads `status`, `page`, and `limit` query parameters.
+- `getAllBookings` reads `status`, `page`, `limit`, `user_id`, `date_from`, and `date_to` query parameters.
+- `getAllBookings` validates positive-integer pagination and enforces an admin safety cap of `limit <= 100`.
+- `getAllBookings` validates `user_id` as a positive integer and validates `date_from`/`date_to` as strict `YYYY-MM-DD` values with an ordered date-range check.
 - `getAllBookings` maps `approved`/`rejected`/`pending` status strings to persisted status IDs for filtering.
 - `getAllBookings` queries bookings with user, position, role, location, and booking status relations.
 - `getAllBookings` sorts pending first, then approved, then rejected, with newest records first inside each status group.
@@ -122,6 +124,8 @@
 #### Automated verification evidence
 - `tests/bookingsReadinessContract.test.js` verifies authenticated non-admin users are blocked from `GET /api/bookings` with `403`.
 - `tests/bookingsReadinessContract.test.js` verifies unauthenticated requests are blocked by `verifyToken` before reaching `GET /api/bookings`.
+- `tests/bookingsControllerReadiness.test.js` verifies `getAllBookings` applies the documented `status`, `user_id`, `date_from`, and `date_to` filters plus pagination metadata.
+- `tests/bookingsControllerReadiness.test.js` verifies invalid `status`, pagination, `user_id`, and date-range inputs are rejected before querying the database.
 - `tests/openApiMountedRoutesContract.test.js` verifies `/api/bookings` remains present in the public OpenAPI inventory.
 
 #### Live verification evidence
@@ -131,10 +135,9 @@
 - Fact: one attempted login using credentials available in the current workspace was rejected at the validation layer with message `Password harus kombinasi huruf dan angka tanpa spasi`.
 
 #### Status
-- Repository evidence present, but OpenAPI/runtime filter alignment is partial because documented `date_from`, `date_to`, and `user_id` filters are not implemented by `getAllBookings`; live evidence confirms unauthenticated access is blocked, but authenticated read behavior remains unverified.
+- Repository evidence present and current OpenAPI/runtime filter alignment is confirmed; live evidence confirms unauthenticated access is blocked, but authenticated read behavior remains unverified.
 
 #### Blocking notes
-- Contract gap: OpenAPI documents `date_from`, `date_to`, and `user_id` query filters, but repository evidence shows `getAllBookings` only reads `status`, `page`, and `limit`.
 - Authenticated read-only live verification remains incomplete for final readiness evidence.
 
 ### `GET /api/bookings/history`
@@ -189,41 +192,42 @@
 
 #### Controller evidence
 - `deleteBooking` returns `404` when the requested booking record/ID does not exist.
-- `deleteBooking` deletes the booking record and then deletes the related location record inside the same transaction.
-- Needs verification: `createBooking` can reuse an existing `location_id`, so deleting the related location record may remove a location still shared by another booking.
+- `deleteBooking` deletes only the booking record inside the transaction and does not destroy any related `Location` record.
 
 #### Automated verification evidence
 - `tests/bookingsReadinessContract.test.js` verifies authenticated non-admin users are blocked from `DELETE /api/bookings/{id}` with `403`.
 - `tests/bookingsReadinessContract.test.js` verifies unauthenticated requests are blocked by `verifyToken` before reaching `DELETE /api/bookings/{id}`.
+- `tests/bookingsControllerReadiness.test.js` verifies `deleteBooking` deletes only the booking record without deleting a shared `Location`.
 - `tests/openApiMountedRoutesContract.test.js` verifies `/api/bookings/{id}` remains present in the public OpenAPI inventory.
 
 #### Live verification evidence
 - Fact: live mutation verification was not performed for `DELETE /api/bookings/{id}` because mutating staging actions are disallowed under the current audit constraint.
 
 #### Status
-- Repository evidence present, but delete readiness remains partial because shared-location deletion safety is not proven; live mutation verification still required for readiness.
+- Repository evidence present and current delete logic no longer carries the earlier shared-location deletion risk; live mutation verification still required for readiness.
 
 #### Blocking notes
-- Logic gap / needs verification: `createBooking` can reuse `location_id`, while `deleteBooking` destroys the related `Location` record; repository evidence does not prove the location is exclusively owned by the deleted booking.
 - Mutation readiness remains unproven until a safe live `DELETE /api/bookings/{id}` verification path exists.
 
 ## Automated verification evidence
 - `tests/bookingsReadinessContract.test.js` verifies route/auth boundaries and exported validator contract shape.
+- `tests/bookingsControllerReadiness.test.js` verifies the current controller-level filter, validation, pagination, and delete-safety behavior that previously appeared stale in this audit.
 - `tests/openApiMountedRoutesContract.test.js` verifies the bookings paths remain present in the public OpenAPI inventory.
 
 ## Task 5 endpoint status posture
 - `POST /api/bookings`: repository evidence present, but live mutation verification remains not performed because mutating staging actions are disallowed under the current constraint.
 - `PATCH /api/bookings/{id}`: repository evidence present, but live mutation verification remains not performed because mutating staging actions are disallowed under the current constraint.
-- `GET /api/bookings`: repository evidence present, OpenAPI/runtime filter alignment is partial, and unauthenticated live access is blocked with `401`; authenticated live read behavior remains unverified because no valid live token could be obtained without guessing.
+- `GET /api/bookings`: repository evidence present, OpenAPI/runtime filter alignment is confirmed, and unauthenticated live access is blocked with `401`; authenticated live read behavior remains unverified because no valid live token could be obtained without guessing.
 - `GET /api/bookings/history`: repository evidence present and unauthenticated live access is blocked with `401`; authenticated live read behavior remains unverified because no valid live token could be obtained without guessing.
-- `DELETE /api/bookings/{id}`: repository evidence present, shared-location deletion safety remains needs-verification, and live mutation verification remains not performed because mutating staging actions are disallowed under the current constraint.
+- `DELETE /api/bookings/{id}`: repository evidence present, current delete behavior no longer removes `Location` records, and live mutation verification remains not performed because mutating staging actions are disallowed under the current constraint.
 
 ## Blocking gap list
 ### Contract gaps
-- `GET /api/bookings` is not fully OpenAPI-aligned: OpenAPI documents `date_from`, `date_to`, and `user_id` filters, while repository evidence shows `getAllBookings` only implements `status`, `page`, and `limit`.
+- None currently evidenced in repository state.
 ### Logic gaps
-- `createBooking` can reuse an existing `location_id`, but `deleteBooking` destroys the related `Location` record after deleting the booking. Repository evidence does not prove that a deleted booking's location is never shared by another booking, so this remains a logic gap / needs-verification item.
+- None currently evidenced in repository state.
 ### Automated verification gaps
+- None blocking from repository-side coverage for the audited contract and controller behaviors.
 ### Live verification gaps
 - Authenticated live verification for `GET /api/bookings` remains incomplete because no valid live token could be obtained from available local credential sources without guessing.
 - Authenticated live verification for `GET /api/bookings/history` remains incomplete because no valid live token could be obtained from available local credential sources without guessing.
@@ -240,16 +244,15 @@
 - Needs Verification: authenticated `GET` behavior and all mutation endpoint live behavior still need approved credentials and/or an approved safe mutation path.
 
 ## Final readiness decision
-- Decision: `PENDING`
+- Decision: `NOT READY`
 - Reasoning:
   - Task 4 repository evidence is captured for runtime routes, OpenAPI documentation, validators, controllers, and automated contract tests.
+  - Current repository evidence closes the earlier `GET /api/bookings` filter-alignment concern and the earlier `DELETE /api/bookings/{id}` shared-location deletion concern.
   - Task 5 live verification confirms unauthenticated live access is blocked for both read endpoints, but authenticated live read behavior remains unverified because no valid live token could be obtained without guessing.
   - Task 5 live mutation verification remains intentionally not performed because mutating staging actions are disallowed under the current constraint.
-  - Task 6 must issue the final `READY` or `NOT READY` result; this Task 5 update does not issue the final decision.
+  - Under this audit standard, missing authenticated live read evidence plus missing live mutation evidence is sufficient to keep the bookings surface out of `READY` status.
 
 ## Fix queue
 1. Provide an approved valid live token or credential source for authenticated `GET /api/bookings` and `GET /api/bookings/history` verification.
 2. Provide an approved safe live mutation verification path for `POST /api/bookings`, `PATCH /api/bookings/{id}`, and `DELETE /api/bookings/{id}`.
-3. Resolve or explicitly accept the `GET /api/bookings` OpenAPI/runtime filter mismatch.
-4. Resolve or explicitly accept the `DELETE /api/bookings/{id}` shared-location deletion needs-verification risk.
-5. Complete Task 6 final readiness assessment with explicit `READY` or `NOT READY` decision.
+3. Re-run the final bookings readiness assessment once the missing live evidence is available.

--- a/docs/droplet-docr-runtime.md
+++ b/docs/droplet-docr-runtime.md
@@ -1,53 +1,95 @@
 # Droplet DOCR Runtime Procedure
 
 ## Runtime source of truth
-The staging droplet runs the backend from a DOCR image, not from a local compose build.
+Backend canonical runtime berjalan dari image DOCR yang dipull oleh Docker Compose di droplet, dengan host Nginx di depan container dan managed MySQL di belakang runtime.
 
 ## Image contract
 - Repository: `registry.digitalocean.com/infinit-track/infinit-track-backend`
 - Runtime tag source: `BACKEND_IMAGE_TAG`
-- `latest` is convenience only; the runtime should pin a SHA tag for actual deploys.
+- `latest` hanya convenience; deploy aktual harus pin SHA image yang immutable.
+
+## Health contract
+- `/livez` = process liveness
+- `/health` = dependency readiness
+- Runtime container listen di `127.0.0.1:3005`
+
+Ready response contoh:
+
+```json
+{"status":"OK","ready":true,"components":{"database":"ready","scheduler":"ready"},"missing":[],"timestamp":"..."}
+```
+
+Not ready response contoh:
+
+```json
+{"status":"NOT_READY","ready":false,"components":{"database":"not_ready","scheduler":"ready"},"missing":["database"],"timestamp":"..."}
+```
 
 ## Deploy procedure
-1. Set the runtime tag:
+1. Set runtime tag ke SHA image yang akan dirilis:
    ```bash
    export BACKEND_IMAGE_TAG=<git-sha>
    ```
-2. Authenticate Docker to DOCR on the droplet.
-   - If `registry.digitalocean.com/infinit-track/infinit-track-backend` is private, authenticate before pulling.
-   - Prerequisite: a DigitalOcean personal access token with Container Registry read access.
+2. Authenticate Docker ke DOCR di droplet.
+   - Jika `registry.digitalocean.com/infinit-track/infinit-track-backend` private, login dulu sebelum pull.
+   - Prerequisite: DigitalOcean personal access token dengan Container Registry read access.
    - Direct Docker login:
      ```bash
      export DOCR_TOKEN=<digitalocean-pat-with-registry-read-access>
      echo "$DOCR_TOKEN" | docker login registry.digitalocean.com -u doctl --password-stdin
      ```
-   - Or, if `doctl` is installed and already authenticated:
+   - Atau, jika `doctl` sudah terpasang dan terautentikasi:
      ```bash
      doctl registry login
      ```
-3. Pull the selected image:
+3. Pull image yang dipilih:
    ```bash
    docker compose pull app
    ```
-4. Restart the app service:
+4. Recreate service app dengan image baru:
    ```bash
-   docker compose up -d app
+   docker compose up -d --force-recreate app
    ```
-5. Verify:
+5. Jalankan migrasi runtime:
    ```bash
-   docker compose ps
-   curl -fsS http://localhost:3000/health
+   docker compose exec -T app npm run migrate
+   ```
+6. Verifikasi local runtime, public runtime, dan DNS/IP expectation:
+   ```bash
+   DOMAIN=<public-domain> EXPECTED_IP=<droplet-ip> ./deploy/scripts/verify-droplet-api.sh
+   ```
+7. Verifikasi smoke/readiness gate aplikasi:
+   ```bash
+   npm run smoke-test https://<public-domain>
+   ```
+8. Cek state container dan migration status jika perlu:
+   ```bash
+   docker compose ps app
+   docker compose exec -T app npm run migrate:status
    docker compose logs --tail=100 app
    ```
 
+## Manual spot checks
+```bash
+curl -fsS http://127.0.0.1:3005/livez
+curl -fsS http://127.0.0.1:3005/health
+curl -fsS https://<public-domain>/livez
+curl -fsS https://<public-domain>/health
+```
+
 ## Rollback procedure
-1. Set `BACKEND_IMAGE_TAG` back to the last known good SHA.
-2. Pull that image:
+1. Set `BACKEND_IMAGE_TAG` kembali ke SHA terakhir yang diketahui sehat.
+2. Pull image tersebut:
    ```bash
    docker compose pull app
    ```
-3. Restart the app service:
+3. Recreate service app:
    ```bash
-   docker compose up -d app
+   docker compose up -d --force-recreate app
    ```
-4. Re-run health and log checks.
+4. Jika rollback membutuhkan schema yang sesuai, verifikasi migration state.
+5. Ulangi verification gate:
+   ```bash
+   DOMAIN=<public-domain> EXPECTED_IP=<droplet-ip> ./deploy/scripts/verify-droplet-api.sh
+   npm run smoke-test https://<public-domain>
+   ```

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -43,17 +43,17 @@ security:
   - bearerAuth: []
 
 paths:
-  # Health Check
-  /health:
+  # System Health Endpoints
+  /livez:
     get:
       tags:
         - System
-      summary: Health check endpoint
-      description: Check if the API server is running and healthy
+      summary: Liveness probe endpoint
+      description: Check whether the API process is alive. Use this for liveness probes only.
       security: []
       responses:
         '200':
-          description: Server is healthy
+          description: Server process is alive
           content:
             application/json:
               schema:
@@ -66,6 +66,76 @@ paths:
                     type: string
                     format: date-time
                     example: '2025-07-05T12:00:00.000Z'
+
+  /health:
+    get:
+      tags:
+        - System
+      summary: Readiness probe endpoint
+      description: Check whether the API is ready to serve traffic after startup dependencies are initialized.
+      security: []
+      responses:
+        '200':
+          description: Server is ready to serve traffic
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: 'OK'
+                  ready:
+                    type: boolean
+                    example: true
+                  timestamp:
+                    type: string
+                    format: date-time
+                    example: '2025-07-05T12:00:00.000Z'
+                  components:
+                    type: object
+                    additionalProperties:
+                      type: string
+                      enum: [ready, not_ready]
+                    example:
+                      database: ready
+                      scheduler: ready
+                  missing:
+                    type: array
+                    items:
+                      type: string
+                    example: []
+        '503':
+          description: Server process is alive but not ready to serve traffic
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: 'NOT_READY'
+                  ready:
+                    type: boolean
+                    example: false
+                  timestamp:
+                    type: string
+                    format: date-time
+                    example: '2025-07-05T12:00:00.000Z'
+                  components:
+                    type: object
+                    additionalProperties:
+                      type: string
+                      enum: [ready, not_ready]
+                    example:
+                      database: ready
+                      scheduler: not_ready
+                  missing:
+                    type: array
+                    items:
+                      type: string
+                    example:
+                      - scheduler
 
   # Authentication Endpoints
   /api/auth/login:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1215,6 +1215,8 @@ paths:
                           $ref: '#/components/schemas/Booking'
                       pagination:
                         $ref: '#/components/schemas/Pagination'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':

--- a/health-check.sh
+++ b/health-check.sh
@@ -14,7 +14,105 @@ print_success() { echo -e "${GREEN}[OK] $1${NC}"; }
 print_warning() { echo -e "${YELLOW}[WARN] $1${NC}"; }
 print_error() { echo -e "${RED}[FAIL] $1${NC}"; }
 
-APP_URL="${APP_URL:-http://localhost:${PORT:-3000}}"
+APP_URL="${APP_URL:-http://localhost:${PORT:-3005}}"
+LIVEZ_URL="${LIVEZ_URL:-${APP_URL}/livez}"
+READINESS_URL="${READINESS_URL:-${APP_URL}/health}"
+CRITICAL_FAILURES=0
+HTTP_PROBE_DEPS_READY=true
+
+record_failure() {
+    CRITICAL_FAILURES=$((CRITICAL_FAILURES + 1))
+}
+
+ensure_http_probe_dependencies() {
+    if ! command -v curl &> /dev/null; then
+        print_error "curl is required to run health probes"
+        HTTP_PROBE_DEPS_READY=false
+    fi
+
+    if ! command -v python3 &> /dev/null; then
+        print_error "python3 is required to validate health JSON contracts"
+        HTTP_PROBE_DEPS_READY=false
+    fi
+
+    if [ "$HTTP_PROBE_DEPS_READY" = false ]; then
+        record_failure
+        return 1
+    fi
+
+    return 0
+}
+
+check_http_contract() {
+    local url="$1"
+    local label="$2"
+    local mode="$3"
+    local response_file
+    local status
+    local body
+
+    response_file="$(mktemp)"
+
+    if ! status="$(curl --silent --show-error --output "$response_file" --write-out "%{http_code}" "$url")"; then
+        rm -f "$response_file"
+        print_error "$label probe failed for $url"
+        return 1
+    fi
+
+    if ! body="$(python3 - "$response_file" "$status" "$mode" <<'PY'
+import json
+import sys
+
+response_file, status_code, mode = sys.argv[1:]
+status_code = int(status_code)
+
+with open(response_file, 'r', encoding='utf-8') as handle:
+    raw_body = handle.read()
+
+try:
+    data = json.loads(raw_body)
+except json.JSONDecodeError as exc:
+    print(f"invalid JSON: {exc}", file=sys.stderr)
+    print(raw_body, file=sys.stderr)
+    sys.exit(1)
+
+if status_code != 200:
+    print(f"unexpected HTTP {status_code}", file=sys.stderr)
+    print(json.dumps(data, ensure_ascii=False), file=sys.stderr)
+    sys.exit(1)
+
+if data.get('status') != 'OK':
+    print("unexpected status field", file=sys.stderr)
+    print(json.dumps(data, ensure_ascii=False), file=sys.stderr)
+    sys.exit(1)
+
+if mode == 'readiness':
+    if data.get('ready') is not True:
+        print("readiness flag is not true", file=sys.stderr)
+        print(json.dumps(data, ensure_ascii=False), file=sys.stderr)
+        sys.exit(1)
+    if not isinstance(data.get('components'), dict):
+        print("readiness components missing", file=sys.stderr)
+        print(json.dumps(data, ensure_ascii=False), file=sys.stderr)
+        sys.exit(1)
+    if not isinstance(data.get('missing'), list):
+        print("readiness missing array absent", file=sys.stderr)
+        print(json.dumps(data, ensure_ascii=False), file=sys.stderr)
+        sys.exit(1)
+
+print(json.dumps(data, ensure_ascii=False))
+PY
+)"; then
+        rm -f "$response_file"
+        print_error "$label returned an invalid health contract"
+        return 1
+    fi
+
+    rm -f "$response_file"
+    print_success "$label passed"
+    echo "  $body"
+    return 0
+}
 
 echo "Infinite Track Backend - Health Check"
 echo "======================================"
@@ -24,28 +122,14 @@ echo ""
 
 # 1. API Health
 print_header "API HEALTH"
-RESPONSE=""
-
-if command -v curl &> /dev/null; then
-    RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" "$APP_URL/health" 2>/dev/null)
-elif command -v wget &> /dev/null; then
-    wget -q --spider "$APP_URL/health" 2>/dev/null
-    WGET_EXIT=$?
-    if [ "$WGET_EXIT" -eq 0 ]; then
-        RESPONSE="200"
-    else
-        RESPONSE="000"
+if ensure_http_probe_dependencies; then
+    if ! check_http_contract "$LIVEZ_URL" "API liveness" "liveness"; then
+        record_failure
     fi
-else
-    print_warning "Neither curl nor wget is available; skipping API health probe"
-fi
 
-if [ -z "$RESPONSE" ]; then
-    print_warning "API health probe skipped"
-elif [ "$RESPONSE" = "200" ]; then
-    print_success "API is healthy (HTTP $RESPONSE)"
-else
-    print_error "API is not responding (HTTP ${RESPONSE:-000})"
+    if ! check_http_contract "$READINESS_URL" "API readiness" "readiness"; then
+        record_failure
+    fi
 fi
 
 # 2. Environment Detection
@@ -100,4 +184,9 @@ if command -v kubectl &> /dev/null; then
 fi
 
 echo ""
+if [ "$CRITICAL_FAILURES" -gt 0 ]; then
+    print_error "Health check failed with ${CRITICAL_FAILURES} critical issue(s)."
+    exit 1
+fi
+
 echo "Health check complete."

--- a/k8s/app-deployment.yaml
+++ b/k8s/app-deployment.yaml
@@ -1,4 +1,7 @@
-# Replace <your-dockerhub-username> with your actual Docker Hub username
+# Legacy/historical backend artifact only.
+# Canonical backend runtime is the droplet-hosted Docker Compose stack that pulls
+# registry.digitalocean.com/infinit-track/infinit-track-backend behind host Nginx.
+# Do not treat this manifest as the active backend deployment source of truth.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -23,7 +26,7 @@ spec:
     spec:
       initContainers:
         - name: migrate
-          image: <your-dockerhub-username>/infinit-track-backend:latest
+          image: registry.digitalocean.com/infinit-track/infinit-track-backend:latest
           command: ["node", "scripts/migrate.js"]
           envFrom:
             - configMapRef:
@@ -32,9 +35,9 @@ spec:
                 name: infinit-track-secrets
       containers:
         - name: app
-          image: <your-dockerhub-username>/infinit-track-backend:latest
+          image: registry.digitalocean.com/infinit-track/infinit-track-backend:latest
           ports:
-            - containerPort: 3000
+            - containerPort: 3005
           envFrom:
             - configMapRef:
                 name: infinit-track-config
@@ -49,15 +52,15 @@ spec:
               cpu: "500m"
           livenessProbe:
             httpGet:
-              path: /health
-              port: 3000
+              path: /livez
+              port: 3005
             initialDelaySeconds: 30
             periodSeconds: 15
             timeoutSeconds: 5
           readinessProbe:
             httpGet:
               path: /health
-              port: 3000
+              port: 3005
             initialDelaySeconds: 10
             periodSeconds: 5
             timeoutSeconds: 3

--- a/scripts/smoke-test.js
+++ b/scripts/smoke-test.js
@@ -10,13 +10,16 @@
  *   node scripts/smoke-test.js <base-url>
  *
  * Example:
- *   node scripts/smoke-test.js https://staging-api.ondigitalocean.app
+ *   node scripts/smoke-test.js https://staging-api.example.internal
  */
 
 import axios from 'axios';
 
 const BASE_URL = process.argv[2] || process.env.BASE_URL;
 const TIMEOUT = 10000; // 10 seconds
+const EXPECTED_INVALID_LOGIN_STATUSES = new Set([400, 401, 422]);
+const LIVEZ_URL = `${BASE_URL}/livez`;
+const HEALTH_URL = `${BASE_URL}/health`;
 
 if (!BASE_URL) {
   console.error('❌ Error: BASE_URL not provided');
@@ -33,6 +36,14 @@ const results = {
   failed: 0,
   tests: []
 };
+
+function formatAxiosError(error) {
+  if (error.response) {
+    return `Status: ${error.response.status}, Response: ${JSON.stringify(error.response.data)}`;
+  }
+
+  return `Error: ${error.message}`;
+}
 
 /**
  * Test result logger
@@ -53,31 +64,71 @@ function logTest(name, passed, details = '') {
 }
 
 /**
- * Test 1: Health Endpoint
+ * Test 1: Liveness Endpoint
  */
-async function testHealth() {
+async function testLiveness() {
   try {
-    const response = await axios.get(`${BASE_URL}/health`, { timeout: TIMEOUT });
+    const response = await axios.get(LIVEZ_URL, { timeout: TIMEOUT });
 
     if (response.status === 200 && response.data.status === 'OK') {
       logTest(
-        'Health Endpoint',
+        'Liveness Endpoint',
         true,
         `Status: ${response.status}, Response: ${JSON.stringify(response.data)}`
       );
       return true;
     } else {
-      logTest('Health Endpoint', false, `Unexpected response: ${JSON.stringify(response.data)}`);
+      logTest('Liveness Endpoint', false, `Unexpected response: ${JSON.stringify(response.data)}`);
       return false;
     }
   } catch (error) {
-    logTest('Health Endpoint', false, `Error: ${error.message}`);
+    logTest('Liveness Endpoint', false, formatAxiosError(error));
     return false;
   }
 }
 
 /**
- * Test 2: API Documentation
+ * Test 2: Readiness Endpoint
+ */
+async function testReadiness() {
+  try {
+    const response = await axios.get(HEALTH_URL, {
+      timeout: TIMEOUT,
+      validateStatus: () => true
+    });
+
+    if (response.status === 200 && response.data.status === 'OK' && response.data.ready === true) {
+      logTest(
+        'Readiness Endpoint',
+        true,
+        `Status: ${response.status}, Response: ${JSON.stringify(response.data)}`
+      );
+      return true;
+    }
+
+    if (response.status === 503 && Array.isArray(response.data?.missing)) {
+      logTest(
+        'Readiness Endpoint',
+        false,
+        `Status: ${response.status}, Missing: ${response.data.missing.join(', ')}`
+      );
+      return false;
+    }
+
+    logTest(
+      'Readiness Endpoint',
+      false,
+      `Unexpected status ${response.status}, Response: ${JSON.stringify(response.data)}`
+    );
+    return false;
+  } catch (error) {
+    logTest('Readiness Endpoint', false, formatAxiosError(error));
+    return false;
+  }
+}
+
+/**
+ * Test 3: API Documentation
  */
 async function testDocs() {
   try {
@@ -91,45 +142,75 @@ async function testDocs() {
       return false;
     }
   } catch (error) {
-    logTest('API Documentation', false, `Error: ${error.message}`);
+    logTest('API Documentation', false, formatAxiosError(error));
     return false;
   }
 }
 
 /**
- * Test 3: CORS Headers
+ * Test 4: CORS Headers
  */
 async function testCORS() {
   try {
-    const response = await axios.options(`${BASE_URL}/health`, {
+    const requestedOrigin = 'https://example.com';
+    const response = await axios.options(`${BASE_URL}/api/auth/login`, {
       timeout: TIMEOUT,
+      validateStatus: () => true,
       headers: {
-        Origin: 'https://example.com',
-        'Access-Control-Request-Method': 'GET'
+        Origin: requestedOrigin,
+        'Access-Control-Request-Method': 'POST',
+        'Access-Control-Request-Headers': 'Content-Type'
       }
     });
 
     const corsHeader = response.headers['access-control-allow-origin'];
-    if (corsHeader) {
-      logTest('CORS Headers', true, `Allow-Origin: ${corsHeader}`);
+    const credentialsHeader = response.headers['access-control-allow-credentials'];
+    const methodsHeader = response.headers['access-control-allow-methods'];
+    const allowedHeaders = response.headers['access-control-allow-headers'];
+    const originAllowed = corsHeader === requestedOrigin;
+    const credentialsAllowed = credentialsHeader === 'true';
+    const allowsPost = methodsHeader
+      ?.split(',')
+      .map((method) => method.trim().toUpperCase())
+      .includes('POST');
+    const allowsContentType = allowedHeaders
+      ?.split(',')
+      .map((header) => header.trim().toLowerCase())
+      .includes('content-type');
+
+    if (
+      [200, 204].includes(response.status) &&
+      originAllowed &&
+      credentialsAllowed &&
+      allowsPost &&
+      allowsContentType
+    ) {
+      logTest(
+        'CORS Headers',
+        true,
+        `Allow-Origin: ${corsHeader}, Allow-Credentials: ${credentialsHeader}, Allow-Methods: ${methodsHeader}, Allow-Headers: ${allowedHeaders}`
+      );
       return true;
-    } else {
-      logTest('CORS Headers', false, 'No CORS headers found');
-      return false;
     }
+
+    logTest(
+      'CORS Headers',
+      false,
+      `Status: ${response.status}, Allow-Origin: ${corsHeader || '-'}, Requested-Origin: ${requestedOrigin}, Allow-Credentials: ${credentialsHeader || '-'}, Allow-Methods: ${methodsHeader || '-'}, Allow-Headers: ${allowedHeaders || '-'}`
+    );
+    return false;
   } catch (error) {
-    // Some servers might not support OPTIONS, which is OK
-    logTest('CORS Headers', true, 'OPTIONS not supported (acceptable)');
-    return true;
+    logTest('CORS Headers', false, formatAxiosError(error));
+    return false;
   }
 }
 
 /**
- * Test 4: Security Headers
+ * Test 5: Security Headers
  */
 async function testSecurityHeaders() {
   try {
-    const response = await axios.get(`${BASE_URL}/health`, { timeout: TIMEOUT });
+    const response = await axios.get(LIVEZ_URL, { timeout: TIMEOUT });
 
     const headers = response.headers;
     const checks = {
@@ -147,13 +228,13 @@ async function testSecurityHeaders() {
     logTest('Security Headers', allPassed, details);
     return allPassed;
   } catch (error) {
-    logTest('Security Headers', false, `Error: ${error.message}`);
+    logTest('Security Headers', false, formatAxiosError(error));
     return false;
   }
 }
 
 /**
- * Test 5: Auth Endpoint (should reject without credentials)
+ * Test 6: Auth Endpoint (should reject without credentials)
  */
 async function testAuthEndpoint() {
   try {
@@ -171,13 +252,13 @@ async function testAuthEndpoint() {
       return false;
     }
   } catch (error) {
-    logTest('Auth Protection', false, `Error: ${error.message}`);
+    logTest('Auth Protection', false, formatAxiosError(error));
     return false;
   }
 }
 
 /**
- * Test 6: Login Endpoint Structure
+ * Test 7: Login Endpoint Structure
  */
 async function testLoginEndpoint() {
   try {
@@ -192,33 +273,33 @@ async function testLoginEndpoint() {
       }
     );
 
-    // Should return 400 or 401, not 500
-    if (response.status === 400 || response.status === 401) {
+    if (EXPECTED_INVALID_LOGIN_STATUSES.has(response.status)) {
       logTest(
         'Login Endpoint',
         true,
         `Returns ${response.status} for invalid credentials (correct)`
       );
       return true;
-    } else if (response.status === 500) {
-      logTest('Login Endpoint', false, 'Returns 500 error (database/server issue)');
-      return false;
-    } else {
-      logTest('Login Endpoint', true, `Returns ${response.status} (acceptable)`);
-      return true;
     }
+
+    logTest(
+      'Login Endpoint',
+      false,
+      `Expected 400/401/422 for invalid credentials, got ${response.status}, Response: ${JSON.stringify(response.data)}`
+    );
+    return false;
   } catch (error) {
-    logTest('Login Endpoint', false, `Error: ${error.message}`);
+    logTest('Login Endpoint', false, formatAxiosError(error));
     return false;
   }
 }
 
 /**
- * Test 7: Request ID in Response
+ * Test 8: Request ID in Response
  */
 async function testRequestId() {
   try {
-    const response = await axios.get(`${BASE_URL}/health`, { timeout: TIMEOUT });
+    const response = await axios.get(LIVEZ_URL, { timeout: TIMEOUT });
 
     const requestId = response.headers['x-request-id'];
     if (requestId) {
@@ -229,18 +310,18 @@ async function testRequestId() {
       return false;
     }
   } catch (error) {
-    logTest('Request ID Header', false, `Error: ${error.message}`);
+    logTest('Request ID Header', false, formatAxiosError(error));
     return false;
   }
 }
 
 /**
- * Test 8: Response Time
+ * Test 9: Response Time
  */
 async function testResponseTime() {
   try {
     const start = Date.now();
-    await axios.get(`${BASE_URL}/health`, { timeout: TIMEOUT });
+    await axios.get(LIVEZ_URL, { timeout: TIMEOUT });
     const duration = Date.now() - start;
 
     if (duration < 1000) {
@@ -254,7 +335,7 @@ async function testResponseTime() {
       return false;
     }
   } catch (error) {
-    logTest('Response Time', false, `Error: ${error.message}`);
+    logTest('Response Time', false, formatAxiosError(error));
     return false;
   }
 }
@@ -267,7 +348,8 @@ async function runTests() {
   console.log('Running Smoke Tests');
   console.log('═══════════════════════════════════════\n');
 
-  await testHealth();
+  await testLiveness();
+  await testReadiness();
   await testDocs();
   await testCORS();
   await testSecurityHeaders();

--- a/src/controllers/attendance.controller.js
+++ b/src/controllers/attendance.controller.js
@@ -12,8 +12,7 @@ import {
   BookingStatus,
   User,
   Role,
-  LocationEvent,
-  Photo
+  LocationEvent
 } from '../models/index.js';
 import {
   calculateDistance,

--- a/src/controllers/booking.controller.js
+++ b/src/controllers/booking.controller.js
@@ -17,9 +17,14 @@ import { getJakartaDateString } from '../utils/geofence.js';
  */
 async function getSuitabilityScoreForCustomLocation(latitude, longitude) {
   try {
-    const geoapifyApiKey = process.env.GEOAPIFY_API_KEY;
+    const geoapifyApiKey = process.env.GEOAPIFY_API_KEY || process.env.GEOAPIFY_KEY;
+    if (!process.env.GEOAPIFY_API_KEY && process.env.GEOAPIFY_KEY) {
+      logger.warn(
+        'Using legacy GEOAPIFY_KEY fallback for booking suitability scoring; migrate to GEOAPIFY_API_KEY.'
+      );
+    }
     if (!geoapifyApiKey) {
-      logger.error('GEOAPIFY_API_KEY not found for booking suitability scoring.');
+      logger.error('Geoapify API key not found for booking suitability scoring. Set GEOAPIFY_API_KEY.');
       return {
         suitability_score: 50,
         suitability_label: 'Lokasi tidak terdaftar'
@@ -35,8 +40,9 @@ async function getSuitabilityScoreForCustomLocation(latitude, longitude) {
       apiKey: geoapifyApiKey
     };
 
+    const diagnosticParams = { ...params, apiKey: '[REDACTED]' };
     logger.info(
-      `[DIAGNOSTIC] Calling Geoapify URL: ${apiUrl} with params: ${JSON.stringify(params)}`
+      `[DIAGNOSTIC] Calling Geoapify URL: ${apiUrl} with params: ${JSON.stringify(diagnosticParams)}`
     );
 
     const response = await axios.get(apiUrl, { params });

--- a/src/controllers/health.controller.js
+++ b/src/controllers/health.controller.js
@@ -1,0 +1,56 @@
+import sequelize from '../config/database.js';
+import logger from '../utils/logger.js';
+import { ensureSchedulerStarted } from '../utils/schedulerLifecycle.js';
+import {
+  getReadinessSnapshot,
+  markDatabaseReady,
+  markDatabaseUnready
+} from '../utils/readinessState.js';
+
+export const getLiveness = (_req, res) => {
+  res.status(200).json({
+    status: 'OK',
+    timestamp: new Date().toISOString()
+  });
+};
+
+export const getReadiness = async (_req, res) => {
+  const previousReadiness = getReadinessSnapshot();
+
+  try {
+    await sequelize.authenticate();
+    markDatabaseReady();
+
+    if (previousReadiness.components.database !== 'ready') {
+      logger.info('Readiness database probe recovered.');
+    }
+
+    const readinessAfterDatabaseProbe = getReadinessSnapshot();
+
+    if (readinessAfterDatabaseProbe.components.scheduler !== 'ready') {
+      try {
+        await ensureSchedulerStarted({ source: 'health' });
+      } catch (schedulerError) {
+        logger.warn('Readiness scheduler recovery failed.', {
+          error: schedulerError.message,
+          stack: schedulerError.stack
+        });
+      }
+    }
+  } catch (error) {
+    markDatabaseUnready();
+
+    if (previousReadiness.components.database !== 'not_ready') {
+      logger.warn('Readiness database probe failed.', {
+        name: error.name,
+        error: error.message,
+        code: error.original?.code || error.parent?.code || error.code,
+        stack: error.stack
+      });
+    }
+  }
+
+  const readiness = getReadinessSnapshot();
+
+  res.status(readiness.ready ? 200 : 503).json(readiness);
+};

--- a/src/controllers/wfa.controller.js
+++ b/src/controllers/wfa.controller.js
@@ -5,6 +5,26 @@ import logger from '../utils/logger.js';
 import fuzzyEngine from '../utils/fuzzyAhpEngine.js';
 import { calculateDistance } from '../utils/geofence.js';
 
+function getGeoapifyApiKey(context) {
+  if (process.env.GEOAPIFY_API_KEY) {
+    return process.env.GEOAPIFY_API_KEY;
+  }
+
+  if (process.env.GEOAPIFY_KEY) {
+    logger.warn(`Using legacy GEOAPIFY_KEY fallback for ${context}; migrate to GEOAPIFY_API_KEY.`);
+    return process.env.GEOAPIFY_KEY;
+  }
+
+  return null;
+}
+
+function redactGeoapifyParams(params) {
+  return {
+    ...params,
+    apiKey: '[REDACTED]'
+  };
+}
+
 /**
  * Get WFA recommendations based on user location
  * Uses Geoapify API to find nearby places and applies Unified Fuzzy AHP scoring
@@ -65,9 +85,9 @@ export const getWfaRecommendations = async (req, res, next) => {
     }
 
     // Langkah B: Panggil API Geoapify
-    const geoapifyApiKey = process.env.GEOAPIFY_API_KEY;
+    const geoapifyApiKey = getGeoapifyApiKey('WFA recommendations');
     if (!geoapifyApiKey) {
-      logger.error('GEOAPIFY_API_KEY not found in environment variables');
+      logger.error('Geoapify API key not found for WFA recommendations. Set GEOAPIFY_API_KEY.');
       return res.status(500).json({
         success: false,
         code: 'E_CONFIG',
@@ -84,7 +104,9 @@ export const getWfaRecommendations = async (req, res, next) => {
       apiKey: geoapifyApiKey,
       lang: 'en'
     };
-    logger.info(`Calling Geoapify API with params: ${JSON.stringify(geoapifyParams)}`);
+    logger.info(
+      `Calling Geoapify API with params: ${JSON.stringify(redactGeoapifyParams(geoapifyParams))}`
+    );
 
     // Retry function for API calls
     const makeGeoapifyRequest = async (retryCount = 0) => {
@@ -446,8 +468,9 @@ export const debugGeoapifyApi = async (req, res, next) => {
     const longitude = parseFloat(lng);
     const searchRadius = parseInt(radius);
 
-    const geoapifyApiKey = process.env.GEOAPIFY_API_KEY;
+    const geoapifyApiKey = getGeoapifyApiKey('WFA Geoapify debug endpoint');
     if (!geoapifyApiKey) {
+      logger.error('Geoapify API key not found for WFA Geoapify debug endpoint. Set GEOAPIFY_API_KEY.');
       return res.status(500).json({
         success: false,
         message: 'GEOAPIFY_API_KEY tidak ditemukan'
@@ -488,7 +511,7 @@ export const debugGeoapifyApi = async (req, res, next) => {
 
     for (const testCase of testCases) {
       try {
-        logger.info(`Running ${testCase.name} with params:`, testCase.params);
+        logger.info(`Running ${testCase.name} with params:`, redactGeoapifyParams(testCase.params));
 
         const response = await axios.get('https://api.geoapify.com/v2/places', {
           params: testCase.params,
@@ -503,7 +526,7 @@ export const debugGeoapifyApi = async (req, res, next) => {
 
         results.push({
           test_name: testCase.name,
-          params_used: testCase.params,
+          params_used: redactGeoapifyParams(testCase.params),
           results_count: features.length,
           sample_places: features.slice(0, 3).map((place) => ({
             name: place.properties?.name || 'Unnamed',
@@ -521,7 +544,7 @@ export const debugGeoapifyApi = async (req, res, next) => {
       } catch (error) {
         results.push({
           test_name: testCase.name,
-          params_used: testCase.params,
+          params_used: redactGeoapifyParams(testCase.params),
           error: error.message,
           status: 'FAILED',
           response_status: error.response?.status || 'NO_RESPONSE'

--- a/src/jobs/autoCheckout.job.js
+++ b/src/jobs/autoCheckout.job.js
@@ -14,59 +14,126 @@ import { defuzzifyMatrixTFN, computeCR } from '../analytics/fahp.js';
 import { extentWeightsTFN } from '../analytics/fahp.extent.js';
 import { SMART_AC_PAIRWISE_TFN } from '../analytics/config.fahp.js';
 
+function isManageableTask(task) {
+  return Boolean(task && (typeof task.destroy === 'function' || typeof task.stop === 'function'));
+}
+
+function assertManageableTask(task, scheduleName) {
+  if (!isManageableTask(task)) {
+    throw new Error(`Auto checkout schedule ${scheduleName} did not return manageable cron task handle`);
+  }
+
+  return task;
+}
+
+function stopScheduledTask(task) {
+  if (typeof task?.destroy === 'function') {
+    task.destroy();
+    return;
+  }
+
+  if (typeof task?.stop === 'function') {
+    task.stop();
+  }
+}
+
+function stopStartedTasks(tasks) {
+  const stopFailures = [];
+
+  for (const task of [...tasks].reverse()) {
+    try {
+      stopScheduledTask(task);
+    } catch (error) {
+      stopFailures.push({ task, error });
+      logger.warn('Auto checkout schedule rollback failed:', error);
+    }
+  }
+
+  return stopFailures;
+}
+
+function createRollbackFailureError(scheduleError, stopFailures) {
+  return new AggregateError(
+    [scheduleError, ...stopFailures.map(({ error }) => error)],
+    'Auto checkout scheduling failed and rollback did not stop all task handles'
+  );
+}
+
 export const startAutoCheckoutJob = () => {
-  logger.info('Missed checkout flagger scheduled to run every 30 minutes');
-  cron.schedule(
-    '*/30 * * * *',
-    async () => {
-      try {
-        await executeJobWithTimeout(
-          'MissedCheckoutFlagger',
-          runMissedCheckoutFlagger,
-          3 * 60 * 1000
-        ); // 3 min timeout
-      } catch (error) {
-        logger.error('Missed checkout flagger failed:', error);
-      }
-    },
-    {
-      scheduled: true,
-      timezone: 'Asia/Jakarta'
+  const startedTasks = [];
+
+  try {
+    logger.info('Missed checkout flagger scheduled to run every 30 minutes');
+    const missedCheckoutTask = assertManageableTask(
+      cron.schedule(
+        '*/30 * * * *',
+        async () => {
+          try {
+            await executeJobWithTimeout(
+              'MissedCheckoutFlagger',
+              runMissedCheckoutFlagger,
+              3 * 60 * 1000
+            ); // 3 min timeout
+          } catch (error) {
+            logger.error('Missed checkout flagger failed:', error);
+          }
+        },
+        {
+          scheduled: true,
+          timezone: 'Asia/Jakarta'
+        }
+      ),
+      'missedCheckout'
+    );
+    startedTasks.push(missedCheckoutTask);
+
+    // Nightly Smart Auto Checkout for yesterday (H-1)
+    logger.info('Smart Auto Checkout (FAHP+DOW) scheduled to run daily at 23:45');
+    const smartAutoCheckoutTask = assertManageableTask(
+      cron.schedule(
+        '45 23 * * *',
+        async () => {
+          try {
+            await executeJobWithTimeout(
+              'SmartAutoCheckout',
+              async () => {
+                // Get current Jakarta time properly
+                const now = new Date();
+                const jakartaTimeString = now.toLocaleString('en-US', { timeZone: 'Asia/Jakarta' });
+                const jakartaTime = new Date(jakartaTimeString);
+
+                // Calculate yesterday (H-1) in Jakarta timezone
+                const yesterday = new Date(jakartaTime);
+                yesterday.setDate(jakartaTime.getDate() - 1);
+                const targetDate = yesterday.toISOString().split('T')[0];
+
+                return runSmartAutoCheckoutForDate(targetDate);
+              },
+              10 * 60 * 1000 // 10 min timeout for smart checkout
+            );
+          } catch (e) {
+            logger.error('Smart Auto Checkout nightly failed:', e);
+          }
+        },
+        {
+          scheduled: true,
+          timezone: 'Asia/Jakarta'
+        }
+      ),
+      'smartAutoCheckout'
+    );
+    startedTasks.push(smartAutoCheckoutTask);
+
+    return startedTasks;
+  } catch (error) {
+    const stopFailures = stopStartedTasks(startedTasks);
+
+    if (stopFailures.length > 0) {
+      throw createRollbackFailureError(error, stopFailures);
     }
-  );
 
-  // Nightly Smart Auto Checkout for yesterday (H-1)
-  logger.info('Smart Auto Checkout (FAHP+DOW) scheduled to run daily at 23:45');
-  cron.schedule(
-    '45 23 * * *',
-    async () => {
-      try {
-        await executeJobWithTimeout(
-          'SmartAutoCheckout',
-          async () => {
-            // Get current Jakarta time properly
-            const now = new Date();
-            const jakartaTimeString = now.toLocaleString('en-US', { timeZone: 'Asia/Jakarta' });
-            const jakartaTime = new Date(jakartaTimeString);
-
-            // Calculate yesterday (H-1) in Jakarta timezone
-            const yesterday = new Date(jakartaTime);
-            yesterday.setDate(jakartaTime.getDate() - 1);
-            const targetDate = yesterday.toISOString().split('T')[0];
-
-            return await runSmartAutoCheckoutForDate(targetDate);
-          },
-          10 * 60 * 1000 // 10 min timeout for smart checkout
-        );
-      } catch (e) {
-        logger.error('Smart Auto Checkout nightly failed:', e);
-      }
-    },
-    {
-      scheduled: true,
-      timezone: 'Asia/Jakarta'
-    }
-  );
+    throw error;
+  }
 };
 
 export const triggerAutoCheckout = async () => {

--- a/src/jobs/createGeneralAlpha.job.js
+++ b/src/jobs/createGeneralAlpha.job.js
@@ -192,7 +192,7 @@ export const startCreateGeneralAlphaJob = () => {
   logger.info('Create General Alpha job scheduled to run on working days at 23:55');
 
   // Schedule cron job to run Monday-Friday at 23:55 Jakarta time
-  cron.schedule(
+  const task = cron.schedule(
     '55 23 * * 1-5',
     async () => {
       try {
@@ -212,6 +212,8 @@ export const startCreateGeneralAlphaJob = () => {
   );
 
   logger.info('Create General Alpha cron job has been initialized');
+
+  return task;
 };
 
 /**

--- a/src/jobs/resolveWfaBookings.job.js
+++ b/src/jobs/resolveWfaBookings.job.js
@@ -31,7 +31,7 @@ export const resolveWfaBookingsJob = async () => {
     await handleUnusedApprovedBookings(targetDate, jakartaTime);
 
     // TASK B: Handle expired pending bookings
-    await handleExpiredPendingBookings(targetDate, jakartaTime);
+    await handleExpiredPendingBookings(targetDate);
 
     logger.info('Resolve WFA bookings job completed successfully');
   } catch (error) {
@@ -51,7 +51,7 @@ export const resolveWfaBookingsForDate = async (targetDate) => {
 
     logger.info(`Resolve WFA bookings for explicit date: ${targetDate}`);
     await handleUnusedApprovedBookings(targetDate, jakartaTime);
-    await handleExpiredPendingBookings(targetDate, jakartaTime);
+    await handleExpiredPendingBookings(targetDate);
     return { success: true, targetDate };
   } catch (error) {
     logger.error('Error in resolveWfaBookingsForDate:', error);
@@ -148,7 +148,7 @@ const handleUnusedApprovedBookings = async (todayDate, jakartaTime) => {
 /**
  * Task B: Reject expired pending bookings
  */
-const handleExpiredPendingBookings = async (todayDate, _jakartaTime) => {
+const handleExpiredPendingBookings = async (todayDate) => {
   try {
     logger.info('Task B: Processing expired pending bookings...');
 
@@ -206,7 +206,7 @@ export const startResolveWfaBookingsJob = () => {
   logger.info('Resolve WFA Bookings job scheduled to run daily at 23:50');
 
   // Schedule cron job to run daily at 23:50 Jakarta time
-  cron.schedule(
+  const task = cron.schedule(
     '50 23 * * *',
     async () => {
       try {
@@ -226,6 +226,8 @@ export const startResolveWfaBookingsJob = () => {
   );
 
   logger.info('Resolve WFA Bookings cron job has been initialized');
+
+  return task;
 };
 
 /**

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -10,8 +10,12 @@ import wfaRoutes from './wfa.routes.js';
 import disciplineRoutes from './discipline.routes.js';
 import analysisRoutes from './analysis.routes.js';
 import settingsRoutes from './settings.routes.js';
+import { getLiveness, getReadiness } from '../controllers/health.controller.js';
 
 const router = express.Router();
+
+router.get('/livez', getLiveness);
+router.get('/health', getReadiness);
 
 // API routes
 router.use('/api/auth', authRoutes);
@@ -24,11 +28,6 @@ router.use('/api/wfa', wfaRoutes);
 router.use('/api/discipline', disciplineRoutes);
 router.use('/api/analysis', analysisRoutes);
 router.use('/api/settings', settingsRoutes);
-
-// Health check
-router.get('/health', (req, res) => {
-  res.json({ status: 'OK', timestamp: new Date().toISOString() });
-});
 
 // 404 handler
 router.use('*', (req, res) => {

--- a/src/server.js
+++ b/src/server.js
@@ -5,32 +5,62 @@ import app from './app.js';
 import config from './config/index.js';
 import sequelize from './config/database.js';
 import logger from './utils/logger.js';
-import { startCreateGeneralAlphaJob } from './jobs/createGeneralAlpha.job.js';
-import { startResolveWfaBookingsJob } from './jobs/resolveWfaBookings.job.js';
-import { startAutoCheckoutJob } from './jobs/autoCheckout.job.js';
+import { ensureSchedulerStarted } from './utils/schedulerLifecycle.js';
+import {
+  getReadinessSnapshot,
+  markDatabaseReady,
+  markDatabaseUnready,
+  markSchedulerUnready
+} from './utils/readinessState.js';
 
 (async () => {
+  let databaseReady = false;
+
   try {
     await sequelize.authenticate();
+    markDatabaseReady();
+    databaseReady = true;
     logger.info('Database connected successfully');
+  } catch (error) {
+    markDatabaseUnready();
+    markSchedulerUnready();
+    logger.error('Database connection failed', {
+      error: error.message,
+      stack: error.stack
+    });
+    logger.warn('Server will start without database connection; readiness will remain failed.');
+  }
 
-    // All smart features are now centralized in fuzzyAhpEngine.js
+  if (databaseReady) {
     logger.info('Fuzzy AHP Engine ready for intelligent features');
 
-    // Initialize all automated jobs
-    startCreateGeneralAlphaJob();
-    startResolveWfaBookingsJob();
-    startAutoCheckoutJob();
-
-    logger.info('All automated attendance jobs have been scheduled.');
-  } catch (err) {
-    logger.error('Database connection failed:', err.message);
-    logger.warn('Server will start without database connection');
+    try {
+      await ensureSchedulerStarted({ source: 'startup' });
+    } catch (schedulerError) {
+      logger.warn('Server will start without scheduled jobs; readiness will remain failed.', {
+        error: schedulerError.message,
+        stack: schedulerError.stack
+      });
+    }
   }
 
   app.listen(config.port, () => {
+    const readiness = getReadinessSnapshot();
+
     logger.info(`Server 🚀 on port ${config.port}`);
+    if (readiness.ready) {
+      logger.info('Startup dependencies are ready.');
+    } else {
+      logger.warn('Server started in degraded mode.', {
+        components: readiness.components,
+        missing: readiness.missing
+      });
+    }
+
     console.log(`🚀 Server running on port ${config.port}`);
+    if (!readiness.ready) {
+      console.warn(`⚠️ Startup readiness failed: ${readiness.missing.join(', ')}`);
+    }
     console.log(`📚 API Documentation: http://localhost:${config.port}/docs`);
   });
 })();

--- a/src/utils/readinessState.js
+++ b/src/utils/readinessState.js
@@ -1,0 +1,70 @@
+const initialComponents = {
+  database: false,
+  scheduler: false
+};
+
+function createInitialState() {
+  return {
+    components: { ...initialComponents }
+  };
+}
+
+let state = createInitialState();
+
+function setComponentReady(component, ready) {
+  if (state.components[component] === ready) {
+    return;
+  }
+
+  state = {
+    ...state,
+    components: {
+      ...state.components,
+      [component]: ready
+    }
+  };
+}
+
+function buildReadinessSnapshot(components) {
+  const missing = Object.entries(components)
+    .filter(([, ready]) => !ready)
+    .map(([component]) => component);
+  const ready = missing.length === 0;
+
+  return {
+    status: ready ? 'OK' : 'NOT_READY',
+    ready,
+    timestamp: new Date().toISOString(),
+    components: Object.fromEntries(
+      Object.entries(components).map(([component, componentReady]) => [
+        component,
+        componentReady ? 'ready' : 'not_ready'
+      ])
+    ),
+    missing
+  };
+}
+
+export function markDatabaseReady() {
+  setComponentReady('database', true);
+}
+
+export function markDatabaseUnready() {
+  setComponentReady('database', false);
+}
+
+export function markSchedulerReady() {
+  setComponentReady('scheduler', true);
+}
+
+export function markSchedulerUnready() {
+  setComponentReady('scheduler', false);
+}
+
+export function getReadinessSnapshot() {
+  return buildReadinessSnapshot(state.components);
+}
+
+export function resetReadinessState() {
+  state = createInitialState();
+}

--- a/src/utils/schedulerLifecycle.js
+++ b/src/utils/schedulerLifecycle.js
@@ -1,0 +1,167 @@
+import { startAutoCheckoutJob } from '../jobs/autoCheckout.job.js';
+import { startCreateGeneralAlphaJob } from '../jobs/createGeneralAlpha.job.js';
+import { startResolveWfaBookingsJob } from '../jobs/resolveWfaBookings.job.js';
+import logger from './logger.js';
+import {
+  getReadinessSnapshot,
+  markSchedulerReady,
+  markSchedulerUnready
+} from './readinessState.js';
+
+const schedulerStarters = [
+  { name: 'createGeneralAlpha', start: startCreateGeneralAlphaJob },
+  { name: 'resolveWfaBookings', start: startResolveWfaBookingsJob },
+  { name: 'autoCheckout', start: startAutoCheckoutJob }
+];
+
+let activeTasks = [];
+let activeTaskSetComplete = false;
+let startPromise = null;
+
+function isManageableTask(task) {
+  return Boolean(task && (typeof task.destroy === 'function' || typeof task.stop === 'function'));
+}
+
+function normalizeStartedTasks(result, jobName) {
+  const tasks = Array.isArray(result) ? result : [result];
+
+  if (tasks.length === 0 || tasks.some((task) => !isManageableTask(task))) {
+    throw new Error(`Scheduler job ${jobName} did not return manageable cron task handle(s)`);
+  }
+
+  return tasks;
+}
+
+function stopScheduledTask(task) {
+  if (typeof task?.destroy === 'function') {
+    task.destroy();
+    return;
+  }
+
+  if (typeof task?.stop === 'function') {
+    task.stop();
+  }
+}
+
+function stopTaskHandles(tasks) {
+  const rollbackTasks = [...tasks].reverse();
+  const stopFailures = [];
+
+  for (const task of rollbackTasks) {
+    try {
+      stopScheduledTask(task);
+    } catch (error) {
+      stopFailures.push({ task, error });
+      logger.warn('Scheduler task stop failed:', error);
+    }
+  }
+
+  return stopFailures;
+}
+
+function createStopFailureError(message, stopFailures, primaryError) {
+  const errors = [
+    ...(primaryError ? [primaryError] : []),
+    ...stopFailures.map(({ error }) => error)
+  ];
+
+  return new AggregateError(errors, message);
+}
+
+async function startScheduler({ source }) {
+  const startedTasks = [];
+  let failedJob;
+
+  try {
+    for (const { name, start } of schedulerStarters) {
+      failedJob = name;
+      const tasks = normalizeStartedTasks(await start(), name);
+      startedTasks.push(...tasks);
+    }
+
+    activeTasks = startedTasks;
+    activeTaskSetComplete = true;
+    markSchedulerReady();
+    logger.info('All automated attendance jobs have been scheduled.', {
+      source,
+      taskCount: activeTasks.length
+    });
+
+    return { started: true, taskCount: activeTasks.length };
+  } catch (error) {
+    const stopFailures = stopTaskHandles(startedTasks);
+    activeTasks = stopFailures.map(({ task }) => task);
+    activeTaskSetComplete = false;
+    markSchedulerUnready();
+    logger.error('Automated job scheduling failed', {
+      source,
+      failedJob,
+      rolledBackTasks: startedTasks.length - stopFailures.length,
+      failedRollbackTasks: stopFailures.length,
+      rollbackErrors: stopFailures.map(({ error: stopError }) => stopError.message),
+      error: error.message,
+      stack: error.stack
+    });
+
+    if (stopFailures.length > 0) {
+      throw createStopFailureError(
+        'Automated job scheduling failed and rollback did not stop all task handles',
+        stopFailures,
+        error
+      );
+    }
+
+    throw error;
+  }
+}
+
+export async function ensureSchedulerStarted({ source = 'unknown' } = {}) {
+  if (activeTasks.length > 0) {
+    if (!activeTaskSetComplete) {
+      stopSchedulerJobs({ source: `${source}:rollback-retry` });
+    } else {
+      const readiness = getReadinessSnapshot();
+
+      if (readiness.components.scheduler !== 'ready') {
+        markSchedulerReady();
+      }
+
+      return { started: false, taskCount: activeTasks.length };
+    }
+  }
+
+  if (!startPromise) {
+    startPromise = startScheduler({ source });
+  }
+
+  try {
+    return await startPromise;
+  } finally {
+    startPromise = null;
+  }
+}
+
+export function stopSchedulerJobs({ source = 'unknown' } = {}) {
+  const taskCount = activeTasks.length;
+  const stopFailures = stopTaskHandles(activeTasks);
+
+  if (stopFailures.length > 0) {
+    activeTasks = stopFailures.map(({ task }) => task);
+    activeTaskSetComplete = false;
+    markSchedulerUnready();
+    logger.error('Automated attendance jobs stop failed.', {
+      source,
+      taskCount,
+      failedStopTasks: stopFailures.length,
+      stopErrors: stopFailures.map(({ error }) => error.message)
+    });
+    throw createStopFailureError('Automated attendance jobs stop failed.', stopFailures);
+  }
+
+  activeTasks = [];
+  activeTaskSetComplete = false;
+  markSchedulerUnready();
+  logger.info('Automated attendance jobs have been stopped.', { source, taskCount });
+
+  return { stopped: taskCount };
+}

--- a/test-production.sh
+++ b/test-production.sh
@@ -1,99 +1,185 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
-# 🧪 Infinite Track Backend - Production Testing Script
-# This script tests all critical functionality in production
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
 
-set -e
+DOMAIN="${DOMAIN:-localhost}"
+ADMIN_TOKEN="${ADMIN_TOKEN:-}"
+DEPLOY_PATH="${DEPLOY_PATH:-/opt/infinite-track/backend}"
+LOCAL_BASE_URL="${LOCAL_BASE_URL:-http://127.0.0.1:3005}"
 
-# Configuration
-DOMAIN="localhost:3005"  # Change to your production domain
-ADMIN_TOKEN=""  # Set your admin JWT token
-API_BASE="http://$DOMAIN/api"
+build_default_public_base_url() {
+    case "$DOMAIN" in
+        localhost*|127.0.0.1*)
+            printf 'http://%s' "$DOMAIN"
+            ;;
+        *)
+            printf 'https://%s' "$DOMAIN"
+            ;;
+    esac
+}
 
-# Colors
+PUBLIC_BASE_URL="${PUBLIC_BASE_URL:-$(build_default_public_base_url)}"
+API_BASE="${API_BASE:-${PUBLIC_BASE_URL}/api}"
+
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 RED='\033[0;31m'
 BLUE='\033[0;34m'
 NC='\033[0m'
 
-print_success() { echo -e "${GREEN}✅ $1${NC}"; }
-print_warning() { echo -e "${YELLOW}⚠️  $1${NC}"; }
-print_error() { echo -e "${RED}❌ $1${NC}"; }
-print_info() { echo -e "${BLUE}ℹ️  $1${NC}"; }
+print_success() { echo -e "${GREEN}OK${NC} $1"; }
+print_warning() { echo -e "${YELLOW}WARN${NC} $1"; }
+print_error() { echo -e "${RED}ERROR${NC} $1"; }
+print_info() { echo -e "${BLUE}INFO${NC} $1"; }
 
-# Function to check if curl is available
 check_curl() {
-    if ! command -v curl &> /dev/null; then
+    if ! command -v curl >/dev/null 2>&1; then
         print_error "curl is required but not installed"
         exit 1
     fi
 }
 
-# Function to make API request
-api_request() {
-    local method=$1
-    local endpoint=$2
-    local data=$3
-    local curl_args=(-s -X "$method" "$API_BASE$endpoint")
-
-    if [ -n "$ADMIN_TOKEN" ]; then
-        curl_args+=(-H "Authorization: Bearer $ADMIN_TOKEN")
+check_python() {
+    if ! command -v python3 >/dev/null 2>&1; then
+        print_error "python3 is required for JSON contract verification"
+        exit 1
     fi
-
-    if [ -n "$data" ]; then
-        curl_args+=(-H "Content-Type: application/json" -d "$data")
-    fi
-
-    curl "${curl_args[@]}"
 }
 
-# Test health endpoint
-test_health() {
-    print_info "Testing health endpoint..."
-    
-    local response=$(curl -s -o /dev/null -w "%{http_code}" "http://$DOMAIN/health")
-    
-    if [ "$response" = "200" ]; then
-        print_success "Health check passed"
-        return 0
-    else
-        print_error "Health check failed (HTTP $response)"
+check_http_contract() {
+    local url="$1"
+    local label="$2"
+    local mode="$3"
+    local response_file
+    local status
+    local body
+
+    response_file="$(mktemp)"
+
+    if ! status="$(curl --silent --show-error --output "$response_file" --write-out '%{http_code}' "$url")"; then
+        rm -f "$response_file"
+        print_error "$label request failed for $url"
         return 1
     fi
+
+    if ! body="$(python3 - "$response_file" "$status" "$label" "$mode" <<'PY'
+import json
+import sys
+
+response_file, status_code, label, mode = sys.argv[1:]
+status_code = int(status_code)
+
+with open(response_file, 'r', encoding='utf-8') as handle:
+    raw_body = handle.read()
+
+try:
+    data = json.loads(raw_body)
+except json.JSONDecodeError as exc:
+    print(f"invalid JSON: {exc}", file=sys.stderr)
+    print(raw_body, file=sys.stderr)
+    sys.exit(1)
+
+if status_code != 200:
+    print(f"unexpected HTTP {status_code}", file=sys.stderr)
+    print(json.dumps(data, ensure_ascii=False), file=sys.stderr)
+    sys.exit(1)
+
+if data.get('status') != 'OK':
+    print("unexpected status field", file=sys.stderr)
+    print(json.dumps(data, ensure_ascii=False), file=sys.stderr)
+    sys.exit(1)
+
+if mode == 'readiness':
+    if data.get('ready') is not True:
+        print("readiness flag is not true", file=sys.stderr)
+        print(json.dumps(data, ensure_ascii=False), file=sys.stderr)
+        sys.exit(1)
+    if not isinstance(data.get('components'), dict):
+        print("readiness components missing", file=sys.stderr)
+        print(json.dumps(data, ensure_ascii=False), file=sys.stderr)
+        sys.exit(1)
+    if not isinstance(data.get('missing'), list):
+        print("readiness missing array absent", file=sys.stderr)
+        print(json.dumps(data, ensure_ascii=False), file=sys.stderr)
+        sys.exit(1)
+
+print(json.dumps(data, ensure_ascii=False))
+PY
+)"; then
+        rm -f "$response_file"
+        print_error "$label returned an invalid health contract"
+        return 1
+    fi
+
+    rm -f "$response_file"
+    print_success "$label passed"
+    print_info "$body"
 }
 
-# Test basic API endpoints
-test_basic_endpoints() {
-    print_info "Testing basic API endpoints..."
-    
-    # Test root endpoint
-    local response=$(curl -s -o /dev/null -w "%{http_code}" "$API_BASE/")
-    if [ "$response" = "200" ] || [ "$response" = "404" ]; then
-        print_success "API base endpoint accessible"
-    else
-        print_error "API base endpoint failed (HTTP $response)"
-    fi
-    
-    # Test authentication endpoint
-    response=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$API_BASE/auth/login" -H "Content-Type: application/json" -d "{}")
-    if [ "$response" = "400" ] || [ "$response" = "422" ]; then
-        print_success "Auth endpoint accessible (expected validation error)"
-    else
-        print_warning "Auth endpoint returned HTTP $response"
-    fi
+test_local_liveness() {
+    print_info "Testing local liveness endpoint..."
+    check_http_contract "${LOCAL_BASE_URL}/livez" "Local liveness" "liveness"
 }
 
-# Test read-only admin operational endpoints (requires admin token)
+test_local_readiness() {
+    print_info "Testing local readiness endpoint..."
+    check_http_contract "${LOCAL_BASE_URL}/health" "Local readiness" "readiness"
+}
+
+test_public_liveness() {
+    print_info "Testing public liveness endpoint..."
+    check_http_contract "${PUBLIC_BASE_URL}/livez" "Public liveness" "liveness"
+}
+
+test_public_readiness() {
+    print_info "Testing public readiness endpoint..."
+    check_http_contract "${PUBLIC_BASE_URL}/health" "Public readiness" "readiness"
+}
+
+test_api_documentation() {
+    print_info "Testing API documentation endpoint..."
+
+    local response
+    response="$(curl -s -o /dev/null -w "%{http_code}" "${PUBLIC_BASE_URL}/docs/")"
+
+    if [ "$response" = "200" ]; then
+        print_success "API documentation endpoint is reachable"
+        return 0
+    fi
+
+    print_error "API documentation endpoint failed with HTTP $response"
+    return 1
+}
+
+test_auth_endpoint() {
+    print_info "Testing auth endpoint..."
+
+    local response
+    response="$(curl -s -o /dev/null -w "%{http_code}" -X POST "${API_BASE}/auth/login" -H "Content-Type: application/json" -d '{}')"
+
+    if [ "$response" = "400" ] || [ "$response" = "401" ] || [ "$response" = "422" ]; then
+        print_success "Auth endpoint rejects invalid payload as expected"
+        return 0
+    fi
+
+    print_error "Auth endpoint returned unexpected HTTP $response"
+    return 1
+}
+
 test_admin_operational_endpoints() {
     if [ -z "$ADMIN_TOKEN" ]; then
-        print_warning "Skipping admin operational endpoint tests (no admin token provided)"
+        print_warning "Skipping admin operational endpoint tests because no admin token was provided"
         return 0
     fi
 
     print_info "Testing read-only admin operational endpoints..."
 
-    ADMIN_ENDPOINTS=(
+    local endpoint
+    local response
+    local failures=0
+    local admin_endpoints=(
         "/settings/operational"
         "/attendance/auto-checkout-settings"
         "/attendance/smart-config"
@@ -101,195 +187,194 @@ test_admin_operational_endpoints() {
         "/attendance/today-locations"
     )
 
-    for endpoint in "${ADMIN_ENDPOINTS[@]}"; do
-        local response=$(curl -s -o /dev/null -w "%{http_code}" "$API_BASE$endpoint" -H "Authorization: Bearer $ADMIN_TOKEN")
+    for endpoint in "${admin_endpoints[@]}"; do
+        response="$(curl -s -o /dev/null -w "%{http_code}" "${API_BASE}${endpoint}" -H "Authorization: Bearer ${ADMIN_TOKEN}")"
 
         if [ "$response" = "200" ]; then
-            print_success "Admin endpoint $endpoint working"
+            print_success "Admin endpoint ${endpoint} returned 200"
         elif [ "$response" = "401" ] || [ "$response" = "403" ]; then
-            print_warning "Admin endpoint $endpoint rejected credentials (HTTP $response)"
+            print_error "Admin endpoint ${endpoint} rejected credentials with HTTP $response"
+            failures=$((failures + 1))
         else
-            print_warning "Admin endpoint $endpoint returned HTTP $response"
+            print_error "Admin endpoint ${endpoint} returned unexpected HTTP $response"
+            failures=$((failures + 1))
         fi
     done
-}
 
-# Test database connectivity
-test_database() {
-    print_info "Testing database connectivity..."
-    
-    # Test attendance endpoint (basic DB read)
-    local response=$(curl -s -o /dev/null -w "%{http_code}" "$API_BASE/attendance")
-    
-    if [ "$response" = "200" ] || [ "$response" = "401" ]; then
-        print_success "Database connectivity working (attendance endpoint accessible)"
-    else
-        print_error "Database connectivity issues (HTTP $response)"
+    if [ "$failures" -gt 0 ]; then
+        return 1
     fi
+
+    return 0
 }
 
-# Test PM2 status
-test_pm2_status() {
-    print_info "Testing PM2 status..."
-    
-    if command -v pm2 &> /dev/null; then
-        local pm2_status=$(pm2 jlist 2>/dev/null | jq -r '.[0].pm2_env.status' 2>/dev/null || echo "unknown")
-        
-        if [ "$pm2_status" = "online" ]; then
-            print_success "PM2 process is online"
-        else
-            print_warning "PM2 status: $pm2_status"
-        fi
-        
-        # Check for recent restarts
-        local restarts=$(pm2 jlist 2>/dev/null | jq -r '.[0].pm2_env.restart_time' 2>/dev/null || echo "0")
-        if [ "$restarts" -lt "5" ]; then
-            print_success "PM2 restart count is healthy ($restarts restarts)"
-        else
-            print_warning "High PM2 restart count: $restarts"
-        fi
-    else
-        print_warning "PM2 not available for testing"
+test_container_runtime() {
+    print_info "Testing Docker Compose runtime state..."
+
+    if ! command -v docker >/dev/null 2>&1; then
+        print_error "Docker CLI is not available on this host"
+        return 1
     fi
-}
 
-# Test log files
-test_logs() {
-    print_info "Testing log files..."
-    
-    # Check if log directory exists
-    if [ -d "logs" ]; then
-        print_success "Log directory exists"
-        
-        # Check for recent logs
-        local recent_logs=$(find logs -name "*.log" -mtime -1 | wc -l)
-        if [ "$recent_logs" -gt "0" ]; then
-            print_success "Recent log files found ($recent_logs files)"
-        else
-            print_warning "No recent log files found"
-        fi
-        
-        # Check for errors in recent logs
-        local error_count=$(find logs -name "*.log" -mtime -1 -exec grep -i "error" {} \; 2>/dev/null | wc -l)
-        if [ "$error_count" -eq "0" ]; then
-            print_success "No errors in recent logs"
-        else
-            print_warning "Found $error_count error entries in recent logs"
-        fi
-    else
-        print_warning "Log directory not found"
+    if [ ! -f "${DEPLOY_PATH}/docker-compose.yml" ]; then
+        print_error "docker-compose.yml not found at ${DEPLOY_PATH}"
+        return 1
     fi
-}
 
-# Test SSL/HTTPS (if applicable)
-test_ssl() {
-    if [[ $DOMAIN == *"localhost"* ]] || [[ $DOMAIN == *"127.0.0.1"* ]]; then
-        print_info "Skipping SSL test (localhost deployment)"
+    if ! docker compose -f "${DEPLOY_PATH}/docker-compose.yml" ps app; then
+        print_error "Failed to inspect Docker Compose app service"
+        return 1
+    fi
+
+    if ! docker inspect infinit-track-app >/dev/null 2>&1; then
+        print_error "Container infinit-track-app is not visible from this host"
+        return 1
+    fi
+
+    local container_status
+    local health_status
+    container_status="$(docker inspect --format '{{.State.Status}}' infinit-track-app)"
+    health_status="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' infinit-track-app)"
+
+    if [ "$container_status" = "running" ]; then
+        print_success "Container infinit-track-app is running"
+    else
+        print_error "Container infinit-track-app is ${container_status}"
+        return 1
+    fi
+
+    if [ "$health_status" = "healthy" ]; then
+        print_success "Container health state is ${health_status}"
         return 0
     fi
-    
-    print_info "Testing SSL certificate..."
-    
-    local ssl_response=$(curl -s -o /dev/null -w "%{http_code}" "https://$DOMAIN/health" 2>/dev/null || echo "failed")
-    
-    if [ "$ssl_response" = "200" ]; then
-        print_success "SSL certificate working"
-    else
-        print_warning "SSL test failed or HTTPS not configured"
+
+    if [ "$health_status" = "none" ]; then
+        print_error "Container healthcheck is missing"
+        return 1
     fi
+
+    print_error "Container health state is ${health_status}"
+    return 1
 }
 
-# Performance test
+test_ssl() {
+    case "$PUBLIC_BASE_URL" in
+        http://localhost*|http://127.0.0.1*)
+            print_info "Skipping SSL test for local base URL"
+            return 0
+            ;;
+    esac
+
+    print_info "Testing public HTTPS connectivity..."
+
+    local response
+    response="$(curl -s -o /dev/null -w "%{http_code}" "${PUBLIC_BASE_URL}/livez" 2>/dev/null || echo "failed")"
+
+    if [ "$response" = "200" ]; then
+        print_success "HTTPS endpoint is reachable"
+        return 0
+    fi
+
+    print_error "HTTPS connectivity check failed"
+    return 1
+}
+
 test_performance() {
-    print_info "Running basic performance test..."
-    
-    local start_time=$(date +%s%N)
-    curl -s "http://$DOMAIN/health" > /dev/null
-    local end_time=$(date +%s%N)
-    
-    local response_time=$(( (end_time - start_time) / 1000000 ))
-    
-    if [ "$response_time" -lt "500" ]; then
+    print_info "Running basic response time check..."
+
+    local start_time
+    local end_time
+    local response_time
+
+    start_time="$(date +%s%N)"
+    curl -s "${PUBLIC_BASE_URL}/livez" >/dev/null
+    end_time="$(date +%s%N)"
+    response_time=$(( (end_time - start_time) / 1000000 ))
+
+    if [ "$response_time" -lt 500 ]; then
         print_success "Response time good: ${response_time}ms"
-    elif [ "$response_time" -lt "1000" ]; then
+    elif [ "$response_time" -lt 1000 ]; then
         print_warning "Response time acceptable: ${response_time}ms"
     else
         print_error "Response time slow: ${response_time}ms"
+        return 1
     fi
 }
 
-# Main test function
 run_tests() {
-    echo "🧪 Infinite Track Backend - Production Testing"
-    echo "=============================================="
-    echo "Testing domain: $DOMAIN"
+    echo "Infinite Track Backend - Production Verification"
+    echo "==============================================="
+    echo "Local base URL : ${LOCAL_BASE_URL}"
+    echo "Public base URL: ${PUBLIC_BASE_URL}"
+    echo "Deploy path    : ${DEPLOY_PATH}"
     echo ""
-    
+
     local failed_tests=0
-    
-    # Core functionality tests
-    test_health || ((failed_tests++))
-    test_basic_endpoints || ((failed_tests++))
-    test_database || ((failed_tests++))
-    
-    # System tests
-    test_pm2_status
-    test_logs
-    test_performance
-    
-    # Security tests
-    test_ssl
-    
-    # Admin functionality tests
-    test_admin_operational_endpoints
-    
+
+    test_local_liveness || failed_tests=$((failed_tests + 1))
+    test_local_readiness || failed_tests=$((failed_tests + 1))
+    test_public_liveness || failed_tests=$((failed_tests + 1))
+    test_public_readiness || failed_tests=$((failed_tests + 1))
+    test_api_documentation || failed_tests=$((failed_tests + 1))
+    test_container_runtime || failed_tests=$((failed_tests + 1))
+    test_performance || failed_tests=$((failed_tests + 1))
+
+    test_auth_endpoint || failed_tests=$((failed_tests + 1))
+    test_ssl || failed_tests=$((failed_tests + 1))
+    test_admin_operational_endpoints || failed_tests=$((failed_tests + 1))
+
     echo ""
-    echo "🎯 Test Summary"
-    echo "==============="
-    
-    if [ "$failed_tests" -eq "0" ]; then
-        print_success "All critical tests passed! 🎉"
-        echo ""
-        print_info "Production system appears to be working correctly"
-        print_info "Monitor logs and performance for ongoing stability"
-    else
-        print_error "$failed_tests critical tests failed"
-        echo ""
-        print_info "Please review failed tests and fix issues before going live"
+    echo "Summary"
+    echo "======="
+
+    if [ "$failed_tests" -eq 0 ]; then
+        print_success "All critical verification checks passed"
+        return 0
     fi
-    
-    echo ""
-    print_info "Additional manual tests recommended:"
-    echo "  - Load testing with realistic traffic"
-    echo "  - Full user workflow testing"
-    echo "  - Database backup/restore testing"
-    echo "  - Failover scenario testing"
+
+    print_error "$failed_tests critical verification checks failed"
+    return 1
 }
 
-# Help function
 show_help() {
-    echo "🧪 Infinite Track Backend - Production Testing Script"
+    echo "Infinite Track Backend - Production Verification Script"
     echo ""
     echo "Usage: $0 [OPTIONS]"
     echo ""
     echo "Options:"
-    echo "  -d, --domain DOMAIN    Set the domain to test (default: localhost:3005)"
-    echo "  -t, --token TOKEN      Set admin JWT token for authenticated tests"
-    echo "  -h, --help            Show this help message"
+    echo "  -d, --domain DOMAIN            Set public domain or host (default: localhost)"
+    echo "  -l, --local-base-url URL       Set local loopback base URL (default: http://127.0.0.1:3005)"
+    echo "  -u, --public-base-url URL      Set public base URL (default: derived from domain)"
+    echo "  -p, --deploy-path PATH         Set droplet deploy path (default: /opt/infinite-track/backend)"
+    echo "  -t, --token TOKEN              Set admin JWT token for authenticated checks"
+    echo "  -h, --help                     Show this help message"
     echo ""
     echo "Examples:"
-    echo "  $0                                    # Test localhost"
-    echo "  $0 -d your-domain.com               # Test production domain"
-    echo "  $0 -d localhost:3005 -t eyJ...      # Test with admin token"
+    echo "  $0"
+    echo "  $0 -d api.example.com"
+    echo "  $0 -u https://api.example.com -p /opt/infinite-track/backend"
     echo ""
 }
 
-# Parse command line arguments
 while [[ $# -gt 0 ]]; do
     case $1 in
         -d|--domain)
             DOMAIN="$2"
-            API_BASE="http://$DOMAIN/api"
+            PUBLIC_BASE_URL="$(build_default_public_base_url)"
+            API_BASE="${PUBLIC_BASE_URL}/api"
+            shift 2
+            ;;
+        -l|--local-base-url)
+            LOCAL_BASE_URL="$2"
+            shift 2
+            ;;
+        -u|--public-base-url)
+            PUBLIC_BASE_URL="$2"
+            API_BASE="${PUBLIC_BASE_URL}/api"
+            shift 2
+            ;;
+        -p|--deploy-path)
+            DEPLOY_PATH="$2"
             shift 2
             ;;
         -t|--token)
@@ -308,6 +393,6 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Main execution
 check_curl
+check_python
 run_tests

--- a/tests/bookingsReadinessContract.test.js
+++ b/tests/bookingsReadinessContract.test.js
@@ -100,7 +100,8 @@ describe('bookings route contract', () => {
 describe('bookings validator contract', () => {
   test('missing schedule_date returns 400', async () => {
     const app = buildValidatorApp();
-    const { schedule_date, ...payload } = validBookingPayload;
+    const payload = { ...validBookingPayload };
+    delete payload.schedule_date;
 
     await request(app).post('/bookings').send(payload).expect(400);
   });

--- a/tests/clientCriticalOpenApiContract.test.js
+++ b/tests/clientCriticalOpenApiContract.test.js
@@ -153,12 +153,15 @@ describe('client-critical OpenAPI contract', () => {
   });
 
   test('documents booking admin list query filters exposed to clients', () => {
-    const bookingListParameters = openapi.paths['/api/bookings'].get.parameters;
-    const parameterNames = bookingListParameters.map((parameter) => parameter.name);
+    const bookingListOperation = openapi.paths['/api/bookings'].get;
+    const parameterNames = bookingListOperation.parameters.map((parameter) => parameter.name);
 
     expect(parameterNames).toEqual(
       expect.arrayContaining(['page', 'limit', 'status', 'date_from', 'date_to', 'user_id'])
     );
+    expect(bookingListOperation.responses).toHaveProperty('400');
+    expect(bookingListOperation.responses).toHaveProperty('401');
+    expect(bookingListOperation.responses).toHaveProperty('403');
   });
 
   test('documents booking creation success response shape from the runtime controller', () => {

--- a/tests/configContract.test.js
+++ b/tests/configContract.test.js
@@ -20,6 +20,18 @@ function readDockerCompose() {
   return fs.readFileSync(path.resolve(process.cwd(), 'docker-compose.yml'), 'utf8');
 }
 
+function readDockerfile() {
+  return fs.readFileSync(path.resolve(process.cwd(), 'Dockerfile'), 'utf8');
+}
+
+function readK8sDeployment() {
+  return fs.readFileSync(path.resolve(process.cwd(), 'k8s/app-deployment.yaml'), 'utf8');
+}
+
+function readScript(relativePath) {
+  return fs.readFileSync(path.resolve(process.cwd(), relativePath), 'utf8');
+}
+
 function migrationFiles() {
   return fs.readdirSync(path.resolve(process.cwd(), 'src/models/migrations')).sort();
 }
@@ -31,6 +43,86 @@ function loadCliConfig() {
   delete require.cache[configPath];
 
   return require(configPath);
+}
+
+function readDoDeploySpec(fileName) {
+  return fs.readFileSync(path.resolve(process.cwd(), '.do', fileName), 'utf8');
+}
+
+function readDoReadme() {
+  return fs.readFileSync(path.resolve(process.cwd(), '.do/README.md'), 'utf8');
+}
+
+function readRootReadme() {
+  return fs.readFileSync(path.resolve(process.cwd(), 'README.md'), 'utf8');
+}
+
+function readClaudeInstructions() {
+  return fs.readFileSync(path.resolve(process.cwd(), 'CLAUDE.md'), 'utf8');
+}
+
+function readWorkflow(relativePath) {
+  return fs.readFileSync(path.resolve(process.cwd(), relativePath), 'utf8');
+}
+
+function buildRes() {
+  const res = {};
+  res.status = jest.fn(() => res);
+  res.json = jest.fn(() => res);
+  return res;
+}
+
+async function loadWfaControllerWithMocks({ axiosGet, logger, settingsValue = null } = {}) {
+  const axiosGetMock = axiosGet || jest.fn().mockResolvedValue({ data: { features: [] } });
+  const loggerMock =
+    logger ||
+    ({
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn()
+    });
+
+  jest.unstable_mockModule('axios', () => ({
+    default: {
+      get: axiosGetMock
+    }
+  }));
+
+  jest.unstable_mockModule('../src/models/settings.model.js', () => ({
+    default: {
+      findOne: jest.fn().mockResolvedValue(settingsValue)
+    }
+  }));
+
+  jest.unstable_mockModule('../src/utils/logger.js', () => ({
+    default: loggerMock
+  }));
+
+  jest.unstable_mockModule('../src/utils/fuzzyAhpEngine.js', () => ({
+    default: {
+      getWfaAhpWeights: jest.fn(() => ({
+        location_type: 0.4,
+        amenity_score: 0.4,
+        distance_factor: 0.2,
+        consistency_ratio: 0.05
+      })),
+      calculateWfaScore: jest.fn(),
+      getCategoryDisplayName: jest.fn((value) => value),
+      categorizePlace: jest.fn(() => 'catering')
+    }
+  }));
+
+  jest.unstable_mockModule('../src/utils/geofence.js', () => ({
+    calculateDistance: jest.fn(() => 0)
+  }));
+
+  const controller = await import('../src/controllers/wfa.controller.js');
+
+  return {
+    ...controller,
+    axiosGetMock,
+    loggerMock
+  };
 }
 
 describe('backend runtime config contract', () => {
@@ -118,6 +210,190 @@ describe('backend runtime config contract', () => {
     expect(compose).toContain('http://127.0.0.1:3005/health');
   });
 
+  test('maps probe consumers to liveness or readiness endpoints by intent', () => {
+    const dockerfile = readDockerfile();
+    const compose = readDockerCompose();
+    const k8sDeployment = readK8sDeployment();
+    const stagingSpec = readDoDeploySpec('app.yaml');
+    const productionSpec = readDoDeploySpec('app-production.yaml');
+
+    expect(dockerfile).toContain('http://localhost:3005/health');
+    expect(compose).toContain('http://127.0.0.1:3005/health');
+    expect(k8sDeployment).toContain('Legacy/historical backend artifact only.');
+    expect(k8sDeployment).toContain('registry.digitalocean.com/infinit-track/infinit-track-backend');
+    expect(k8sDeployment).toContain('containerPort: 3005');
+    expect(k8sDeployment).toMatch(/livenessProbe:\s+httpGet:\s+path: \/livez/s);
+    expect(k8sDeployment).toMatch(/livenessProbe:\s+httpGet:\s+path: \/livez\s+port: 3005/s);
+    expect(k8sDeployment).toMatch(/readinessProbe:\s+httpGet:\s+path: \/health/s);
+    expect(k8sDeployment).toMatch(/readinessProbe:\s+httpGet:\s+path: \/health\s+port: 3005/s);
+    expect(stagingSpec).toContain('http_path: /health');
+    expect(productionSpec).toContain('http_path: /health');
+  });
+
+  test('operator verification scripts check liveness and readiness explicitly', () => {
+    const smokeTest = readScript('scripts/smoke-test.js');
+    const healthCheck = readScript('health-check.sh');
+    const productionTest = readScript('test-production.sh');
+    const dropletVerify = readScript('deploy/scripts/verify-droplet-api.sh');
+
+    expect(smokeTest).toContain('/livez');
+    expect(smokeTest).toContain('/health');
+    expect(smokeTest).toContain('const originAllowed = corsHeader === requestedOrigin;');
+    expect(smokeTest).toContain("const credentialsAllowed = credentialsHeader === 'true';");
+    expect(smokeTest).toContain('Allow-Credentials');
+    expect(smokeTest).not.toContain("corsHeader === '*'");
+    expect(healthCheck).toContain('/livez');
+    expect(healthCheck).toContain('/health');
+    expect(healthCheck).toContain('http://localhost:${PORT:-3005}');
+    expect(healthCheck).not.toContain('http://localhost:${PORT:-3000}');
+    expect(healthCheck).toContain('curl is required to run health probes');
+    expect(healthCheck).toContain('python3 is required to validate health JSON contracts');
+    expect(healthCheck).toContain('check_http_contract');
+    expect(healthCheck).toContain('json.loads(raw_body)');
+    expect(healthCheck).toContain("data.get('status') != 'OK'");
+    expect(healthCheck).toContain("data.get('ready') is not True");
+    expect(healthCheck).toContain("isinstance(data.get('components'), dict)");
+    expect(healthCheck).toContain("isinstance(data.get('missing'), list)");
+    expect(productionTest).toContain('/livez');
+    expect(productionTest).toContain('/health');
+    expect(productionTest).toContain('check_http_contract');
+    expect(productionTest).toContain('test_container_runtime');
+    expect(productionTest).toContain('python3 is required for JSON contract verification');
+    expect(productionTest).toContain('json.loads(raw_body)');
+    expect(productionTest).toContain("data.get('status') != 'OK'");
+    expect(productionTest).toContain("data.get('ready') is not True");
+    expect(productionTest).toContain("isinstance(data.get('components'), dict)");
+    expect(productionTest).toContain("isinstance(data.get('missing'), list)");
+    expect(productionTest).toContain('docker compose -f "${DEPLOY_PATH}/docker-compose.yml" ps app');
+    expect(productionTest).not.toContain('docker compose -f "${DEPLOY_PATH}/docker-compose.yml" ps app || true');
+    expect(productionTest).toContain('docker inspect infinit-track-app >/dev/null 2>&1');
+    expect(productionTest).toContain('Container healthcheck is missing');
+    expect(productionTest).toContain('Auth endpoint returned unexpected HTTP');
+    expect(productionTest).toContain('Admin endpoint ${endpoint} rejected credentials');
+    expect(productionTest).toContain('Local readiness');
+    expect(productionTest).toContain('Public readiness');
+    expect(productionTest).not.toContain('PM2');
+    expect(productionTest).not.toContain('pm2');
+    expect(dropletVerify).toContain('/livez');
+    expect(dropletVerify).toContain('/health');
+    expect(dropletVerify).toContain("check_json_endpoint");
+    expect(dropletVerify).toContain('python3 is required for JSON readiness verification');
+    expect(dropletVerify).toContain('socket.getaddrinfo');
+    expect(dropletVerify).toContain('DNS_FAIL lookup failed');
+    expect(dropletVerify).not.toContain('getent ahostsv4');
+    expect(dropletVerify).toContain("data.get('status') != 'OK'");
+    expect(dropletVerify).toContain("data.get('ready') is not True");
+    expect(dropletVerify).toContain("isinstance(data.get('components'), dict)");
+    expect(dropletVerify).toContain("isinstance(data.get('missing'), list)");
+  });
+
+  test('documents DigitalOcean health semantics with separate liveness and readiness checks', () => {
+    const deployReadme = readDoReadme();
+
+    expect(deployReadme).toContain('/livez');
+    expect(deployReadme).toContain('/health');
+    expect(deployReadme).toContain('"ready":true');
+    expect(deployReadme).toContain('"components"');
+    expect(deployReadme).toContain('"missing"');
+    expect(deployReadme).toContain('HTTP `503`');
+    expect(deployReadme).toContain('`missing` array');
+    expect(deployReadme).not.toContain(
+      '- **Success Response:** `{"status":"OK","timestamp":"..."}`'
+    );
+  });
+
+  test('documents root health semantics with separate liveness and readiness checks', () => {
+    const readme = readRootReadme();
+
+    expect(readme).toContain('/livez');
+    expect(readme).toContain('/health');
+    expect(readme).toContain('Process liveness');
+    expect(readme).toContain('Dependency readiness');
+    expect(readme).toContain('HTTP `503`');
+    expect(readme).toContain('`missing` array');
+    expect(readme).not.toContain('# Expected: {"status":"OK","timestamp":"..."}');
+    expect(readme).not.toContain('GET /health              # Basic server health');
+  });
+
+  test('documents droplet and DOCR as the canonical backend deployment path', () => {
+    const claude = readClaudeInstructions();
+    const readme = readRootReadme();
+    const deployReadme = readDoReadme();
+    const dropletRuntime = readScript('docs/droplet-docr-runtime.md');
+
+    expect(claude).toContain('Canonical backend runtime is the droplet-hosted Docker Compose stack');
+    expect(claude).toContain('registry.digitalocean.com/infinit-track/infinit-track-backend');
+    expect(claude).toContain('Treat `.do/app*.yaml` and `k8s/` as legacy or historical backend paths');
+    expect(readme).toContain('DigitalOcean Container Registry (DOCR) + droplet-hosted Docker Compose runtime + host Nginx');
+    expect(readme).toContain('registry.digitalocean.com/infinit-track/infinit-track-backend');
+    expect(readme).toContain('Smoke/readiness verification adalah release gate');
+    expect(readme).toContain('Staging host is environment-specific');
+    expect(readme).toContain('Docker Compose');
+    expect(readme).toContain('bash ./test-production.sh --local-base-url http://127.0.0.1:3005 --public-base-url http://127.0.0.1:3005');
+    expect(readme).not.toContain('**PM2**');
+    expect(readme).not.toContain('npm run prod:pm2');
+    expect(readme).not.toContain('DigitalOcean App Platform dan GitHub Actions');
+    expect(readme).not.toContain('https://infinit-track-staging.ondigitalocean.app');
+    expect(readme).not.toContain('https://api.yourdomain.com');
+    expect(readme).not.toContain('doctl apps list');
+    expect(deployReadme).toContain('App Platform Backend Specs (Legacy)');
+    expect(deployReadme).toContain('bukan lagi App Platform');
+    expect(dropletRuntime).toContain('registry.digitalocean.com/infinit-track/infinit-track-backend');
+    expect(dropletRuntime).toContain('/livez');
+    expect(dropletRuntime).toContain('/health');
+    expect(dropletRuntime).toContain('127.0.0.1:3005');
+    expect(dropletRuntime).toContain('docker compose up -d --force-recreate app');
+    expect(dropletRuntime).toContain('docker compose exec -T app npm run migrate');
+    expect(dropletRuntime).toContain('./deploy/scripts/verify-droplet-api.sh');
+    expect(dropletRuntime).toContain('npm run smoke-test https://<public-domain>');
+    expect(dropletRuntime).not.toContain('localhost:3000');
+    expect(dropletRuntime).not.toContain('docker compose up -d app');
+  });
+
+  test('locks staging and production workflows to droplet rollout with blocking verification', () => {
+    const stagingWorkflow = readWorkflow('.github/workflows/deploy-staging.yml');
+    const productionWorkflow = readWorkflow('.github/workflows/deploy-production.yml');
+    const dockerDeployWorkflow = readWorkflow('.github/workflows/docker-deploy.yml');
+
+    expect(stagingWorkflow).toContain('Deploy to Staging Droplet');
+    expect(stagingWorkflow).toContain('registry.digitalocean.com/infinit-track/infinit-track-backend');
+    expect(stagingWorkflow).toContain('docker compose pull app');
+    expect(stagingWorkflow).toContain('docker compose up -d --force-recreate app');
+    expect(stagingWorkflow).toContain("docker compose exec -T app npm run migrate");
+    expect(stagingWorkflow).toContain('./deploy/scripts/verify-droplet-api.sh');
+    expect(stagingWorkflow).toContain('npm run smoke-test "$STAGING_PUBLIC_BASE_URL"');
+    expect(stagingWorkflow).toContain('STAGING_PUBLIC_BASE_URL');
+    expect(stagingWorkflow).toContain('STAGING_PUBLIC_DOMAIN');
+    expect(stagingWorkflow).toContain('STAGING_EXPECTED_IP');
+    expect(stagingWorkflow).toContain('Missing required staging runtime variable');
+    expect(stagingWorkflow).not.toContain('https://api.infinite-track.tech');
+    expect(stagingWorkflow).not.toContain('continue-on-error: true');
+    expect(stagingWorkflow).not.toContain('doctl apps create-deployment');
+    expect(stagingWorkflow).not.toContain('ondigitalocean.app');
+
+    expect(productionWorkflow).toContain('Deploy to Production Droplet');
+    expect(productionWorkflow).toContain('registry.digitalocean.com/infinit-track/infinit-track-backend');
+    expect(productionWorkflow).toContain('docker compose pull app');
+    expect(productionWorkflow).toContain('docker compose up -d --force-recreate app');
+    expect(productionWorkflow).toContain("docker compose exec -T app npm run migrate");
+    expect(productionWorkflow).toContain('./deploy/scripts/verify-droplet-api.sh');
+    expect(productionWorkflow).toContain('npm run smoke-test "$PRODUCTION_PUBLIC_BASE_URL"');
+    expect(productionWorkflow).toContain('Type "deploy-to-production" to confirm');
+    expect(productionWorkflow).toContain('PRODUCTION_PUBLIC_BASE_URL');
+    expect(productionWorkflow).not.toContain('doctl apps create-deployment');
+    expect(productionWorkflow).not.toContain('yourdomain.com');
+    expect(productionWorkflow).not.toContain('ondigitalocean.app');
+
+    expect(dockerDeployWorkflow).toContain('name: Publish Backend Image');
+    expect(dockerDeployWorkflow).toContain('Build & Push Docker Image');
+    expect(dockerDeployWorkflow).toContain('registry.digitalocean.com/infinit-track/infinit-track-backend');
+    expect(dockerDeployWorkflow).toContain('Use the immutable SHA tag for droplet rollout.');
+    expect(dockerDeployWorkflow).not.toContain('Deploy to Kubernetes');
+    expect(dockerDeployWorkflow).not.toContain('kubectl apply -f k8s/');
+    expect(dockerDeployWorkflow).not.toContain('KUBECONFIG');
+    expect(dockerDeployWorkflow).not.toContain('api.your-domain.com');
+  });
+
   test('uses CommonJS migration filenames for sequelize-cli compatibility', () => {
     const files = migrationFiles();
 
@@ -137,6 +413,126 @@ describe('backend runtime config contract', () => {
       const content = fs.readFileSync(path.resolve(process.cwd(), 'src/models/migrations', file), 'utf8');
       expect(content).not.toContain('export default');
     }
+  });
+
+  test('documents GEOAPIFY_API_KEY in DigitalOcean deployment manifests and operator guide', () => {
+    const stagingSpec = readDoDeploySpec('app.yaml');
+    const productionSpec = readDoDeploySpec('app-production.yaml');
+    const deployReadme = readDoReadme();
+
+    expect(stagingSpec).toContain('GEOAPIFY_API_KEY');
+    expect(productionSpec).toContain('GEOAPIFY_API_KEY');
+    expect(deployReadme).toContain('GEOAPIFY_API_KEY=<your-geoapify-key>');
+    expect(stagingSpec).not.toMatch(/\bGEOAPIFY_KEY\b/);
+    expect(productionSpec).not.toMatch(/\bGEOAPIFY_KEY\b/);
+    expect(deployReadme).not.toMatch(/\bGEOAPIFY_KEY\b/);
+  });
+
+  test('keeps legacy deployment references non-authoritative and environment-specific', () => {
+    const stagingSpec = readDoDeploySpec('app.yaml');
+    const productionSpec = readDoDeploySpec('app-production.yaml');
+    const k8sDeployment = readK8sDeployment();
+
+    expect(stagingSpec).toContain('Legacy/historical backend artifact only.');
+    expect(stagingSpec).toContain('Do not treat this App Platform spec as the active backend deployment source of truth.');
+    expect(productionSpec).toContain('Legacy/historical backend artifact only.');
+    expect(productionSpec).toContain('Do not treat this App Platform spec as the active backend deployment source of truth.');
+    expect(productionSpec).toContain('<production-spaces-bucket>');
+    expect(productionSpec).not.toContain('infinite-track-staging-sgp1');
+    expect(k8sDeployment).toContain('Legacy/historical backend artifact only.');
+    expect(k8sDeployment).toContain('Do not treat this manifest as the active backend deployment source of truth.');
+    expect(k8sDeployment).not.toContain('<your-dockerhub-username>/infinit-track-backend:latest');
+  });
+
+  test('accepts GEOAPIFY_KEY as a temporary fallback for WFA recommendations', async () => {
+    delete process.env.GEOAPIFY_API_KEY;
+    process.env.GEOAPIFY_KEY = 'legacy-geoapify-key';
+
+    const axiosGet = jest.fn().mockResolvedValue({ data: { features: [] } });
+    const logger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn()
+    };
+
+    const { getWfaRecommendations } = await loadWfaControllerWithMocks({
+      axiosGet,
+      logger
+    });
+
+    const req = {
+      query: {
+        lat: '-0.8917',
+        lng: '119.8707'
+      }
+    };
+    const res = buildRes();
+    const next = jest.fn();
+
+    await getWfaRecommendations(req, res, next);
+
+    expect(axiosGet).toHaveBeenCalledWith(
+      'https://api.geoapify.com/v2/places',
+      expect.objectContaining({
+        params: expect.objectContaining({ apiKey: 'legacy-geoapify-key' })
+      })
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Using legacy GEOAPIFY_KEY fallback for WFA recommendations')
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('fails explicitly when no Geoapify env variable is configured for WFA recommendations', async () => {
+    delete process.env.GEOAPIFY_API_KEY;
+    delete process.env.GEOAPIFY_KEY;
+
+    const axiosGet = jest.fn();
+    const logger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn()
+    };
+
+    const { getWfaRecommendations } = await loadWfaControllerWithMocks({
+      axiosGet,
+      logger
+    });
+
+    const req = {
+      query: {
+        lat: '-0.8917',
+        lng: '119.8707'
+      }
+    };
+    const res = buildRes();
+    const next = jest.fn();
+
+    await getWfaRecommendations(req, res, next);
+
+    expect(axiosGet).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(
+      'Geoapify API key not found for WFA recommendations. Set GEOAPIFY_API_KEY.'
+    );
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      code: 'E_CONFIG',
+      message: 'API key Geoapify tidak ditemukan'
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('redacts Geoapify API key in booking suitability diagnostics', () => {
+    const bookingController = fs.readFileSync(
+      path.resolve(process.cwd(), 'src/controllers/booking.controller.js'),
+      'utf8'
+    );
+
+    expect(bookingController).toContain("const diagnosticParams = { ...params, apiKey: '[REDACTED]' };");
+    expect(bookingController).toContain('JSON.stringify(diagnosticParams)');
+    expect(bookingController).not.toContain('JSON.stringify(params)');
   });
 
   test('documents BACKEND_IMAGE_TAG in env example for operators', () => {

--- a/tests/healthReadiness.test.js
+++ b/tests/healthReadiness.test.js
@@ -1,0 +1,191 @@
+import fs from 'fs';
+import path from 'path';
+import { jest } from '@jest/globals';
+import express from 'express';
+import request from 'supertest';
+import yaml from 'yamljs';
+
+function expectLivenessResponse(response) {
+  expect(response.status).toBe(200);
+  expect(response.body).toEqual(
+    expect.objectContaining({
+      status: 'OK',
+      timestamp: expect.any(String)
+    })
+  );
+}
+
+function expectNotReadyResponse(response, { database, scheduler, missing }) {
+  expect(response.status).toBe(503);
+  expect(response.body).toEqual(
+    expect.objectContaining({
+      status: 'NOT_READY',
+      ready: false,
+      timestamp: expect.any(String),
+      components: {
+        database,
+        scheduler
+      },
+      missing
+    })
+  );
+}
+
+function expectReadyResponse(response) {
+  expect(response.status).toBe(200);
+  expect(response.body).toEqual({
+    status: 'OK',
+    ready: true,
+    timestamp: expect.any(String),
+    components: {
+      database: 'ready',
+      scheduler: 'ready'
+    },
+    missing: []
+  });
+}
+
+function readOpenApiSpec() {
+  const openApiPath = path.resolve(process.cwd(), 'docs/openapi.yaml');
+  const openApiSource = fs.readFileSync(openApiPath, 'utf8');
+
+  return yaml.parse(openApiSource);
+}
+
+async function markSchedulerReadyFromMock() {
+  const { markSchedulerReady } = await import('../src/utils/readinessState.js');
+  markSchedulerReady();
+  return { started: true, taskCount: 4 };
+}
+
+async function loadAppHarness({ authenticateImpl, schedulerStartImpl } = {}) {
+  jest.resetModules();
+
+  const authenticate = authenticateImpl ?? jest.fn().mockResolvedValue(undefined);
+  const ensureSchedulerStarted = schedulerStartImpl ?? jest.fn(markSchedulerReadyFromMock);
+
+  jest.unstable_mockModule('../src/config/database.js', () => ({
+    default: { authenticate }
+  }));
+
+  jest.unstable_mockModule('../src/utils/schedulerLifecycle.js', () => ({
+    ensureSchedulerStarted
+  }));
+
+  jest.unstable_mockModule('../src/utils/logger.js', () => ({
+    default: {
+      debug: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn()
+    }
+  }));
+
+  const { getLiveness, getReadiness } = await import('../src/controllers/health.controller.js');
+  const readinessState = await import('../src/utils/readinessState.js');
+  const app = express();
+  app.get('/livez', getLiveness);
+  app.get('/health', getReadiness);
+
+  return {
+    app,
+    authenticate,
+    ensureSchedulerStarted,
+    ...readinessState
+  };
+}
+
+describe('health and readiness contract', () => {
+  let healthyAppHarness;
+
+  beforeAll(async () => {
+    healthyAppHarness = await loadAppHarness();
+  }, 15000);
+
+  beforeEach(() => {
+    healthyAppHarness.resetReadinessState();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    jest.resetModules();
+  });
+
+  test('returns process liveness from /livez without probing dependencies', async () => {
+    const { app, authenticate, ensureSchedulerStarted } = healthyAppHarness;
+
+    const response = await request(app).get('/livez');
+
+    expect(authenticate).not.toHaveBeenCalled();
+    expect(ensureSchedulerStarted).not.toHaveBeenCalled();
+    expectLivenessResponse(response);
+  });
+
+  test('starts scheduler recovery from /health when the database probe succeeds', async () => {
+    const { app, authenticate, ensureSchedulerStarted } = healthyAppHarness;
+
+    const response = await request(app).get('/health');
+
+    expect(authenticate).toHaveBeenCalledTimes(1);
+    expect(ensureSchedulerStarted).toHaveBeenCalledWith({ source: 'health' });
+    expectReadyResponse(response);
+  });
+
+  test('returns 200 from /health without scheduler recovery when scheduler is already ready', async () => {
+    const { app, authenticate, ensureSchedulerStarted, markSchedulerReady } = healthyAppHarness;
+
+    markSchedulerReady();
+
+    const response = await request(app).get('/health');
+
+    expect(authenticate).toHaveBeenCalledTimes(1);
+    expect(ensureSchedulerStarted).not.toHaveBeenCalled();
+    expectReadyResponse(response);
+  });
+
+  test('returns 503 from /health when scheduler recovery fails after a successful database probe', async () => {
+    const schedulerError = new Error('scheduler failed');
+    const ensureSchedulerStarted = jest.fn().mockRejectedValue(schedulerError);
+    const { app, authenticate } = await loadAppHarness({ schedulerStartImpl: ensureSchedulerStarted });
+
+    const response = await request(app).get('/health');
+
+    expect(authenticate).toHaveBeenCalledTimes(1);
+    expect(ensureSchedulerStarted).toHaveBeenCalledWith({ source: 'health' });
+    expectNotReadyResponse(response, {
+      database: 'ready',
+      scheduler: 'not_ready',
+      missing: ['scheduler']
+    });
+  });
+
+  test('returns 503 from /health when the live database probe fails after prior startup readiness', async () => {
+    const authenticate = jest.fn().mockRejectedValue(new Error('db down'));
+    const { app, ensureSchedulerStarted, markDatabaseReady, markSchedulerReady, resetReadinessState } =
+      await loadAppHarness({ authenticateImpl: authenticate });
+
+    resetReadinessState();
+    markDatabaseReady();
+    markSchedulerReady();
+
+    const response = await request(app).get('/health');
+
+    expect(ensureSchedulerStarted).not.toHaveBeenCalled();
+    expectNotReadyResponse(response, {
+      database: 'not_ready',
+      scheduler: 'ready',
+      missing: ['database']
+    });
+  });
+
+  test('documents both /livez and /health in the public OpenAPI spec', () => {
+    const openapi = readOpenApiSpec();
+
+    expect(openapi.paths['/livez']).toBeDefined();
+    expect(openapi.paths['/health']).toBeDefined();
+    expect(openapi.paths['/health'].get.responses['503']).toBeDefined();
+  });
+});

--- a/tests/schedulerJobHandles.test.js
+++ b/tests/schedulerJobHandles.test.js
@@ -1,0 +1,204 @@
+import { jest } from '@jest/globals';
+
+function createTask(name) {
+  return {
+    name,
+    destroy: jest.fn(),
+    stop: jest.fn()
+  };
+}
+
+async function mockJobDependencies({ scheduleImpl } = {}) {
+  jest.resetModules();
+
+  const schedule = scheduleImpl ?? jest.fn(() => createTask('scheduled-task'));
+
+  jest.unstable_mockModule('node-cron', () => ({
+    default: { schedule }
+  }));
+
+  jest.unstable_mockModule('../src/models/index.js', () => ({
+    Attendance: {},
+    AttendanceCategory: {},
+    Booking: {},
+    LocationEvent: {},
+    Role: {},
+    User: {}
+  }));
+
+  jest.unstable_mockModule('../src/utils/logger.js', () => ({
+    default: {
+      debug: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn()
+    }
+  }));
+
+  jest.unstable_mockModule('../src/utils/jobHelper.js', () => ({
+    executeJobWithTimeout: jest.fn(),
+    processBatchRecords: jest.fn()
+  }));
+
+  jest.unstable_mockModule('../src/utils/attendanceDuplicateError.js', () => ({
+    isAttendanceDuplicateConstraintError: jest.fn(() => false)
+  }));
+
+  jest.unstable_mockModule('../src/utils/workHourFormatter.js', () => ({
+    calculateWorkHour: jest.fn(() => 8),
+    formatTimeOnly: jest.fn(() => '18:00:00')
+  }));
+
+  jest.unstable_mockModule('../src/utils/settings.js', () => ({
+    getOperationalSettings: jest.fn(() => ({
+      defaultShiftEnd: '18:00:00',
+      lateCheckoutToleranceMin: 30
+    }))
+  }));
+
+  jest.unstable_mockModule('../src/utils/geofence.js', () => ({
+    toJakartaTime: jest.fn((date) => date)
+  }));
+
+  jest.unstable_mockModule('../src/utils/fuzzyAhpEngine.js', () => ({
+    default: {
+      weightedPrediction: jest.fn(() => null)
+    }
+  }));
+
+  jest.unstable_mockModule('../src/analytics/fahp.js', () => ({
+    computeCR: jest.fn(() => ({ CR: 0 })),
+    defuzzifyMatrixTFN: jest.fn(() => [])
+  }));
+
+  jest.unstable_mockModule('../src/analytics/fahp.extent.js', () => ({
+    extentWeightsTFN: jest.fn(() => [0.25, 0.25, 0.25, 0.25])
+  }));
+
+  jest.unstable_mockModule('../src/analytics/config.fahp.js', () => ({
+    SMART_AC_PAIRWISE_TFN: []
+  }));
+
+  return { schedule };
+}
+
+describe('scheduler job handle contracts', () => {
+  let consoleLogSpy;
+
+  beforeEach(() => {
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+    jest.clearAllMocks();
+    jest.resetModules();
+  });
+
+  test('create general alpha starter returns its cron handle without changing schedule semantics', async () => {
+    const task = createTask('create-general-alpha');
+    const { schedule } = await mockJobDependencies({
+      scheduleImpl: jest.fn(() => task)
+    });
+    const { startCreateGeneralAlphaJob } = await import('../src/jobs/createGeneralAlpha.job.js');
+
+    const result = startCreateGeneralAlphaJob();
+
+    expect(result).toBe(task);
+    expect(schedule).toHaveBeenCalledWith('55 23 * * 1-5', expect.any(Function), {
+      scheduled: true,
+      timezone: 'Asia/Jakarta'
+    });
+  });
+
+  test('resolve WFA bookings starter returns its cron handle without changing schedule semantics', async () => {
+    const task = createTask('resolve-wfa-bookings');
+    const { schedule } = await mockJobDependencies({
+      scheduleImpl: jest.fn(() => task)
+    });
+    const { startResolveWfaBookingsJob } = await import('../src/jobs/resolveWfaBookings.job.js');
+
+    const result = startResolveWfaBookingsJob();
+
+    expect(result).toBe(task);
+    expect(schedule).toHaveBeenCalledWith('50 23 * * *', expect.any(Function), {
+      scheduled: true,
+      timezone: 'Asia/Jakarta'
+    });
+  });
+
+  test('auto checkout starter returns both cron handles without changing schedule semantics', async () => {
+    const missedCheckoutTask = createTask('missed-checkout');
+    const smartAutoCheckoutTask = createTask('smart-auto-checkout');
+    const { schedule } = await mockJobDependencies({
+      scheduleImpl: jest.fn().mockReturnValueOnce(missedCheckoutTask).mockReturnValueOnce(smartAutoCheckoutTask)
+    });
+    const { startAutoCheckoutJob } = await import('../src/jobs/autoCheckout.job.js');
+
+    const result = startAutoCheckoutJob();
+
+    expect(result).toEqual([missedCheckoutTask, smartAutoCheckoutTask]);
+    expect(schedule).toHaveBeenNthCalledWith(1, '*/30 * * * *', expect.any(Function), {
+      scheduled: true,
+      timezone: 'Asia/Jakarta'
+    });
+    expect(schedule).toHaveBeenNthCalledWith(2, '45 23 * * *', expect.any(Function), {
+      scheduled: true,
+      timezone: 'Asia/Jakarta'
+    });
+  });
+
+  test('auto checkout starter rolls back the first cron handle when the second schedule fails', async () => {
+    const missedCheckoutTask = createTask('missed-checkout');
+    const scheduleError = new Error('schedule failed');
+    await mockJobDependencies({
+      scheduleImpl: jest
+        .fn()
+        .mockReturnValueOnce(missedCheckoutTask)
+        .mockImplementationOnce(() => {
+          throw scheduleError;
+        })
+    });
+    const { startAutoCheckoutJob } = await import('../src/jobs/autoCheckout.job.js');
+
+    expect(() => startAutoCheckoutJob()).toThrow(scheduleError);
+    expect(missedCheckoutTask.destroy).toHaveBeenCalledTimes(1);
+    expect(missedCheckoutTask.stop).not.toHaveBeenCalled();
+  });
+
+  test('auto checkout starter rolls back the first cron handle when the second schedule returns an invalid handle', async () => {
+    const missedCheckoutTask = createTask('missed-checkout');
+    await mockJobDependencies({
+      scheduleImpl: jest.fn().mockReturnValueOnce(missedCheckoutTask).mockReturnValueOnce(undefined)
+    });
+    const { startAutoCheckoutJob } = await import('../src/jobs/autoCheckout.job.js');
+
+    expect(() => startAutoCheckoutJob()).toThrow(
+      'Auto checkout schedule smartAutoCheckout did not return manageable cron task handle'
+    );
+    expect(missedCheckoutTask.destroy).toHaveBeenCalledTimes(1);
+    expect(missedCheckoutTask.stop).not.toHaveBeenCalled();
+  });
+
+  test('auto checkout starter surfaces rollback failure when the second schedule fails', async () => {
+    const missedCheckoutTask = createTask('missed-checkout');
+    missedCheckoutTask.destroy.mockImplementationOnce(() => {
+      throw new Error('destroy failed');
+    });
+    const scheduleError = new Error('schedule failed');
+    await mockJobDependencies({
+      scheduleImpl: jest
+        .fn()
+        .mockReturnValueOnce(missedCheckoutTask)
+        .mockImplementationOnce(() => {
+          throw scheduleError;
+        })
+    });
+    const { startAutoCheckoutJob } = await import('../src/jobs/autoCheckout.job.js');
+
+    expect(() => startAutoCheckoutJob()).toThrow(
+      'Auto checkout scheduling failed and rollback did not stop all task handles'
+    );
+    expect(missedCheckoutTask.destroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/schedulerLifecycle.test.js
+++ b/tests/schedulerLifecycle.test.js
@@ -1,0 +1,222 @@
+import { jest } from '@jest/globals';
+
+function createTask(name, methods = ['destroy']) {
+  return {
+    name,
+    ...(methods.includes('destroy') ? { destroy: jest.fn() } : {}),
+    ...(methods.includes('stop') ? { stop: jest.fn() } : {})
+  };
+}
+
+async function loadSchedulerLifecycle({ createStart, resolveStart, autoStart } = {}) {
+  jest.resetModules();
+
+  const startCreateGeneralAlphaJob = createStart ?? jest.fn(() => createTask('create-general-alpha'));
+  const startResolveWfaBookingsJob = resolveStart ?? jest.fn(() => createTask('resolve-wfa-bookings'));
+  const startAutoCheckoutJob = autoStart ?? jest.fn(() => [createTask('missed-checkout')]);
+
+  jest.unstable_mockModule('../src/jobs/createGeneralAlpha.job.js', () => ({
+    startCreateGeneralAlphaJob
+  }));
+
+  jest.unstable_mockModule('../src/jobs/resolveWfaBookings.job.js', () => ({
+    startResolveWfaBookingsJob
+  }));
+
+  jest.unstable_mockModule('../src/jobs/autoCheckout.job.js', () => ({
+    startAutoCheckoutJob
+  }));
+
+  jest.unstable_mockModule('../src/utils/logger.js', () => ({
+    default: {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn()
+    }
+  }));
+
+  const lifecycle = await import('../src/utils/schedulerLifecycle.js');
+  const readinessState = await import('../src/utils/readinessState.js');
+
+  return {
+    ...lifecycle,
+    ...readinessState,
+    startCreateGeneralAlphaJob,
+    startResolveWfaBookingsJob,
+    startAutoCheckoutJob
+  };
+}
+
+describe('scheduler lifecycle', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+  });
+
+  test('starts all scheduler jobs and marks the scheduler ready', async () => {
+    const createTaskHandle = createTask('create-general-alpha');
+    const resolveTaskHandle = createTask('resolve-wfa-bookings');
+    const autoTaskHandle = createTask('auto-checkout');
+    const harness = await loadSchedulerLifecycle({
+      createStart: jest.fn(() => createTaskHandle),
+      resolveStart: jest.fn(() => resolveTaskHandle),
+      autoStart: jest.fn(() => [autoTaskHandle])
+    });
+
+    const result = await harness.ensureSchedulerStarted({ source: 'test' });
+
+    expect(result).toEqual({ started: true, taskCount: 3 });
+    expect(harness.startCreateGeneralAlphaJob).toHaveBeenCalledTimes(1);
+    expect(harness.startResolveWfaBookingsJob).toHaveBeenCalledTimes(1);
+    expect(harness.startAutoCheckoutJob).toHaveBeenCalledTimes(1);
+    expect(harness.getReadinessSnapshot().components.scheduler).toBe('ready');
+  });
+
+  test('does not start duplicate jobs when handles are already active', async () => {
+    const harness = await loadSchedulerLifecycle();
+
+    const firstResult = await harness.ensureSchedulerStarted({ source: 'first' });
+    const secondResult = await harness.ensureSchedulerStarted({ source: 'second' });
+
+    expect(firstResult).toEqual({ started: true, taskCount: 3 });
+    expect(secondResult).toEqual({ started: false, taskCount: 3 });
+    expect(harness.startCreateGeneralAlphaJob).toHaveBeenCalledTimes(1);
+    expect(harness.startResolveWfaBookingsJob).toHaveBeenCalledTimes(1);
+    expect(harness.startAutoCheckoutJob).toHaveBeenCalledTimes(1);
+  });
+
+  test('coalesces concurrent startup attempts into one scheduler registration', async () => {
+    let releaseCreateJob;
+    const createJobStarted = new Promise((resolve) => {
+      releaseCreateJob = resolve;
+    });
+    const harness = await loadSchedulerLifecycle({
+      createStart: jest.fn(async () => {
+        await createJobStarted;
+        return createTask('create-general-alpha');
+      })
+    });
+
+    const firstStart = harness.ensureSchedulerStarted({ source: 'first' });
+    const secondStart = harness.ensureSchedulerStarted({ source: 'second' });
+
+    expect(harness.startCreateGeneralAlphaJob).toHaveBeenCalledTimes(1);
+    releaseCreateJob();
+
+    await expect(Promise.all([firstStart, secondStart])).resolves.toEqual([
+      { started: true, taskCount: 3 },
+      { started: true, taskCount: 3 }
+    ]);
+    expect(harness.startResolveWfaBookingsJob).toHaveBeenCalledTimes(1);
+    expect(harness.startAutoCheckoutJob).toHaveBeenCalledTimes(1);
+  });
+
+  test('rolls back started task handles when a later scheduler job fails', async () => {
+    const createTaskHandle = createTask('create-general-alpha');
+    const schedulerError = new Error('resolve failed');
+    const harness = await loadSchedulerLifecycle({
+      createStart: jest.fn(() => createTaskHandle),
+      resolveStart: jest.fn(() => {
+        throw schedulerError;
+      })
+    });
+
+    await expect(harness.ensureSchedulerStarted({ source: 'test' })).rejects.toThrow(schedulerError);
+
+    expect(createTaskHandle.destroy).toHaveBeenCalledTimes(1);
+    expect(harness.startAutoCheckoutJob).not.toHaveBeenCalled();
+    expect(harness.getReadinessSnapshot().components.scheduler).toBe('not_ready');
+  });
+
+  test('retries failed rollback cleanup before registering new scheduler jobs', async () => {
+    const firstCreateTask = createTask('first-create-general-alpha');
+    firstCreateTask.destroy.mockImplementationOnce(() => {
+      throw new Error('destroy failed');
+    });
+    const secondCreateTask = createTask('second-create-general-alpha');
+    const resolveTaskHandle = createTask('resolve-wfa-bookings');
+    const autoTaskHandle = createTask('auto-checkout');
+    const harness = await loadSchedulerLifecycle({
+      createStart: jest.fn().mockReturnValueOnce(firstCreateTask).mockReturnValueOnce(secondCreateTask),
+      resolveStart: jest
+        .fn()
+        .mockImplementationOnce(() => {
+          throw new Error('resolve failed');
+        })
+        .mockReturnValueOnce(resolveTaskHandle),
+      autoStart: jest.fn(() => [autoTaskHandle])
+    });
+
+    await expect(harness.ensureSchedulerStarted({ source: 'first' })).rejects.toThrow(
+      'Automated job scheduling failed and rollback did not stop all task handles'
+    );
+    const retryResult = await harness.ensureSchedulerStarted({ source: 'retry' });
+
+    expect(firstCreateTask.destroy).toHaveBeenCalledTimes(2);
+    expect(retryResult).toEqual({ started: true, taskCount: 3 });
+    expect(harness.startCreateGeneralAlphaJob).toHaveBeenCalledTimes(2);
+    expect(harness.startResolveWfaBookingsJob).toHaveBeenCalledTimes(2);
+    expect(harness.startAutoCheckoutJob).toHaveBeenCalledTimes(1);
+    expect(harness.getReadinessSnapshot().components.scheduler).toBe('ready');
+  });
+
+  test('can retry scheduler startup after a failed attempt', async () => {
+    const firstCreateTask = createTask('first-create-general-alpha');
+    const secondCreateTask = createTask('second-create-general-alpha');
+    const resolveTaskHandle = createTask('resolve-wfa-bookings');
+    const autoTaskHandle = createTask('auto-checkout');
+    const harness = await loadSchedulerLifecycle({
+      createStart: jest.fn().mockReturnValueOnce(firstCreateTask).mockReturnValueOnce(secondCreateTask),
+      resolveStart: jest
+        .fn()
+        .mockImplementationOnce(() => {
+          throw new Error('first attempt failed');
+        })
+        .mockReturnValueOnce(resolveTaskHandle),
+      autoStart: jest.fn(() => [autoTaskHandle])
+    });
+
+    await expect(harness.ensureSchedulerStarted({ source: 'first' })).rejects.toThrow(
+      'first attempt failed'
+    );
+    const retryResult = await harness.ensureSchedulerStarted({ source: 'retry' });
+
+    expect(firstCreateTask.destroy).toHaveBeenCalledTimes(1);
+    expect(retryResult).toEqual({ started: true, taskCount: 3 });
+    expect(harness.startCreateGeneralAlphaJob).toHaveBeenCalledTimes(2);
+    expect(harness.startResolveWfaBookingsJob).toHaveBeenCalledTimes(2);
+    expect(harness.startAutoCheckoutJob).toHaveBeenCalledTimes(1);
+    expect(harness.getReadinessSnapshot().components.scheduler).toBe('ready');
+  });
+
+  test('stops active scheduler jobs and marks the scheduler unready', async () => {
+    const createTaskHandle = createTask('create-general-alpha');
+    const resolveTaskHandle = createTask('resolve-wfa-bookings', ['stop']);
+    const autoTaskHandle = createTask('auto-checkout');
+    const harness = await loadSchedulerLifecycle({
+      createStart: jest.fn(() => createTaskHandle),
+      resolveStart: jest.fn(() => resolveTaskHandle),
+      autoStart: jest.fn(() => [autoTaskHandle])
+    });
+
+    await harness.ensureSchedulerStarted({ source: 'test' });
+    const result = harness.stopSchedulerJobs({ source: 'test' });
+
+    expect(result).toEqual({ stopped: 3 });
+    expect(autoTaskHandle.destroy).toHaveBeenCalledTimes(1);
+    expect(resolveTaskHandle.stop).toHaveBeenCalledTimes(1);
+    expect(createTaskHandle.destroy).toHaveBeenCalledTimes(1);
+    expect(harness.getReadinessSnapshot().components.scheduler).toBe('not_ready');
+  });
+
+  test('rejects scheduler jobs that do not return manageable task handles', async () => {
+    const harness = await loadSchedulerLifecycle({
+      createStart: jest.fn(() => undefined)
+    });
+
+    await expect(harness.ensureSchedulerStarted({ source: 'test' })).rejects.toThrow(
+      'Scheduler job createGeneralAlpha did not return manageable cron task handle(s)'
+    );
+    expect(harness.getReadinessSnapshot().components.scheduler).toBe('not_ready');
+  });
+});


### PR DESCRIPTION
## Summary
- Split liveness/readiness behavior so `/livez` stays process-only while `/health` reports database and scheduler readiness.
- Add rollback-safe scheduler lifecycle handling and cron handle contracts for attendance jobs.
- Harden Docker Compose deployment verification and smoke checks against readiness, login, and credentialed CORS false-greens.

## Test plan
- [x] npm test -- --runInBand tests/configContract.test.js
- [x] npm run lint
- [x] npm test -- --runInBand

## Architecture notes
- Impact: scheduler/readiness behavior now fails closed and can recover cron jobs after database recovery.
- Risk: `/health` intentionally has a recovery side effect; lifecycle idempotency and rollback tests cover duplicate/partial scheduler registration.
- Docs/ADR: OpenAPI and runtime/deploy docs updated; no ADR added because this implements the existing Docker Compose readiness remediation path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)