### PR TITLE
INF-145 harden auth session contract

### DIFF
--- a/docs/adr/ADR-007-auth-session-contract.md
+++ b/docs/adr/ADR-007-auth-session-contract.md
@@ -1,0 +1,92 @@
+# ADR-007: Auth Session Contract
+
+Status: Accepted
+Date: 2026-05-21
+
+## Context
+
+Infinite Track backend is the final authority for authentication state and session validity. Access tokens are still JWTs, but protected-route authorization must not be purely stateless because logout, refresh rotation, session replacement, inactivity expiry, and revocation all depend on persisted backend state.
+
+The backend supports two credential transports:
+
+- browser/web clients receive HTTP-only auth cookies;
+- native/non-browser clients receive credentials in JSON.
+
+Existing clients also depend on legacy token fields, so the contract needs a primary shape that new clients can use while preserving backward-compatible fields during migration.
+
+## Decision
+
+The backend auth contract is session-backed. Every successful login or register creates an `auth_sessions` row, and every access token includes the backend `session_id`. Protected routes validate the decoded access JWT against the persisted session before accepting the request.
+
+Login creates one active session per user per resolved client type. A new login for the same user and client type revokes previous active sessions for that same client type with `revocation_reason = 'replaced_by_new_login'`. The same-client replacement runs inside one database transaction and locks the user row before revoking and creating sessions, so concurrent replacement attempts for the same user are serialized and failed replacement creation does not revoke the previous session. Sessions for other client types remain active.
+
+Refresh tokens include both `session_id` and refresh `jti`. Refresh rotates the refresh `jti` with a compare-and-swap update against the current persisted `refresh_jti`, so a consumed refresh token cannot be reused after a successful rotation.
+
+## Client Type Resolution
+
+Clients can explicitly request transport behavior with `X-Client-Type`:
+
+- `web` uses browser cookie transport;
+- `mobile` uses native JSON transport;
+- `android` remains a backward-compatible native JSON alias.
+
+When the header is absent, the backend falls back to User-Agent and Bearer-token heuristics. Native fallback values may still persist as `android` for compatibility, while explicit `mobile` persists as `mobile`.
+
+## Response Contract
+
+The primary response contract is `data.auth`:
+
+- web login and web refresh return `data.auth.access_token` in JSON and rotate HTTP-only cookies;
+- native login and native refresh return `data.auth.access_token` and `data.auth.refresh_token` in JSON.
+
+Backward-compatible direct fields remain available:
+
+- login web: `data.token`;
+- login native: `data.token` and `data.refresh_token`;
+- refresh web: `data.access_token`;
+- refresh native: `data.access_token` and `data.refresh_token`.
+
+New clients should read `data.auth`. Legacy fields are kept for existing web and Android/mobile integrations.
+
+## Refresh Rejection Contract
+
+Refresh failures use stable error codes:
+
+| Condition | HTTP | Code | Message |
+| --- | --- | --- | --- |
+| malformed refresh JWT, missing session identity, stale/consumed refresh JTI | 401 | `AUTH_REFRESH_TOKEN_INVALID` | `Refresh token invalid` |
+| persisted session already revoked | 401 | `AUTH_REFRESH_TOKEN_REVOKED` | `Refresh session revoked` |
+| refresh JWT expired, persisted session expired, or session inactive beyond the inactivity window | 401 | `AUTH_SESSION_INACTIVE` | `Refresh session expired` |
+
+The inactivity window is controlled by `JWT_REFRESH_INACTIVITY_WINDOW_SECONDS`; the current deployment contract is 48 hours.
+
+## Protected Route Contract
+
+`verifyToken` accepts a Bearer token before falling back to the `token` cookie. Malformed or non-Bearer Authorization headers are rejected and must not fall back to cookies.
+
+After JWT verification, `verifyToken` checks the persisted `auth_sessions` row by `session_id`. The request is rejected when the session is missing, belongs to a different user, is revoked, is absolutely expired, or is inactive beyond the refresh inactivity window.
+
+Expired access JWTs return `AUTH_ACCESS_TOKEN_EXPIRED` with `details.refreshable = true` so clients can attempt refresh when they still have a valid refresh session.
+
+## Consequences
+
+- Logout and same-client login replacement are enforced by backend session state, not by trusting clients to discard tokens.
+- Refresh token replay is rejected by persisted `refresh_jti` rotation.
+- Web and native transports remain compatible while sharing the same session lifecycle model.
+- OpenAPI must describe `data.auth` as the primary token response shape while retaining legacy fields until clients are migrated.
+- Any future auth/session changes must update both `docs/openapi.yaml` and this ADR when they change wire contract, error codes, or persisted session semantics.
+
+## Verification
+
+The contract is covered by auth/session tests for:
+
+- stateful protected-route session validation;
+- Authorization header precedence over cookie tokens;
+- malformed Authorization rejection without cookie fallback;
+- login web cookie transport and native JSON transport;
+- explicit `X-Client-Type: web`, `mobile`, and backward-compatible `android`;
+- same-client session replacement without revoking other client types;
+- atomic same-client login replacement using a transaction and user-row lock;
+- refresh JTI rotation and concurrent rotation rejection;
+- refresh invalid, revoked, expired, and inactive error contracts;
+- logout revocation and cookie clearing.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -13,13 +13,19 @@ info:
     - Comprehensive reporting and analytics
 
     ## Authentication
-    This API uses a stateless access token plus a stateful refresh session.
+    This API uses a JWT access credential backed by a stateful `auth_sessions` record.
 
     Protected endpoints accept the access token through either:
     - `Authorization: Bearer <access_token>`
     - HTTP-only `token` cookie for browser-based flows
 
-    Browser login sets HTTP-only `token` and `refresh_token` cookies while also returning the access token in `data.token`. Non-browser clients can receive a `refresh_token` in JSON and submit it to `/api/auth/refresh`.
+    Protected routes treat the access token as valid only while the linked `auth_sessions` row remains active.
+
+    Browser login sets HTTP-only `token` and `refresh_token` cookies while also returning the access token in `data.token` and the primary `data.auth.access_token` field. Non-browser clients receive the access token in `data.token`, the refresh token in `data.refresh_token`, and both tokens under `data.auth`.
+
+    Clients can explicitly force login transport behavior with `X-Client-Type: web` or `X-Client-Type: mobile`; `X-Client-Type: android` remains a backward-compatible native alias. When the header is absent, the backend falls back to User-Agent heuristics.
+
+    A successful login atomically replaces any previous active session for the same user and resolved client type before issuing credentials. The backend serializes same-user replacement attempts and keeps sessions for other client types active.
 
     ## Timezone
     All timestamps are handled in WIB (Jakarta timezone, UTC+7) for consistency.
@@ -149,11 +155,21 @@ paths:
         - Authentication
       summary: User login
       description: |
-        Authenticate user credentials, create a refresh-backed session, and issue an access token.
+        Authenticate user credentials, atomically revoke any previous active session for the same user and resolved client type, create a refresh-backed replacement session, and issue new credentials.
 
-        Browser clients receive HTTP-only `token` and `refresh_token` cookies, and the response body still includes the access token in `data.token`.
-        Non-browser clients receive the access token in `data.token` and the refresh token in `data.refresh_token`.
+        `X-Client-Type: web` forces browser cookie transport. `X-Client-Type: mobile` forces native JSON transport, while `X-Client-Type: android` remains a backward-compatible native alias. When the header is absent, the backend falls back to User-Agent heuristics and treats Bearer-only clients as native.
+
+        Browser clients receive HTTP-only `token` and `refresh_token` cookies. The response body includes the access token in both the backward-compatible `data.token` field and the primary `data.auth.access_token` field.
+        Non-browser clients receive the access token in `data.token`, the refresh token in `data.refresh_token`, and both credentials under the primary `data.auth` object.
       security: []
+      parameters:
+        - in: header
+          name: X-Client-Type
+          required: false
+          schema:
+            type: string
+            enum: [web, android, mobile]
+          description: Optional explicit client transport hint for login. `web` forces cookie transport, while `android` and `mobile` force native JSON transport.
       requestBody:
         required: true
         content:
@@ -204,8 +220,11 @@ paths:
         Browser clients can supply the refresh credential through the HTTP-only `refresh_token` cookie.
         Non-browser clients can supply it in the JSON body as `refresh_token`.
         Refresh succeeds only while the persisted refresh session is still active.
-        The refresh session is rejected when the refresh JWT is invalid, when the session was revoked, when the persisted session `expires_at` has passed, or when there has been no successful login/refresh activity for longer than `JWT_REFRESH_INACTIVITY_WINDOW_SECONDS` (48 hours in the current deployment contract).
-        Once the refresh session is expired or inactive, clients must perform a full login again.
+
+        The refresh transport follows the stored session type established at login: web sessions rotate cookies and return only `access_token` in JSON, while native sessions return both `access_token` and `refresh_token` in JSON.
+
+        The refresh session is rejected when the refresh JWT is malformed, when the session was revoked, when the persisted session `expires_at` has passed, or when there has been no successful login/refresh activity for longer than `JWT_REFRESH_INACTIVITY_WINDOW_SECONDS` (48 hours in the current deployment contract).
+        Expired refresh JWTs and inactive persisted sessions both return `AUTH_SESSION_INACTIVE` and require a full login.
       security: []
       requestBody:
         required: false
@@ -223,14 +242,14 @@ paths:
                   - $ref: '#/components/schemas/RefreshWebResponse'
                   - $ref: '#/components/schemas/RefreshNonWebResponse'
         '401':
-          description: Refresh rejected because the token or refresh session is invalid
+          description: Refresh rejected because the token is invalid, the session was revoked, or the session is no longer active
           content:
             application/json:
               schema:
                 oneOf:
                   - $ref: '#/components/schemas/RefreshInvalidError'
                   - $ref: '#/components/schemas/RefreshRevokedError'
-                  - $ref: '#/components/schemas/RefreshExpiredError'
+                  - $ref: '#/components/schemas/RefreshSessionInactiveError'
         '500':
           $ref: '#/components/responses/AuthInternalServerError'
 
@@ -244,7 +263,7 @@ paths:
 
         Session identification can come from the authenticated access token (`Authorization: Bearer <access_token>` or `token` cookie) or from the refresh token (`refresh_token` cookie or body field for non-browser clients).
         Invalid or expired JWT credentials do not block cookie clearing; this endpoint stays idempotent and only revokes a server-side session when one can still be resolved.
-        Revoking the refresh session blocks future refresh attempts, but it does not retroactively invalidate a still-valid access token because protected routes currently verify access JWTs statelessly until their own expiry.
+        Revoking the refresh session blocks future refresh attempts and also causes protected routes to reject the same access JWT once middleware re-checks the linked `auth_sessions` row.
         Session-store failures after a session has been identified return the generic auth 500 response. Unexpected token-verification failures are delegated to the shared error handler.
       security: []
       requestBody:
@@ -271,7 +290,7 @@ paths:
       description: |
         Get the authenticated user profile resolved from the current access token and database record.
 
-        Protected-route authentication is currently stateless at the access-token layer, so a refresh session that has already been revoked does not block a still-valid access token until that access JWT expires.
+        Protected-route authentication requires both a valid access JWT and an active linked `auth_sessions` row. A revoked session causes this route to reject the access credential even before the JWT expiry time.
       security:
         - bearerAuth: []
         - cookieAuth: []
@@ -3131,17 +3150,42 @@ components:
               nullable: true
               example: 'WFH'
 
+    AuthWebTokenBundle:
+      type: object
+      required:
+        - access_token
+      properties:
+        access_token:
+          type: string
+          description: Primary access token field for the current authenticated session.
+          example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...'
+
+    AuthNativeTokenBundle:
+      allOf:
+        - $ref: '#/components/schemas/AuthWebTokenBundle'
+        - type: object
+          required:
+            - refresh_token
+          properties:
+            refresh_token:
+              type: string
+              description: Primary refresh token field for native/non-browser clients.
+              example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...'
+
     AuthLoginWebData:
       allOf:
         - $ref: '#/components/schemas/AuthProfile'
         - type: object
           required:
             - token
+            - auth
           properties:
             token:
               type: string
-              description: Access token for authenticated requests.
+              description: Backward-compatible access token field for authenticated requests.
               example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...'
+            auth:
+              $ref: '#/components/schemas/AuthWebTokenBundle'
 
     AuthLoginNonWebData:
       allOf:
@@ -3149,11 +3193,14 @@ components:
         - type: object
           required:
             - refresh_token
+            - auth
           properties:
             refresh_token:
               type: string
-              description: Refresh token returned to non-browser clients.
+              description: Backward-compatible refresh token field returned to non-browser clients.
               example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...'
+            auth:
+              $ref: '#/components/schemas/AuthNativeTokenBundle'
 
     LoginWebResponse:
       type: object
@@ -3201,10 +3248,14 @@ components:
           type: object
           required:
             - access_token
+            - auth
           properties:
             access_token:
               type: string
+              description: Backward-compatible access token field.
               example: 'new-access-token'
+            auth:
+              $ref: '#/components/schemas/AuthWebTokenBundle'
         message:
           type: string
           example: 'Refresh successful'
@@ -3224,13 +3275,18 @@ components:
           required:
             - access_token
             - refresh_token
+            - auth
           properties:
             access_token:
               type: string
+              description: Backward-compatible access token field.
               example: 'new-access-token'
             refresh_token:
               type: string
+              description: Backward-compatible refresh token field.
               example: 'new-refresh-token'
+            auth:
+              $ref: '#/components/schemas/AuthNativeTokenBundle'
         message:
           type: string
           example: 'Refresh successful'
@@ -3318,7 +3374,7 @@ components:
           example: false
         code:
           type: string
-          example: 'AUTH_REFRESH_INVALID'
+          example: 'AUTH_REFRESH_TOKEN_INVALID'
         message:
           type: string
           example: 'Refresh token invalid'
@@ -3336,12 +3392,12 @@ components:
           example: false
         code:
           type: string
-          example: 'AUTH_REFRESH_REVOKED'
+          example: 'AUTH_REFRESH_TOKEN_REVOKED'
         message:
           type: string
           example: 'Refresh session revoked'
 
-    RefreshExpiredError:
+    RefreshSessionInactiveError:
       type: object
       description: Returned when the refresh JWT expired, the persisted refresh session absolute expiry passed, or the inactivity window elapsed. Clients must log in again.
       required:
@@ -3354,7 +3410,7 @@ components:
           example: false
         code:
           type: string
-          example: 'AUTH_REFRESH_EXPIRED'
+          example: 'AUTH_SESSION_INACTIVE'
         message:
           type: string
           example: 'Refresh session expired'

--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -103,7 +103,7 @@ export const login = async (req, res) => {
       );
     }
 
-const roleName = await resolveRoleName(user);
+    const roleName = await resolveRoleName(user);
     const photoUrl = user.photo_file ? user.photo_file.photo_url : null;
     const tokenUserState = {
       id: user.id_users,
@@ -135,28 +135,48 @@ const roleName = await resolveRoleName(user);
         : null
     };
 
-    const currentTime = new Date();
-    const refreshJti = randomUUID();
-    const session = await AuthSession.create({
-      user_id: user.id_users,
-      refresh_jti: refreshJti,
-      client_type: clientType,
-      user_agent: userAgent || null,
-      last_activity_at: currentTime,
-      expires_at: new Date(currentTime.getTime() + config.jwt.refreshTtl * 1000)
-    });
+    const transaction = await sequelize.transaction();
+    let accessToken;
+    let refreshToken;
 
-    const { accessToken, refreshToken } = buildSessionTokens(
-      tokenUserState,
-      session.session_id,
-      refreshJti
-    );
+    try {
+      await lockUserForSessionReplacement(user.id_users, transaction);
+      await revokeActiveSessionsForClient(user.id_users, clientType, { transaction });
+
+      const { refreshJti, session } = await createAuthSession(
+        user.id_users,
+        clientType,
+        userAgent,
+        { transaction }
+      );
+      ({ accessToken, refreshToken } = buildSessionTokens(
+        tokenUserState,
+        session.session_id,
+        refreshJti
+      ));
+
+      await transaction.commit();
+    } catch (error) {
+      try {
+        await transaction.rollback();
+      } catch (rollbackError) {
+        logger.error(`Login session replacement rollback failed: ${rollbackError.message}`, {
+          stack: rollbackError.stack,
+          original_error: error.message,
+          user_id: user.id_users,
+          client_type: clientType
+        });
+      }
+
+      throw error;
+    }
 
     if (clientType === 'web') {
       setSessionCookies(res, accessToken, refreshToken);
     }
 
     responseData.token = accessToken;
+    responseData.auth = buildAuthResponse(accessToken, refreshToken, clientType);
     if (clientType !== 'web') {
       responseData.refresh_token = refreshToken;
     }
@@ -197,10 +217,23 @@ function resolveAccessToken(req) {
 }
 
 function resolveClientType(req) {
+  const explicitClientType = req.headers?.['x-client-type']?.toString().trim().toLowerCase();
   const userAgent = req.get('User-Agent') || '';
   const authHeader = req.headers?.authorization || '';
   const browserUserAgentPattern = /(Mozilla\/|AppleWebKit\/|Chrome\/|Safari\/|Firefox\/|Edg\/)/i;
   const nativeUserAgentPattern = /(okhttp|dalvik|cfnetwork)/i;
+
+  if (explicitClientType === 'web') {
+    return 'web';
+  }
+
+  if (explicitClientType === 'mobile') {
+    return 'mobile';
+  }
+
+  if (explicitClientType === 'android') {
+    return 'android';
+  }
 
   if (browserUserAgentPattern.test(userAgent)) {
     return 'web';
@@ -257,6 +290,67 @@ function buildSessionTokens(userState, sessionId, refreshJti) {
     refreshToken: jwt.sign(refreshPayload, config.jwt.refreshSecret, {
       expiresIn: config.jwt.refreshTtl
     })
+  };
+}
+
+function buildRefreshExpiryDate(currentTime) {
+  return new Date(currentTime.getTime() + config.jwt.refreshTtl * 1000);
+}
+
+function buildAuthResponse(accessToken, refreshToken, clientType) {
+  const auth = {
+    access_token: accessToken
+  };
+
+  if (clientType !== 'web') {
+    auth.refresh_token = refreshToken;
+  }
+
+  return auth;
+}
+
+async function lockUserForSessionReplacement(userId, transaction) {
+  return User.findByPk(userId, {
+    lock: transaction.LOCK.UPDATE,
+    transaction
+  });
+}
+
+async function revokeActiveSessionsForClient(userId, clientType, options = {}) {
+  return AuthSession.update(
+    {
+      revoked_at: new Date(),
+      revocation_reason: 'replaced_by_new_login'
+    },
+    {
+      where: {
+        user_id: userId,
+        client_type: clientType,
+        revoked_at: null
+      },
+      ...(options.transaction ? { transaction: options.transaction } : {})
+    }
+  );
+}
+
+async function createAuthSession(userId, clientType, userAgent, options = {}) {
+  const currentTime = options.currentTime || new Date();
+  const payload = {
+    user_id: userId,
+    refresh_jti: options.refreshJti || randomUUID(),
+    client_type: clientType,
+    user_agent: userAgent || null,
+    last_activity_at: currentTime,
+    expires_at: buildRefreshExpiryDate(currentTime)
+  };
+
+  const session = options.transaction
+    ? await AuthSession.create(payload, { transaction: options.transaction })
+    : await AuthSession.create(payload);
+
+  return {
+    refreshJti: session.refresh_jti,
+    session
   };
 }
 
@@ -364,15 +458,15 @@ function isSessionInactive(lastActivityAt, inactivityWindowSeconds) {
 function sendInvalidRefreshResponse(res) {
   return res.status(401).json({
     success: false,
-    code: 'AUTH_REFRESH_INVALID',
+    code: 'AUTH_REFRESH_TOKEN_INVALID',
     message: 'Refresh token invalid'
   });
 }
 
-function sendExpiredRefreshResponse(res) {
+function sendInactiveSessionResponse(res) {
   return res.status(401).json({
     success: false,
-    code: 'AUTH_REFRESH_EXPIRED',
+    code: 'AUTH_SESSION_INACTIVE',
     message: 'Refresh session expired'
   });
 }
@@ -406,7 +500,7 @@ export const refresh = async (req, res) => {
     if (session.revoked_at) {
       return res.status(401).json({
         success: false,
-        code: 'AUTH_REFRESH_REVOKED',
+        code: 'AUTH_REFRESH_TOKEN_REVOKED',
         message: 'Refresh session revoked'
       });
     }
@@ -420,7 +514,7 @@ export const refresh = async (req, res) => {
         revocation_reason: 'expired'
       });
 
-      return sendExpiredRefreshResponse(res);
+      return sendInactiveSessionResponse(res);
     }
 
     const tokenUserState = await loadSessionTokenUserState(session.user_id);
@@ -472,7 +566,8 @@ export const refresh = async (req, res) => {
       return res.json({
         success: true,
         data: {
-          access_token: accessToken
+          access_token: accessToken,
+          auth: buildAuthResponse(accessToken, nextRefreshToken, 'web')
         },
         message: 'Refresh successful'
       });
@@ -482,14 +577,15 @@ export const refresh = async (req, res) => {
       success: true,
       data: {
         access_token: accessToken,
-        refresh_token: nextRefreshToken
+        refresh_token: nextRefreshToken,
+        auth: buildAuthResponse(accessToken, nextRefreshToken, session.client_type)
       },
       message: 'Refresh successful'
     });
   } catch (error) {
     if (isJwtExpiredError(error)) {
       logger.warn(`Refresh expired: ${error.message}`);
-      return sendExpiredRefreshResponse(res);
+      return sendInactiveSessionResponse(res);
     }
 
     if (isJwtVerificationError(error)) {
@@ -586,6 +682,8 @@ export const register = async (req, res) => {
       radius,
       description
     } = req.body;
+    const userAgent = req.get('User-Agent') || '';
+    const clientType = resolveClientType(req);
 
     // Validate required fields
     if (!id_roles) {
@@ -721,22 +819,30 @@ export const register = async (req, res) => {
       { transaction }
     );
 
-    // Commit transaksi
-    await transaction.commit(); // Generate JWT token for the new user
-    const payload = {
+    const roleName = userWithRole.role?.role_name || null;
+    const tokenUserState = {
       id: user.id_users,
       email: user.email,
       full_name: user.full_name,
-      role_name: userWithRole.role?.role_name || null,
+      role_name: roleName,
       photo: uploadResult.url
     };
-
-    const token = jwt.sign(payload, config.jwt.secret, {
-      expiresIn: config.jwt.ttl
+    const { refreshJti, session } = await createAuthSession(user.id_users, clientType, userAgent, {
+      transaction
     });
+    const { accessToken, refreshToken } = buildSessionTokens(
+      tokenUserState,
+      session.session_id,
+      refreshJti
+    );
 
-    // Set token in cookies
-    res.cookie('token', token, { httpOnly: true }); // Response sukses dengan data user dan lokasi
+    // Commit transaksi
+    await transaction.commit();
+
+    if (clientType === 'web') {
+      setSessionCookies(res, accessToken, refreshToken);
+    }
+
     res.status(201).json({
       success: true,
       data: {
@@ -744,9 +850,10 @@ export const register = async (req, res) => {
           id: userWithRole.id_users,
           full_name: userWithRole.full_name,
           email: userWithRole.email,
-          role_name: userWithRole.role?.role_name || null,
-          token: token
+          role_name: roleName,
+          token: accessToken
         },
+        ...(clientType !== 'web' ? { refresh_token: refreshToken } : {}),
         location: {
           location_id: location.location_id,
           latitude: location.latitude,

--- a/src/middlewares/authJwt.js
+++ b/src/middlewares/authJwt.js
@@ -1,10 +1,45 @@
 import jwt from 'jsonwebtoken';
 
 import config from '../config/index.js';
-import { User, Role } from '../models/index.js';
+import { User, Role, AuthSession } from '../models/index.js';
 import logger from '../utils/logger.js';
 
-const isJwtError = (error, expectedName) => error?.name === expectedName;
+function isJwtError(error, expectedName) {
+  return error?.name === expectedName;
+}
+
+function isSessionInactive(lastActivityAt, inactivityWindowSeconds) {
+  if (!lastActivityAt) {
+    return true;
+  }
+
+  return Date.now() - new Date(lastActivityAt).getTime() > inactivityWindowSeconds * 1000;
+}
+
+function isSessionExpired(expiresAt) {
+  return new Date(expiresAt).getTime() <= Date.now();
+}
+
+async function isSessionActive(decoded) {
+  if (!decoded?.session_id || !decoded?.id) {
+    return false;
+  }
+
+  const session = await AuthSession.findByPk(decoded.session_id);
+
+  if (!session || session.user_id !== decoded.id || session.revoked_at) {
+    return false;
+  }
+
+  if (
+    isSessionInactive(session.last_activity_at, config.jwt.refreshInactivityWindowSeconds) ||
+    isSessionExpired(session.expires_at)
+  ) {
+    return false;
+  }
+
+  return true;
+}
 
 export const verifyToken = async (req, res, next) => {
   const authHeader = req.headers.authorization;
@@ -50,6 +85,12 @@ export const verifyToken = async (req, res, next) => {
   }
 
   try {
+    const sessionIsActive = await isSessionActive(decoded);
+
+    if (!sessionIsActive) {
+      return res.status(401).json({ message: 'Invalid token' });
+    }
+
     if (!decoded.role_name && decoded.id) {
       try {
         const userWithRole = await User.findByPk(decoded.id, {

--- a/src/middlewares/requestLogger.js
+++ b/src/middlewares/requestLogger.js
@@ -25,8 +25,7 @@ export const requestLogger = (req, res, next) => {
   // Capture request start time
   const startTime = Date.now();
 
-  // Log incoming request
-  logger.info({
+  logger.info('HTTP request started', {
     type: 'request',
     requestId,
     method: req.method,
@@ -34,7 +33,7 @@ export const requestLogger = (req, res, next) => {
     query: req.query,
     ip: req.ip || req.connection.remoteAddress,
     userAgent: req.headers['user-agent'],
-    userId: req.user?.id || null // Will be null before auth
+    userId: req.user?.id || null
   });
 
   // Capture response using event listeners
@@ -44,8 +43,7 @@ export const requestLogger = (req, res, next) => {
 
     const duration = Date.now() - startTime;
 
-    // Log response
-    logger.info({
+    logger.info('HTTP request completed', {
       type: 'response',
       requestId,
       method: req.method,
@@ -62,7 +60,7 @@ export const requestLogger = (req, res, next) => {
   res.on('error', (error) => {
     const duration = Date.now() - startTime;
 
-    logger.error({
+    logger.error('HTTP request failed during response stream', {
       type: 'response_error',
       requestId,
       method: req.method,
@@ -88,16 +86,16 @@ export const createRequestLogger = (req) => {
 
   return {
     info: (message, meta = {}) => {
-      logger.info({ ...meta, message, requestId });
+      logger.info(message, { ...meta, requestId });
     },
     warn: (message, meta = {}) => {
-      logger.warn({ ...meta, message, requestId });
+      logger.warn(message, { ...meta, requestId });
     },
     error: (message, meta = {}) => {
-      logger.error({ ...meta, message, requestId });
+      logger.error(message, { ...meta, requestId });
     },
     debug: (message, meta = {}) => {
-      logger.debug({ ...meta, message, requestId });
+      logger.debug(message, { ...meta, requestId });
     }
   };
 };

--- a/tests/authJwtTokenPrecedence.test.js
+++ b/tests/authJwtTokenPrecedence.test.js
@@ -4,6 +4,8 @@ import jwt from 'jsonwebtoken';
 import request from 'supertest';
 
 const TEST_JWT_SECRET = 'test-secret';
+const mockUserFindByPk = jest.fn();
+const mockAuthSessionFindByPk = jest.fn();
 
 jest.unstable_mockModule('../src/config/index.js', () => ({
   default: {
@@ -21,9 +23,28 @@ jest.unstable_mockModule('../src/config/index.js', () => ({
   }
 }));
 
+jest.unstable_mockModule('../src/models/index.js', () => ({
+  User: {
+    findByPk: mockUserFindByPk
+  },
+  Role: {},
+  AuthSession: {
+    findByPk: mockAuthSessionFindByPk
+  }
+}));
+
 const { verifyToken } = await import('../src/middlewares/authJwt.js');
-const { User } = await import('../src/models/index.js');
 const { default: logger } = await import('../src/utils/logger.js');
+
+function buildActiveSession(sessionId, userId) {
+  return {
+    session_id: sessionId,
+    user_id: userId,
+    revoked_at: null,
+    last_activity_at: new Date(),
+    expires_at: new Date(Date.now() + 60_000)
+  };
+}
 
 const app = express();
 app.use((req, _res, next) => {
@@ -42,18 +63,39 @@ app.get('/protected', verifyToken, (req, res) => {
 });
 
 describe('authJwt token precedence', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const activeSessions = {
+      101: buildActiveSession(101, 1),
+      102: buildActiveSession(102, 2),
+      103: buildActiveSession(103, 3),
+      104: buildActiveSession(104, 4),
+      105: buildActiveSession(105, 5)
+    };
+
+    mockAuthSessionFindByPk.mockImplementation(async (sessionId) => activeSessions[sessionId] ?? null);
+  });
+
   afterEach(() => {
     jest.restoreAllMocks();
   });
 
+  const signAccessToken = (payload) => jwt.sign(payload, TEST_JWT_SECRET, { expiresIn: '1h' });
+
   const employeeCookieToken = () =>
-    jwt.sign({ id: 1, email: 'employee@example.com', role_name: 'Employee' }, TEST_JWT_SECRET, {
-      expiresIn: '1h'
+    signAccessToken({
+      id: 1,
+      email: 'employee@example.com',
+      role_name: 'Employee',
+      session_id: 101
     });
 
   const managementBearerToken = () =>
-    jwt.sign({ id: 2, email: 'management@example.com', role_name: 'Management' }, TEST_JWT_SECRET, {
-      expiresIn: '1h'
+    signAccessToken({
+      id: 2,
+      email: 'management@example.com',
+      role_name: 'Management',
+      session_id: 102
     });
 
   it('uses the Authorization Bearer token when a cookie token is also present', async () => {
@@ -101,9 +143,11 @@ describe('authJwt token precedence', () => {
 
   it('rejects a valid token without role_name when role hydration fails', async () => {
     const loggerError = jest.spyOn(logger, 'error').mockImplementation(() => {});
-    jest.spyOn(User, 'findByPk').mockRejectedValueOnce(new Error('database unavailable'));
-    const tokenWithoutRoleName = jwt.sign({ id: 3, email: 'legacy@example.com' }, TEST_JWT_SECRET, {
-      expiresIn: '1h'
+    mockUserFindByPk.mockRejectedValueOnce(new Error('database unavailable'));
+    const tokenWithoutRoleName = signAccessToken({
+      id: 3,
+      email: 'legacy@example.com',
+      session_id: 103
     });
 
     const res = await request(app)
@@ -120,9 +164,11 @@ describe('authJwt token precedence', () => {
 
   it('rejects a valid token without role_name when no role can be hydrated', async () => {
     const loggerError = jest.spyOn(logger, 'error').mockImplementation(() => {});
-    jest.spyOn(User, 'findByPk').mockResolvedValueOnce({ role: null });
-    const tokenWithoutRoleName = jwt.sign({ id: 5, email: 'norole@example.com' }, TEST_JWT_SECRET, {
-      expiresIn: '1h'
+    mockUserFindByPk.mockResolvedValueOnce({ role: null });
+    const tokenWithoutRoleName = signAccessToken({
+      id: 5,
+      email: 'norole@example.com',
+      session_id: 105
     });
 
     const res = await request(app)
@@ -161,12 +207,13 @@ describe('authJwt token precedence', () => {
     expect(res.json).not.toHaveBeenCalled();
   });
 
-  it('keeps protected-route verification stateless after successful decoding', async () => {
-    const token = jwt.sign(
-      { id: 4, email: 'expiring@example.com', role_name: 'Management' },
-      TEST_JWT_SECRET,
-      { expiresIn: '1h' }
-    );
+  it('keeps protected-route verification stateful after successful decoding', async () => {
+    const token = signAccessToken({
+      id: 4,
+      email: 'expiring@example.com',
+      role_name: 'Management',
+      session_id: 104
+    });
     const req = {
       headers: { authorization: `Bearer ${token}` },
       cookies: {}
@@ -180,6 +227,7 @@ describe('authJwt token precedence', () => {
 
     await verifyToken(req, res, next);
 
+    expect(mockAuthSessionFindByPk).toHaveBeenCalledWith(104);
     expect(next).toHaveBeenCalledWith();
     expect(req.user).toEqual(
       expect.objectContaining({

--- a/tests/authLoginCookieReuse.test.js
+++ b/tests/authLoginCookieReuse.test.js
@@ -40,8 +40,22 @@ jest.unstable_mockModule('bcryptjs', () => ({
   }
 }));
 
+const mockUserFindOne = jest.fn(async () => mockUser);
+const mockUserFindByPk = jest.fn(async () => mockUser);
+const mockTransaction = {
+  LOCK: {
+    UPDATE: 'UPDATE'
+  },
+  commit: jest.fn(async () => undefined),
+  rollback: jest.fn(async () => undefined)
+};
+const mockSequelizeTransaction = jest.fn(async () => mockTransaction);
 const mockAuthSession = {
-  create: jest.fn(async () => ({ session_id: 42 }))
+  create: jest.fn(async (payload) => ({
+    session_id: 42,
+    refresh_jti: payload.refresh_jti
+  })),
+  update: jest.fn(async () => [0])
 };
 
 jest.unstable_mockModule('../src/config/index.js', () => ({
@@ -59,7 +73,8 @@ jest.unstable_mockModule('../src/config/index.js', () => ({
 
 jest.unstable_mockModule('../src/models/index.js', () => ({
   User: {
-    findOne: jest.fn(async () => mockUser)
+    findOne: mockUserFindOne,
+    findByPk: mockUserFindByPk
   },
   Photo: {},
   Role: {
@@ -73,7 +88,9 @@ jest.unstable_mockModule('../src/models/index.js', () => ({
 }));
 
 jest.unstable_mockModule('../src/config/database.js', () => ({
-  default: {}
+  default: {
+    transaction: mockSequelizeTransaction
+  }
 }));
 
 jest.unstable_mockModule('../src/models/location.js', () => ({
@@ -98,28 +115,40 @@ jest.unstable_mockModule('../src/config/spaces.js', () => ({
 
 const { login } = await import('../src/controllers/auth.controller.js');
 
+function createRequest() {
+  return {
+    body: {
+      email: 'management@example.com',
+      password: 'correct-password'
+    },
+    cookies: {
+      token: employeeCookieToken
+    },
+    headers: {},
+    get: jest.fn(() => 'Mozilla/5.0')
+  };
+}
+
+function createResponse() {
+  return {
+    cookie: jest.fn(),
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn()
+  };
+}
+
 describe('auth login cookie token reuse', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   afterEach(() => {
     jest.restoreAllMocks();
   });
 
   it('does not reuse a valid cookie token that belongs to a different authenticated user', async () => {
-    const req = {
-      body: {
-        email: 'management@example.com',
-        password: 'correct-password'
-      },
-      cookies: {
-        token: employeeCookieToken
-      },
-      headers: {},
-      get: jest.fn(() => 'Mozilla/5.0')
-    };
-    const res = {
-      cookie: jest.fn(),
-      status: jest.fn().mockReturnThis(),
-      json: jest.fn()
-    };
+    const req = createRequest();
+    const res = createResponse();
 
     await login(req, res);
 
@@ -163,22 +192,8 @@ describe('auth login cookie token reuse', () => {
       throw new jwt.NotBeforeError('jwt not active', new Date());
     });
 
-    const req = {
-      body: {
-        email: 'management@example.com',
-        password: 'correct-password'
-      },
-      cookies: {
-        token: employeeCookieToken
-      },
-      headers: {},
-      get: jest.fn(() => 'Mozilla/5.0')
-    };
-    const res = {
-      cookie: jest.fn(),
-      status: jest.fn().mockReturnThis(),
-      json: jest.fn()
-    };
+    const req = createRequest();
+    const res = createResponse();
 
     await login(req, res);
 
@@ -187,7 +202,8 @@ describe('auth login cookie token reuse', () => {
       expect.objectContaining({
         user_id: 2,
         client_type: 'web'
-      })
+      }),
+      { transaction: mockTransaction }
     );
     expect(res.status).not.toHaveBeenCalled();
     expect(res.json).toHaveBeenCalledWith(
@@ -206,22 +222,8 @@ describe('auth login cookie token reuse', () => {
       throw new Error('jwt library unavailable');
     });
 
-    const req = {
-      body: {
-        email: 'management@example.com',
-        password: 'correct-password'
-      },
-      cookies: {
-        token: employeeCookieToken
-      },
-      headers: {},
-      get: jest.fn(() => 'Mozilla/5.0')
-    };
-    const res = {
-      cookie: jest.fn(),
-      status: jest.fn().mockReturnThis(),
-      json: jest.fn()
-    };
+    const req = createRequest();
+    const res = createResponse();
 
     await login(req, res);
 

--- a/tests/authMiddlewareContract.test.js
+++ b/tests/authMiddlewareContract.test.js
@@ -2,6 +2,7 @@ import { jest } from '@jest/globals';
 
 const mockVerify = jest.fn();
 const mockUserFindByPk = jest.fn();
+const mockAuthSessionFindByPk = jest.fn();
 
 jest.unstable_mockModule('jsonwebtoken', () => ({
   default: {
@@ -15,7 +16,8 @@ jest.unstable_mockModule('../src/config/index.js', () => ({
     jwt: {
       secret: 'access-secret',
       ttl: 900,
-      accessTtl: 900
+      accessTtl: 900,
+      refreshInactivityWindowSeconds: 172800
     }
   }
 }));
@@ -24,41 +26,62 @@ jest.unstable_mockModule('../src/models/index.js', () => ({
   User: {
     findByPk: mockUserFindByPk
   },
-  Role: {}
+  Role: {},
+  AuthSession: {
+    findByPk: mockAuthSessionFindByPk
+  }
 }));
 
 const { verifyToken } = await import('../src/middlewares/authJwt.js');
+
+function buildSession(overrides = {}) {
+  return {
+    session_id: 77,
+    user_id: 5,
+    revoked_at: null,
+    last_activity_at: new Date(),
+    expires_at: new Date(Date.now() + 60_000),
+    ...overrides
+  };
+}
+
+function buildRequest(token) {
+  return {
+    cookies: { token },
+    headers: {}
+  };
+}
+
+function buildResponse() {
+  return {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+    cookie: jest.fn()
+  };
+}
 
 describe('Auth middleware contract', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('accepts a valid access token without consulting refresh-session state', async () => {
+  it('accepts a valid access token only when the linked auth session remains active', async () => {
     mockVerify.mockReturnValue({
       id: 5,
       session_id: 77,
       role_name: 'Admin',
       email: 'user@example.com'
     });
+    mockAuthSessionFindByPk.mockResolvedValue(buildSession());
 
-    const req = {
-      cookies: {
-        token: 'valid-access-token'
-      },
-      headers: {}
-    };
-
-    const res = {
-      status: jest.fn().mockReturnThis(),
-      json: jest.fn(),
-      cookie: jest.fn()
-    };
+    const req = buildRequest('valid-access-token');
+    const res = buildResponse();
 
     const next = jest.fn();
 
     await verifyToken(req, res, next);
 
+    expect(mockAuthSessionFindByPk).toHaveBeenCalledWith(77);
     expect(next).toHaveBeenCalled();
     expect(req.user).toEqual(
       expect.objectContaining({
@@ -69,6 +92,103 @@ describe('Auth middleware contract', () => {
     );
     expect(mockUserFindByPk).not.toHaveBeenCalled();
     expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('rejects a valid access token when the linked auth session was already revoked', async () => {
+    mockVerify.mockReturnValue({
+      id: 5,
+      session_id: 77,
+      role_name: 'Admin',
+      email: 'user@example.com'
+    });
+    mockAuthSessionFindByPk.mockResolvedValue(buildSession({
+      revoked_at: new Date()
+    }));
+
+    const req = buildRequest('revoked-session-access-token');
+    const res = buildResponse();
+    const next = jest.fn();
+
+    await verifyToken(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(mockAuthSessionFindByPk).toHaveBeenCalledWith(77);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Invalid token' });
+  });
+
+  it('rejects a decoded access token when no linked auth session id is present', async () => {
+    mockVerify.mockReturnValue({
+      id: 5,
+      role_name: 'Admin',
+      email: 'user@example.com'
+    });
+
+    const req = buildRequest('legacy-access-token');
+    const res = buildResponse();
+
+    const next = jest.fn();
+
+    await verifyToken(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(mockAuthSessionFindByPk).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Invalid token' });
+  });
+
+  it('rejects a decoded access token when the linked auth session is already expired', async () => {
+    mockVerify.mockReturnValue({
+      id: 5,
+      session_id: 88,
+      role_name: 'Admin',
+      email: 'user@example.com'
+    });
+    mockAuthSessionFindByPk.mockResolvedValue(
+      buildSession({
+        session_id: 88,
+        expires_at: new Date(Date.now() - 60_000)
+      })
+    );
+
+    const req = buildRequest('expired-session-access-token');
+    const res = buildResponse();
+
+    const next = jest.fn();
+
+    await verifyToken(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(mockAuthSessionFindByPk).toHaveBeenCalledWith(88);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Invalid token' });
+  });
+
+  it('rejects a decoded access token when the linked auth session is inactive beyond the refresh inactivity window', async () => {
+    mockVerify.mockReturnValue({
+      id: 5,
+      session_id: 89,
+      role_name: 'Admin',
+      email: 'user@example.com'
+    });
+    mockAuthSessionFindByPk.mockResolvedValue(
+      buildSession({
+        session_id: 89,
+        last_activity_at: new Date(Date.now() - 172801000)
+      })
+    );
+
+    const req = buildRequest('inactive-session-access-token');
+    const res = buildResponse();
+
+    const next = jest.fn();
+
+    await verifyToken(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(mockAuthSessionFindByPk).toHaveBeenCalledWith(89);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Invalid token' });
   });
 
   it('returns a refreshable 401 contract when the access token is expired', async () => {

--- a/tests/authRefreshContract.test.js
+++ b/tests/authRefreshContract.test.js
@@ -165,13 +165,17 @@ describe('Auth refresh contract', () => {
       success: true,
       data: {
         access_token: 'new-access-token',
-        refresh_token: 'new-refresh-token'
+        refresh_token: 'new-refresh-token',
+        auth: {
+          access_token: 'new-access-token',
+          refresh_token: 'new-refresh-token'
+        }
       },
       message: 'Refresh successful'
     });
   });
 
-  it('returns AUTH_REFRESH_INVALID when the refresh JWT is malformed', async () => {
+  it('returns AUTH_REFRESH_TOKEN_INVALID when the refresh JWT is malformed', async () => {
     const invalidError = new Error('jwt malformed');
     invalidError.name = 'JsonWebTokenError';
     mockVerify.mockImplementation(() => {
@@ -197,13 +201,13 @@ describe('Auth refresh contract', () => {
     expect(res.status).toHaveBeenCalledWith(401);
     expect(res.json).toHaveBeenCalledWith({
       success: false,
-      code: 'AUTH_REFRESH_INVALID',
+      code: 'AUTH_REFRESH_TOKEN_INVALID',
       message: 'Refresh token invalid'
     });
     expect(mockLogger.warn).toHaveBeenCalledWith('Refresh rejected: jwt malformed');
   });
 
-  it('returns AUTH_REFRESH_EXPIRED when the refresh JWT is expired', async () => {
+  it('returns AUTH_SESSION_INACTIVE when the refresh JWT is expired', async () => {
     const expiredError = new Error('jwt expired');
     expiredError.name = 'TokenExpiredError';
     mockVerify.mockImplementation(() => {
@@ -229,13 +233,13 @@ describe('Auth refresh contract', () => {
     expect(res.status).toHaveBeenCalledWith(401);
     expect(res.json).toHaveBeenCalledWith({
       success: false,
-      code: 'AUTH_REFRESH_EXPIRED',
+      code: 'AUTH_SESSION_INACTIVE',
       message: 'Refresh session expired'
     });
     expect(mockLogger.warn).toHaveBeenCalledWith('Refresh expired: jwt expired');
   });
 
-  it('returns AUTH_REFRESH_REVOKED when the refresh session is already revoked', async () => {
+  it('returns AUTH_REFRESH_TOKEN_REVOKED when the refresh session is already revoked', async () => {
     mockVerify.mockReturnValue({
       session_id: 77,
       jti: 'refresh-jti-old',
@@ -268,12 +272,12 @@ describe('Auth refresh contract', () => {
     expect(res.status).toHaveBeenCalledWith(401);
     expect(res.json).toHaveBeenCalledWith({
       success: false,
-      code: 'AUTH_REFRESH_REVOKED',
+      code: 'AUTH_REFRESH_TOKEN_REVOKED',
       message: 'Refresh session revoked'
     });
   });
 
-  it('returns AUTH_REFRESH_EXPIRED when the refresh session is inactive for longer than the inactivity window', async () => {
+  it('returns AUTH_SESSION_INACTIVE when the refresh session is inactive for longer than the inactivity window', async () => {
     mockVerify.mockReturnValue({
       session_id: 77,
       jti: 'refresh-jti-old',
@@ -314,12 +318,12 @@ describe('Auth refresh contract', () => {
     expect(res.status).toHaveBeenCalledWith(401);
     expect(res.json).toHaveBeenCalledWith({
       success: false,
-      code: 'AUTH_REFRESH_EXPIRED',
+      code: 'AUTH_SESSION_INACTIVE',
       message: 'Refresh session expired'
     });
   });
 
-  it('returns AUTH_REFRESH_INVALID when concurrent rotation already consumed the same refresh jti', async () => {
+  it('returns AUTH_REFRESH_TOKEN_INVALID when concurrent rotation already consumed the same refresh jti', async () => {
     mockVerify.mockReturnValue({
       session_id: 77,
       jti: 'refresh-jti-old',
@@ -370,7 +374,7 @@ describe('Auth refresh contract', () => {
     expect(res.status).toHaveBeenCalledWith(401);
     expect(res.json).toHaveBeenCalledWith({
       success: false,
-      code: 'AUTH_REFRESH_INVALID',
+      code: 'AUTH_REFRESH_TOKEN_INVALID',
       message: 'Refresh token invalid'
     });
     expect(mockLogger.warn).toHaveBeenCalledWith(

--- a/tests/authSessionLifecycleContract.test.js
+++ b/tests/authSessionLifecycleContract.test.js
@@ -5,9 +5,19 @@ const mockCompare = jest.fn();
 const mockSign = jest.fn();
 const mockVerify = jest.fn();
 const mockUserFindOne = jest.fn();
+const mockUserFindByPk = jest.fn();
 const mockAuthSessionCreate = jest.fn();
 const mockAuthSessionFindByPk = jest.fn();
+const mockAuthSessionUpdate = jest.fn();
 const mockSessionUpdate = jest.fn();
+const mockTransaction = {
+  LOCK: {
+    UPDATE: 'UPDATE'
+  },
+  commit: jest.fn(),
+  rollback: jest.fn()
+};
+const mockSequelizeTransaction = jest.fn();
 const mockLocationFindOne = jest.fn();
 const mockRoleFindByPk = jest.fn();
 const mockLogger = {
@@ -51,12 +61,15 @@ jest.unstable_mockModule('../src/config/cloudinary.js', () => ({
 }));
 
 jest.unstable_mockModule('../src/config/database.js', () => ({
-  default: {}
+  default: {
+    transaction: mockSequelizeTransaction
+  }
 }));
 
 jest.unstable_mockModule('../src/models/index.js', () => ({
   User: {
-    findOne: mockUserFindOne
+    findOne: mockUserFindOne,
+    findByPk: mockUserFindByPk
   },
   Photo: {},
   Role: {
@@ -68,7 +81,8 @@ jest.unstable_mockModule('../src/models/index.js', () => ({
   AttendanceCategory: {},
   AuthSession: {
     create: mockAuthSessionCreate,
-    findByPk: mockAuthSessionFindByPk
+    findByPk: mockAuthSessionFindByPk,
+    update: mockAuthSessionUpdate
   }
 }));
 
@@ -101,13 +115,13 @@ function createLoginUser(overrides = {}) {
   };
 }
 
-function createLoginRequest(userAgent) {
+function createLoginRequest(userAgent, headers = {}) {
   return {
     body: {
       email: 'user@example.com',
       password: 'password123'
     },
-    headers: {},
+    headers,
     cookies: {},
     get: jest.fn((header) => (header === 'User-Agent' ? userAgent : ''))
   };
@@ -130,7 +144,12 @@ describe('Auth session lifecycle contract', () => {
       array: () => []
     });
     mockCompare.mockResolvedValue(true);
+    mockUserFindByPk.mockResolvedValue(createLoginUser());
     mockLocationFindOne.mockResolvedValue(null);
+    mockAuthSessionUpdate.mockResolvedValue([0]);
+    mockTransaction.commit.mockResolvedValue(undefined);
+    mockTransaction.rollback.mockResolvedValue(undefined);
+    mockSequelizeTransaction.mockResolvedValue(mockTransaction);
     mockRoleFindByPk.mockReset();
     mockVerify.mockReset();
   });
@@ -153,7 +172,8 @@ describe('Auth session lifecycle contract', () => {
         refresh_jti: expect.any(String),
         last_activity_at: expect.any(Date),
         expires_at: expect.any(Date)
-      })
+      }),
+      { transaction: mockTransaction }
     );
     expect(res.cookie).toHaveBeenNthCalledWith(
       1,
@@ -177,7 +197,11 @@ describe('Auth session lifecycle contract', () => {
       expect.objectContaining({
         success: true,
         data: expect.objectContaining({
-          id: 5
+          id: 5,
+          token: 'access-token',
+          auth: {
+            access_token: 'access-token'
+          }
         })
       })
     );
@@ -201,7 +225,8 @@ describe('Auth session lifecycle contract', () => {
         refresh_jti: expect.any(String),
         last_activity_at: expect.any(Date),
         expires_at: expect.any(Date)
-      })
+      }),
+      { transaction: mockTransaction }
     );
     expect(res.cookie).not.toHaveBeenCalled();
     expect(res.json).toHaveBeenCalledWith(
@@ -210,7 +235,11 @@ describe('Auth session lifecycle contract', () => {
         data: expect.objectContaining({
           id: 5,
           token: 'android-access-token',
-          refresh_token: 'android-refresh-token'
+          refresh_token: 'android-refresh-token',
+          auth: {
+            access_token: 'android-access-token',
+            refresh_token: 'android-refresh-token'
+          }
         })
       })
     );
@@ -232,7 +261,8 @@ describe('Auth session lifecycle contract', () => {
       expect.objectContaining({
         user_id: 5,
         client_type: 'web'
-      })
+      }),
+      { transaction: mockTransaction }
     );
     expect(res.cookie).toHaveBeenCalledTimes(2);
     expect(res.json).toHaveBeenCalledWith(
@@ -240,6 +270,111 @@ describe('Auth session lifecycle contract', () => {
         success: true,
         data: expect.objectContaining({
           id: 5
+        })
+      })
+    );
+  });
+
+  it('prefers explicit web client header when user agent does not look like a browser', async () => {
+    mockUserFindOne.mockResolvedValue(createLoginUser());
+    mockAuthSessionCreate.mockResolvedValue({ session_id: 80 });
+    mockSign.mockReturnValueOnce('header-web-access-token').mockReturnValueOnce('header-web-refresh-token');
+
+    const req = createLoginRequest('InfiniteTrackWeb/1.0', {
+      'x-client-type': 'web'
+    });
+    const res = createResponse();
+
+    await login(req, res);
+
+    expect(mockAuthSessionCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: 5,
+        client_type: 'web',
+        user_agent: 'InfiniteTrackWeb/1.0'
+      }),
+      { transaction: mockTransaction }
+    );
+    expect(res.cookie).toHaveBeenCalledTimes(2);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        data: expect.objectContaining({
+          auth: {
+            access_token: 'header-web-access-token'
+          }
+        })
+      })
+    );
+    expect(res.json.mock.calls[0][0].data.auth).not.toHaveProperty('refresh_token');
+    expect(res.json.mock.calls[0][0].data).not.toHaveProperty('refresh_token');
+  });
+
+  it('uses explicit mobile client header for native JSON transport', async () => {
+    mockUserFindOne.mockResolvedValue(createLoginUser());
+    mockAuthSessionCreate.mockResolvedValue({ session_id: 81 });
+    mockSign.mockReturnValueOnce('mobile-access-token').mockReturnValueOnce('mobile-refresh-token');
+
+    const req = createLoginRequest('Mozilla/5.0', {
+      'x-client-type': 'mobile'
+    });
+    const res = createResponse();
+
+    await login(req, res);
+
+    expect(mockAuthSessionCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: 5,
+        client_type: 'mobile',
+        user_agent: 'Mozilla/5.0'
+      }),
+      { transaction: mockTransaction }
+    );
+    expect(res.cookie).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        data: expect.objectContaining({
+          token: 'mobile-access-token',
+          refresh_token: 'mobile-refresh-token',
+          auth: {
+            access_token: 'mobile-access-token',
+            refresh_token: 'mobile-refresh-token'
+          }
+        })
+      })
+    );
+  });
+
+  it('keeps android client header as a backward-compatible native alias', async () => {
+    mockUserFindOne.mockResolvedValue(createLoginUser());
+    mockAuthSessionCreate.mockResolvedValue({ session_id: 82 });
+    mockSign.mockReturnValueOnce('alias-access-token').mockReturnValueOnce('alias-refresh-token');
+
+    const req = createLoginRequest('Mozilla/5.0', {
+      'x-client-type': 'android'
+    });
+    const res = createResponse();
+
+    await login(req, res);
+
+    expect(mockAuthSessionCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: 5,
+        client_type: 'android',
+        user_agent: 'Mozilla/5.0'
+      }),
+      { transaction: mockTransaction }
+    );
+    expect(res.cookie).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        data: expect.objectContaining({
+          auth: {
+            access_token: 'alias-access-token',
+            refresh_token: 'alias-refresh-token'
+          }
         })
       })
     );
@@ -288,8 +423,152 @@ describe('Auth session lifecycle contract', () => {
         data: expect.objectContaining({
           role_name: 'Management',
           token: 'fallback-access-token',
-          refresh_token: 'fallback-refresh-token'
+          refresh_token: 'fallback-refresh-token',
+          auth: {
+            access_token: 'fallback-access-token',
+            refresh_token: 'fallback-refresh-token'
+          }
         })
+      })
+    );
+  });
+
+  it('revokes previous active sessions for the same user and client type before login creates a new session', async () => {
+    mockUserFindOne.mockResolvedValue(createLoginUser());
+    mockAuthSessionCreate.mockResolvedValue({ session_id: 83 });
+    mockSign.mockReturnValueOnce('replacement-access-token').mockReturnValueOnce('replacement-refresh-token');
+
+    const req = createLoginRequest('Mozilla/5.0', {
+      'x-client-type': 'web'
+    });
+    const res = createResponse();
+
+    await login(req, res);
+
+    expect(mockAuthSessionUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        revoked_at: expect.any(Date),
+        revocation_reason: 'replaced_by_new_login'
+      }),
+      {
+        where: {
+          user_id: 5,
+          client_type: 'web',
+          revoked_at: null
+        },
+        transaction: mockTransaction
+      }
+    );
+    expect(mockUserFindByPk).toHaveBeenCalledWith(5, {
+      lock: mockTransaction.LOCK.UPDATE,
+      transaction: mockTransaction
+    });
+    expect(mockUserFindByPk.mock.invocationCallOrder[0]).toBeLessThan(
+      mockAuthSessionUpdate.mock.invocationCallOrder[0]
+    );
+    expect(mockAuthSessionUpdate.mock.invocationCallOrder[0]).toBeLessThan(
+      mockAuthSessionCreate.mock.invocationCallOrder[0]
+    );
+    expect(mockAuthSessionCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: 5,
+        client_type: 'web'
+      }),
+      { transaction: mockTransaction }
+    );
+    expect(mockTransaction.commit).toHaveBeenCalledTimes(1);
+    expect(mockTransaction.rollback).not.toHaveBeenCalled();
+  });
+
+  it('only revokes active sessions for the resolved client type when another client type logs in', async () => {
+    mockUserFindOne.mockResolvedValue(createLoginUser());
+    mockAuthSessionCreate.mockResolvedValue({ session_id: 84 });
+    mockSign.mockReturnValueOnce('mobile-replacement-access-token').mockReturnValueOnce('mobile-replacement-refresh-token');
+
+    const req = createLoginRequest('okhttp/4.12.0', {
+      'x-client-type': 'mobile'
+    });
+    const res = createResponse();
+
+    await login(req, res);
+
+    expect(mockAuthSessionUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        revoked_at: expect.any(Date),
+        revocation_reason: 'replaced_by_new_login'
+      }),
+      {
+        where: {
+          user_id: 5,
+          client_type: 'mobile',
+          revoked_at: null
+        },
+        transaction: mockTransaction
+      }
+    );
+    expect(mockAuthSessionUpdate).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        where: expect.objectContaining({
+          user_id: 5,
+          client_type: 'web'
+        })
+      })
+    );
+  });
+
+  it('returns generic login failure when session persistence breaks after valid credentials', async () => {
+    const sessionError = new Error('auth_sessions table missing');
+    mockUserFindOne.mockResolvedValue(createLoginUser());
+    mockAuthSessionCreate.mockRejectedValue(sessionError);
+
+    const req = createLoginRequest('Mozilla/5.0');
+    const res = createResponse();
+
+    await login(req, res);
+
+    expect(mockCompare).toHaveBeenCalledWith('password123', 'hashed-password');
+    expect(res.cookie).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      code: 'E_LOGIN',
+      message: 'Terjadi kesalahan pada server'
+    });
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      'Login error: auth_sessions table missing',
+      expect.objectContaining({
+        stack: expect.any(String)
+      })
+    );
+  });
+
+  it('preserves the original login error when rollback also fails', async () => {
+    const sessionError = new Error('auth_sessions table missing');
+    const rollbackError = new Error('rollback connection lost');
+    mockUserFindOne.mockResolvedValue(createLoginUser());
+    mockAuthSessionCreate.mockRejectedValue(sessionError);
+    mockTransaction.rollback.mockRejectedValue(rollbackError);
+
+    const req = createLoginRequest('Mozilla/5.0');
+    const res = createResponse();
+
+    await login(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      'Login session replacement rollback failed: rollback connection lost',
+      expect.objectContaining({
+        original_error: 'auth_sessions table missing',
+        stack: expect.any(String),
+        user_id: 5,
+        client_type: 'web'
+      })
+    );
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      'Login error: auth_sessions table missing',
+      expect.objectContaining({
+        stack: expect.any(String)
       })
     );
   });

--- a/tests/requestLoggerContract.test.js
+++ b/tests/requestLoggerContract.test.js
@@ -1,0 +1,119 @@
+import { jest } from '@jest/globals';
+
+const mockInfo = jest.fn();
+const mockWarn = jest.fn();
+const mockError = jest.fn();
+const mockDebug = jest.fn();
+
+jest.unstable_mockModule('crypto', () => ({
+  randomUUID: () => 'req-123'
+}));
+
+jest.unstable_mockModule('../src/utils/logger.js', () => ({
+  default: {
+    info: mockInfo,
+    warn: mockWarn,
+    error: mockError,
+    debug: mockDebug
+  }
+}));
+
+const { requestLogger, createRequestLogger } = await import('../src/middlewares/requestLogger.js');
+
+describe('Request logger contract', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('logs request and response events as message plus metadata instead of object payloads', () => {
+    const req = {
+      headers: {
+        'user-agent': 'jest-agent'
+      },
+      method: 'GET',
+      path: '/api/profile',
+      query: { page: '1' },
+      ip: '127.0.0.1',
+      connection: {
+        remoteAddress: '127.0.0.1'
+      }
+    };
+
+    const originalSend = jest.fn((data) => data);
+    const responseErrorHandler = jest.fn();
+    const res = {
+      statusCode: 200,
+      setHeader: jest.fn(),
+      on: jest.fn((event, handler) => {
+        if (event === 'error') {
+          responseErrorHandler.mockImplementation(handler);
+        }
+      }),
+      send: originalSend
+    };
+    const next = jest.fn();
+
+    requestLogger(req, res, next);
+    res.send('ok');
+
+    expect(res.setHeader).toHaveBeenCalledWith('X-Request-ID', 'req-123');
+    expect(next).toHaveBeenCalled();
+    expect(mockInfo).toHaveBeenNthCalledWith(
+      1,
+      'HTTP request started',
+      expect.objectContaining({
+        type: 'request',
+        requestId: 'req-123',
+        method: 'GET',
+        path: '/api/profile',
+        query: { page: '1' },
+        ip: '127.0.0.1',
+        userAgent: 'jest-agent',
+        userId: null
+      })
+    );
+    expect(mockInfo).toHaveBeenNthCalledWith(
+      2,
+      'HTTP request completed',
+      expect.objectContaining({
+        type: 'response',
+        requestId: 'req-123',
+        method: 'GET',
+        path: '/api/profile',
+        statusCode: 200,
+        duration: expect.stringMatching(/^[0-9]+ms$/),
+        userId: null
+      })
+    );
+    expect(mockInfo).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'request' }));
+    expect(mockInfo).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'response' }));
+    expect(responseErrorHandler).not.toHaveBeenCalled();
+  });
+
+  it('propagates requestId through child logger helpers without wrapping the message in an object', () => {
+    const req = {
+      requestId: 'req-456'
+    };
+
+    const log = createRequestLogger(req);
+
+    log.info('User action completed', {
+      userId: 9,
+      action: 'profile.read'
+    });
+
+    expect(mockInfo).toHaveBeenCalledWith('User action completed', {
+      userId: 9,
+      action: 'profile.read',
+      requestId: 'req-456'
+    });
+    expect(mockInfo).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'User action completed',
+        userId: 9,
+        action: 'profile.read',
+        requestId: 'req-456'
+      })
+    );
+  });
+});

--- a/tests/spacesUploadRollbackContract.test.js
+++ b/tests/spacesUploadRollbackContract.test.js
@@ -95,7 +95,10 @@ describe('Spaces upload rollback contract', () => {
       .fn()
       .mockReturnValue('users/77/profile/register-photo.jpg');
     const hash = jest.fn().mockResolvedValue('hashed');
-    const sign = jest.fn().mockReturnValue('jwt-token');
+    const sign = jest
+      .fn()
+      .mockReturnValueOnce('register-access-token')
+      .mockReturnValueOnce('register-refresh-token');
 
     jest.unstable_mockModule('../src/config/database.js', () => ({
       default: { transaction: jest.fn().mockResolvedValue(transaction) }
@@ -177,10 +180,14 @@ describe('Spaces upload rollback contract', () => {
       'test-secret',
       { expiresIn: 900 }
     );
-    expect(res.cookie).toHaveBeenCalledWith('token', 'jwt-token', expect.objectContaining({ httpOnly: true }));
+    expect(res.cookie).toHaveBeenCalledWith(
+      'token',
+      'register-access-token',
+      expect.objectContaining({ httpOnly: true })
+    );
     expect(res.cookie).toHaveBeenCalledWith(
       'refresh_token',
-      'jwt-token',
+      'register-refresh-token',
       expect.objectContaining({ httpOnly: true })
     );
     expect(res.status).toHaveBeenCalledWith(201);

--- a/tests/spacesUploadRollbackContract.test.js
+++ b/tests/spacesUploadRollbackContract.test.js
@@ -1,9 +1,191 @@
 import { jest } from '@jest/globals';
 
+function buildRegisterRequest() {
+  return {
+    body: {
+      email: 'new.user@example.com',
+      password: 'Password123!',
+      id_roles: 1,
+      id_position: 2,
+      full_name: 'New User',
+      nipNim: '123456',
+      phoneNumber: '08123',
+      id_divisions: 3,
+      id_programs: 4,
+      latitude: '-6.2',
+      longitude: '106.8',
+      radius: 100,
+      description: 'WFH'
+    },
+    file: {
+      buffer: Buffer.from('fake-image'),
+      originalname: 'register-photo.jpg',
+      mimetype: 'image/jpeg'
+    },
+    headers: {},
+    get: jest.fn(() => 'Mozilla/5.0')
+  };
+}
+
+function buildResponse() {
+  return {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+    cookie: jest.fn().mockReturnThis()
+  };
+}
+
 describe('Spaces upload rollback contract', () => {
   beforeEach(() => {
     jest.resetModules();
     jest.clearAllMocks();
+  });
+
+  test('register issues a protected-route-compatible access token with a linked auth session', async () => {
+    const transaction = {
+      rollback: jest.fn(),
+      commit: jest.fn()
+    };
+
+    const user = {
+      id_users: 77,
+      email: 'new.user@example.com',
+      full_name: 'New User',
+      update: jest.fn()
+    };
+
+    const userWithRole = {
+      id_users: 77,
+      email: 'new.user@example.com',
+      full_name: 'New User',
+      role: { role_name: 'Employee' }
+    };
+
+    const User = {
+      findOne: jest.fn().mockResolvedValueOnce(null).mockResolvedValueOnce(null),
+      create: jest.fn().mockResolvedValue(user),
+      findByPk: jest.fn().mockResolvedValue(userWithRole)
+    };
+
+    const Photo = {
+      create: jest.fn().mockResolvedValue({ id_photos: 15 })
+    };
+
+    const Location = {
+      create: jest.fn().mockResolvedValue({
+        location_id: 9,
+        latitude: -6.2,
+        longitude: 106.8,
+        radius: 100,
+        description: 'WFH'
+      })
+    };
+
+    const AuthSession = {
+      create: jest.fn().mockResolvedValue({ session_id: 321 })
+    };
+
+    const uploadBufferToSpaces = jest.fn().mockResolvedValue({
+      key: 'users/77/profile/register-photo.jpg',
+      url: 'https://infinite-track-staging-sgp1.sgp1.digitaloceanspaces.com/users/77/profile/register-photo.jpg'
+    });
+
+    const deleteSpacesObject = jest.fn().mockResolvedValue(undefined);
+    const buildUserProfilePhotoKey = jest
+      .fn()
+      .mockReturnValue('users/77/profile/register-photo.jpg');
+    const hash = jest.fn().mockResolvedValue('hashed');
+    const sign = jest.fn().mockReturnValue('jwt-token');
+
+    jest.unstable_mockModule('../src/config/database.js', () => ({
+      default: { transaction: jest.fn().mockResolvedValue(transaction) }
+    }));
+
+    jest.unstable_mockModule('../src/models/index.js', () => ({
+      User,
+      Photo,
+      Role: {},
+      Program: {},
+      Position: {},
+      Division: {},
+      AttendanceCategory: {},
+      AuthSession
+    }));
+
+    jest.unstable_mockModule('../src/models/location.js', () => ({
+      default: Location
+    }));
+
+    jest.unstable_mockModule('../src/config/spaces.js', () => ({
+      buildUserProfilePhotoKey,
+      uploadBufferToSpaces,
+      deleteSpacesObject
+    }));
+
+    jest.unstable_mockModule('../src/config/index.js', () => ({
+      default: {
+        jwt: {
+          secret: 'test-secret',
+          refreshSecret: 'refresh-secret',
+          ttl: 900,
+          accessTtl: 900,
+          refreshTtl: 2592000
+        }
+      }
+    }));
+
+    jest.unstable_mockModule('bcryptjs', () => ({
+      default: { hash }
+    }));
+
+    jest.unstable_mockModule('jsonwebtoken', () => ({
+      default: { sign }
+    }));
+
+    jest.unstable_mockModule('../src/utils/logger.js', () => ({
+      default: { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+    }));
+
+    const { register } = await import('../src/controllers/auth.controller.js');
+
+    const req = buildRegisterRequest();
+    const res = buildResponse();
+
+    await register(req, res);
+
+    expect(AuthSession.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: 77,
+        client_type: 'web',
+        user_agent: 'Mozilla/5.0',
+        refresh_jti: expect.any(String),
+        last_activity_at: expect.any(Date),
+        expires_at: expect.any(Date)
+      }),
+      { transaction }
+    );
+    expect(sign).toHaveBeenCalledWith(
+      expect.objectContaining({
+        session_id: 321,
+        id: 77,
+        email: 'new.user@example.com',
+        full_name: 'New User',
+        role_name: 'Employee',
+        photo:
+          'https://infinite-track-staging-sgp1.sgp1.digitaloceanspaces.com/users/77/profile/register-photo.jpg'
+      }),
+      'test-secret',
+      { expiresIn: 900 }
+    );
+    expect(res.cookie).toHaveBeenCalledWith('token', 'jwt-token', expect.objectContaining({ httpOnly: true }));
+    expect(res.cookie).toHaveBeenCalledWith(
+      'refresh_token',
+      'jwt-token',
+      expect.objectContaining({ httpOnly: true })
+    );
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(transaction.commit).toHaveBeenCalled();
+    expect(transaction.rollback).not.toHaveBeenCalled();
   });
 
   test('register deletes uploaded Spaces object when photo persistence fails after upload', async () => {
@@ -82,36 +264,8 @@ describe('Spaces upload rollback contract', () => {
 
     const { register } = await import('../src/controllers/auth.controller.js');
 
-    const req = {
-      body: {
-        email: 'new.user@example.com',
-        password: 'Password123!',
-        id_roles: 1,
-        id_position: 2,
-        full_name: 'New User',
-        nipNim: '123456',
-        phoneNumber: '08123',
-        id_divisions: 3,
-        id_programs: 4,
-        latitude: '-6.2',
-        longitude: '106.8',
-        radius: 100,
-        description: 'WFH'
-      },
-      file: {
-        buffer: Buffer.from('fake-image'),
-        originalname: 'register-photo.jpg',
-        mimetype: 'image/jpeg'
-      },
-      headers: {},
-      get: jest.fn(() => 'Mozilla/5.0')
-    };
-
-    const res = {
-      status: jest.fn().mockReturnThis(),
-      json: jest.fn().mockReturnThis(),
-      cookie: jest.fn().mockReturnThis()
-    };
+    const req = buildRegisterRequest();
+    const res = buildResponse();
 
     await register(req, res);
 


### PR DESCRIPTION
## Summary
- Make same-user/same-client login replacement atomic by wrapping revoke/create/signing in one transaction and locking the user row before replacement.
- Align auth/session contract tests, cookie-reuse harness, request logging, and Spaces rollback coverage with the hardened session flow.
- Sync OpenAPI and ADR-007 with the primary `data.auth` response contract and atomic same-client replacement semantics.

## Impact
- Backend session state remains the authority for login replacement, refresh rotation, logout, and protected-route validity.
- A failed replacement session creation/signing no longer revokes the previous same-client session.
- Concurrent same-user login replacement attempts are serialized by row-level lock scope on the user row.

## Risk
- Legacy access tokens issued before this contract do not carry `session_id`; this is a rollout/cutover concern and should be handled by the follow-up cutover policy.
- Row-level locking can add minor latency for concurrent login attempts by the same user, bounded to the single user row.
- Browser and native clients must migrate toward `data.auth` while legacy direct token fields remain during compatibility window.

## Verification
- `npm run lint` — PASS
- `npm test -- --runTestsByPath tests/authSessionLifecycleContract.test.js tests/authRefreshContract.test.js tests/authJwtTokenPrecedence.test.js tests/authLoginCookieReuse.test.js tests/authMiddlewareContract.test.js tests/clientCriticalOpenApiContract.test.js tests/requestLoggerContract.test.js tests/spacesUploadRollbackContract.test.js` — PASS, 8 suites / 61 tests
- Earlier full suite on this worktree: `npm test` — PASS, 53 suites / 303 tests
- Earlier local runtime smoke on port 3006: login, refresh, `/api/auth/me`, and logout succeeded against local runtime using branch code

## Docs / ADR
- `docs/openapi.yaml` updated for `data.auth`, refresh error contract, and atomic same-client session replacement.
- `docs/adr/ADR-007-auth-session-contract.md` added for auth session contract, transaction + row-lock semantics, and verification expectations.

## Linear
- Closes INF-145

🤖 Generated with [Claude Code](https://claude.com/claude-code)