### PR TITLE
INF-155 investigate dashboard summary search contract

### DIFF
--- a/docs/inf-155-evidence/RUN_2026-05-30.md
+++ b/docs/inf-155-evidence/RUN_2026-05-30.md
@@ -1,0 +1,227 @@
+# INF-155 summary search smoke evidence — 2026-05-30
+
+Scope: local runtime smoke for `GET /api/summary/reports` search-query alias behavior.
+
+## Sanitization
+
+- No token, cookie, database password, or `.env` value is stored here.
+- Request authorization used a user-supplied privileged token. The endpoint allows `Admin` and `Management`; this run used an allowed privileged caller. Strict literal Admin-token evidence remains **Needs Verification** if required by review.
+- Response evidence redacts full names, emails, and NIP/NIM values.
+- Evidence records only HTTP status, public envelope fields, pagination, row counts, and a non-PII first-row fingerprint.
+
+## Runtime reachability
+
+| Target | Result |
+| --- | --- |
+| `GET http://localhost:3005/livez` | HTTP 200 |
+
+## Curl commands
+
+Use a privileged `Admin` or `Management` bearer token. Token omitted from evidence.
+
+```bash
+curl -sS -H "Authorization: Bearer <TOKEN_REDACTED>" \
+  "http://localhost:3005/api/summary/reports?search=nico"
+
+curl -sS -H "Authorization: Bearer <TOKEN_REDACTED>" \
+  "http://localhost:3005/api/summary/reports?q=nico"
+
+curl -sS -H "Authorization: Bearer <TOKEN_REDACTED>" \
+  "http://localhost:3005/api/summary/reports?query=nico"
+
+curl -sS -H "Authorization: Bearer <TOKEN_REDACTED>" \
+  "http://localhost:3005/api/summary/reports?keyword=nico"
+```
+
+A baseline request without search alias was also captured for comparison:
+
+```bash
+curl -sS -H "Authorization: Bearer <TOKEN_REDACTED>" \
+  "http://localhost:3005/api/summary/reports"
+```
+
+## Smoke result summary
+
+| Case | HTTP | Period | Total items | Total pages | Row count | Rows matching `nico` on returned page | Observation |
+| --- | ---: | --- | ---: | ---: | ---: | ---: | --- |
+| Baseline no search | 200 | `30d` | 246 | 25 | 10 | 1 | Baseline page already includes one returned-row match for `nico`. |
+| `search=nico` | 200 | `30d` | 246 | 25 | 10 | 1 | Same pagination and first-row fingerprint as baseline. |
+| `q=nico` | 200 | `30d` | 246 | 25 | 10 | 1 | Same pagination and first-row fingerprint as baseline. |
+| `query=nico` | 200 | `30d` | 246 | 25 | 10 | 1 | Same pagination and first-row fingerprint as baseline. |
+| `keyword=nico` | 200 | `30d` | 246 | 25 | 10 | 1 | Same pagination and first-row fingerprint as baseline. |
+
+## Observation
+
+The runtime accepts all four query params at the HTTP layer, but the response is indistinguishable from the baseline request for this smoke case:
+
+- same status (`200`),
+- same `period` (`30d`),
+- same date range (`2026-05-01` to `2026-05-30`),
+- same `total_items` (`246`),
+- same `total_pages` (`25`),
+- same returned row count (`10`),
+- same first-row non-PII fingerprint.
+
+Conclusion for Phase A: `search`, `q`, `query`, and `keyword` are accepted but ignored by current summary report behavior. They do not filter the result rows or pagination in this runtime evidence.
+
+## Raw sanitized output
+
+```json
+[
+  {
+    "name": "baseline",
+    "command": "GET /api/summary/reports",
+    "status": 200,
+    "success": true,
+    "message": "Summary report with discipline analysis generated successfully",
+    "period": "30d",
+    "date_range": {
+      "start_date": "2026-05-01",
+      "end_date": "2026-05-30"
+    },
+    "pagination": {
+      "current_page": 1,
+      "total_pages": 25,
+      "total_items": 246,
+      "items_per_page": 10,
+      "has_next_page": true,
+      "has_prev_page": false
+    },
+    "row_count": 10,
+    "rows_matching_nico": 1,
+    "first_row_non_pii": {
+      "attendance_id": 2518,
+      "user_id_present": true,
+      "full_name_redacted": "[REDACTED]",
+      "email_redacted": "[REDACTED]",
+      "nip_nim_redacted": "[REDACTED]",
+      "status": "alpha",
+      "attendance_date": "2026-05-28"
+    }
+  },
+  {
+    "name": "search",
+    "command": "GET /api/summary/reports?search=nico",
+    "status": 200,
+    "success": true,
+    "message": "Summary report with discipline analysis generated successfully",
+    "period": "30d",
+    "date_range": {
+      "start_date": "2026-05-01",
+      "end_date": "2026-05-30"
+    },
+    "pagination": {
+      "current_page": 1,
+      "total_pages": 25,
+      "total_items": 246,
+      "items_per_page": 10,
+      "has_next_page": true,
+      "has_prev_page": false
+    },
+    "row_count": 10,
+    "rows_matching_nico": 1,
+    "first_row_non_pii": {
+      "attendance_id": 2518,
+      "user_id_present": true,
+      "full_name_redacted": "[REDACTED]",
+      "email_redacted": "[REDACTED]",
+      "nip_nim_redacted": "[REDACTED]",
+      "status": "alpha",
+      "attendance_date": "2026-05-28"
+    }
+  },
+  {
+    "name": "q",
+    "command": "GET /api/summary/reports?q=nico",
+    "status": 200,
+    "success": true,
+    "message": "Summary report with discipline analysis generated successfully",
+    "period": "30d",
+    "date_range": {
+      "start_date": "2026-05-01",
+      "end_date": "2026-05-30"
+    },
+    "pagination": {
+      "current_page": 1,
+      "total_pages": 25,
+      "total_items": 246,
+      "items_per_page": 10,
+      "has_next_page": true,
+      "has_prev_page": false
+    },
+    "row_count": 10,
+    "rows_matching_nico": 1,
+    "first_row_non_pii": {
+      "attendance_id": 2518,
+      "user_id_present": true,
+      "full_name_redacted": "[REDACTED]",
+      "email_redacted": "[REDACTED]",
+      "nip_nim_redacted": "[REDACTED]",
+      "status": "alpha",
+      "attendance_date": "2026-05-28"
+    }
+  },
+  {
+    "name": "query",
+    "command": "GET /api/summary/reports?query=nico",
+    "status": 200,
+    "success": true,
+    "message": "Summary report with discipline analysis generated successfully",
+    "period": "30d",
+    "date_range": {
+      "start_date": "2026-05-01",
+      "end_date": "2026-05-30"
+    },
+    "pagination": {
+      "current_page": 1,
+      "total_pages": 25,
+      "total_items": 246,
+      "items_per_page": 10,
+      "has_next_page": true,
+      "has_prev_page": false
+    },
+    "row_count": 10,
+    "rows_matching_nico": 1,
+    "first_row_non_pii": {
+      "attendance_id": 2518,
+      "user_id_present": true,
+      "full_name_redacted": "[REDACTED]",
+      "email_redacted": "[REDACTED]",
+      "nip_nim_redacted": "[REDACTED]",
+      "status": "alpha",
+      "attendance_date": "2026-05-28"
+    }
+  },
+  {
+    "name": "keyword",
+    "command": "GET /api/summary/reports?keyword=nico",
+    "status": 200,
+    "success": true,
+    "message": "Summary report with discipline analysis generated successfully",
+    "period": "30d",
+    "date_range": {
+      "start_date": "2026-05-01",
+      "end_date": "2026-05-30"
+    },
+    "pagination": {
+      "current_page": 1,
+      "total_pages": 25,
+      "total_items": 246,
+      "items_per_page": 10,
+      "has_next_page": true,
+      "has_prev_page": false
+    },
+    "row_count": 10,
+    "rows_matching_nico": 1,
+    "first_row_non_pii": {
+      "attendance_id": 2518,
+      "user_id_present": true,
+      "full_name_redacted": "[REDACTED]",
+      "email_redacted": "[REDACTED]",
+      "nip_nim_redacted": "[REDACTED]",
+      "status": "alpha",
+      "attendance_date": "2026-05-28"
+    }
+  }
+]
+```

--- a/docs/linear-sync/INF-155-followup-issue-draft-2026-05-30.md
+++ b/docs/linear-sync/INF-155-followup-issue-draft-2026-05-30.md
@@ -1,0 +1,129 @@
+# Linear follow-up issue draft — 2026-05-30
+
+Do not create this issue automatically from this file. User should paste manually after Phase A review.
+
+## Title
+
+Backend: standardize dashboard summary search query param
+
+## Related
+
+- INF-155 — dashboard summary search contract investigation
+- INF-160 — Web FE dashboard consumer alignment
+- INF-159 — reporting/dashboard analytics boundary
+
+## Background
+
+INF-155 Phase A found a contract mismatch between Web FE dashboard search and backend summary report behavior.
+
+Current backend:
+
+- Canonical report endpoint: `GET /api/summary/reports`.
+- Deprecated compatibility alias: `GET /api/summary`.
+- `getSummaryReport` reads `period`, `from`, `to`, `page`, and `limit`.
+- Search aliases `search`, `q`, `query`, and `keyword` are not currently used by backend query logic.
+- Runtime smoke confirms all aliases are accepted at the HTTP layer but ignored for filtering.
+
+Current FE:
+
+- Dashboard service sends all four aliases when search is non-empty.
+- Dashboard real API path does not apply client-side filtering after fetch.
+- FE currently depends on backend for search semantics.
+
+Phase A evidence:
+
+- Spec: `docs/superpowers/specs/2026-05-30-inf-155-dashboard-search-contract.md`
+- Runtime evidence: `docs/inf-155-evidence/RUN_2026-05-30.md`
+
+## Problem
+
+Dashboard search UI can send search intent to the backend, but backend summary report currently ignores search params. This creates a user-visible mismatch: search appears wired in FE, but report rows and pagination remain unchanged.
+
+## Proposed direction
+
+Standardize canonical summary report search on `q`.
+
+Recommended transitional compatibility:
+
+- Canonical param: `q`
+- Temporary aliases: `search`, `query`, `keyword`
+- Alias precedence if multiple are present: `q > search > query > keyword`
+- Add deprecation note for aliases in OpenAPI/docs
+
+## Acceptance criteria
+
+- [ ] `GET /api/summary/reports?q=<term>` filters summary report detail rows before pagination.
+- [ ] `report.pagination.total_items` and `total_pages` reflect the filtered dataset.
+- [ ] Blank or whitespace-only `q` behaves the same as no search param.
+- [ ] Search is case-insensitive for supported text fields where the database collation/runtime supports it, or equivalent lower-case matching is implemented safely.
+- [ ] Search covers agreed row fields, at minimum: user full name, NIP/NIM, email, role name, attendance status, and attendance category.
+- [ ] Search preserves existing period semantics for `30d`, `current_month`, and `custom`.
+- [ ] Search works consistently on both `GET /api/summary/reports` and deprecated alias `GET /api/summary` while the alias remains supported.
+- [ ] If transitional aliases are accepted, `search`, `query`, and `keyword` are covered by tests and documented as deprecated aliases.
+- [ ] If multiple search aliases are sent, precedence is deterministic and tested.
+- [ ] Contract tests prove search is applied before pagination, not only to the current page.
+- [ ] OpenAPI documents canonical `q`, alias/deprecation behavior if applicable, and examples.
+- [ ] Runtime smoke evidence is captured with sanitized output.
+
+## Decision points before implementation
+
+- [ ] Confirm whether `q` filters only `report.data` + `report.pagination`, or also top-level summary cards.
+- [ ] Confirm whether temporary aliases (`search`, `query`, `keyword`) should be accepted and for how long.
+- [ ] Confirm alias precedence: recommended `q > search > query > keyword`.
+- [ ] Confirm whether period mismatch (`all`, `daily`, `weekly`, `monthly`) is a separate issue.
+- [ ] Confirm whether backend sort params (`sortBy`, `sortOrder`) are out of scope for this issue.
+
+## Non-goals
+
+- Do not change attendance final-state semantics.
+- Do not change background jobs or scheduler behavior.
+- Do not implement FE changes in this backend issue.
+- Do not expand accepted period values unless explicitly approved as separate scope.
+- Do not implement backend sorting unless explicitly added to this issue.
+- Do not remove `/api/summary` compatibility alias in this issue.
+- Do not change auth/session behavior.
+
+## Verification plan
+
+Automated tests:
+
+- Add or update summary report contract tests for canonical `q`.
+- Test blank `q` equals no search.
+- Test search before pagination using enough mock rows to prove filtered `total_items` changes.
+- Test supported fields such as full name, NIP/NIM, role, status, and category.
+- Test `period=30d`, `period=current_month`, and `period=custom` interactions.
+- If aliases are accepted, test `search`, `query`, and `keyword` behavior.
+- Test multiple-alias precedence.
+- Update OpenAPI contract tests.
+
+Runtime smoke:
+
+- `GET /api/summary/reports?q=nico`
+- `GET /api/summary/reports?search=nico` if alias supported
+- `GET /api/summary/reports?query=nico` if alias supported
+- `GET /api/summary/reports?keyword=nico` if alias supported
+- Baseline no-search request for comparison
+- All output sanitized: no token, email, NIP/NIM, or full name stored.
+
+Standard checks:
+
+- `npm run lint`
+- Relevant focused Jest contract tests
+- Full test suite if scope touches shared query helpers or OpenAPI contract tests
+
+## DOCS/ADR UPDATE REQUIRED
+
+Required because this changes an API contract surface and dashboard/reporting boundary.
+
+Expected documentation updates:
+
+- `docs/openapi.yaml`
+- `docs/reporting-analytics-boundary.md` if search semantics become a documented reporting boundary rule
+- Optional ADR or decision note if product decides summary cards are or are not affected by row search
+
+## Suggested PR notes for Phase B
+
+- Impact: Backend summary report search becomes server-driven and canonicalized on `q`.
+- Risk: Pagination and summary-card semantics can confuse consumers if not documented.
+- Verification: Contract tests, OpenAPI tests, lint, and sanitized runtime smoke.
+- Docs/ADR: Required.

--- a/docs/linear-sync/INF-155-investigation-2026-05-30.md
+++ b/docs/linear-sync/INF-155-investigation-2026-05-30.md
@@ -1,0 +1,68 @@
+# INF-155 Linear sync draft — 2026-05-30
+
+Use these as paste-ready Linear comments. Do not change issue status from these notes alone.
+
+## INF-155 — Phase A investigation done
+
+Phase A investigation is complete for the dashboard summary search contract mismatch.
+
+Evidence/spec files prepared in the backend repo:
+
+- Spec: `docs/superpowers/specs/2026-05-30-inf-155-dashboard-search-contract.md`
+- Runtime evidence: `docs/inf-155-evidence/RUN_2026-05-30.md`
+
+Findings:
+
+- Backend `GET /api/summary/reports` currently reads only `period`, `from`, `to`, `page`, and `limit`.
+- Backend does not currently implement search behavior for `search`, `q`, `query`, or `keyword`.
+- Runtime smoke shows all four aliases are accepted at the HTTP layer but produce the same pagination and first-row fingerprint as the baseline request, so they are ignored rather than used for filtering.
+- Web FE currently sends all four search aliases (`search`, `q`, `query`, `keyword`) when dashboard search is non-empty.
+- Web FE real API path does not apply client-side filtering after fetch, so dashboard search depends on backend filtering.
+- Additional mismatch: FE defaults/options include `period=all`/legacy period values, while backend summary report currently accepts only `30d`, `current_month`, and `custom`.
+
+Recommendation for Phase B:
+
+- Standardize canonical dashboard summary search query param as `q`.
+- Consider temporary alias support for `search`, `query`, and `keyword` for one migration window.
+- Recommended alias precedence if multiple are present: `q > search > query > keyword`.
+- Apply search before pagination at the backend query layer so `report.pagination.total_items` reflects filtered results.
+- Keep Phase B as a new follow-up implementation issue, not part of this investigation branch.
+
+Open decision needed before Phase B:
+
+- Should `q` filter only `report.data` + pagination, or also top-level summary cards?
+- Should period mismatch (`all`, `daily`, `weekly`, `monthly`) be handled in the same follow-up or a separate issue?
+- Should backend sort params (`sortBy`, `sortOrder`) remain out of scope for the search standardization issue?
+
+No Linear status change requested from this comment.
+
+## INF-160 — FE heads-up
+
+Heads up for FE dashboard integration:
+
+Backend Phase A investigation for INF-155 found that summary search is not currently implemented server-side.
+
+Current backend behavior:
+
+- Canonical report endpoint is `GET /api/summary/reports`.
+- `GET /api/summary` is a deprecated compatibility alias.
+- Current supported summary periods are `30d`, `current_month`, and `custom` with `from`/`to`.
+- `search`, `q`, `query`, and `keyword` are accepted but ignored by runtime behavior today.
+
+Current FE behavior observed from the local FE `develop` clone:
+
+- Dashboard calls the compatibility route through `/summary`.
+- Dashboard service sends all four aliases (`search`, `q`, `query`, `keyword`) when search is non-empty.
+- Real API dashboard path does not perform client-side filtering after fetch.
+- Dashboard defaults/options include `period=all`, which backend summary report does not accept today.
+
+Recommendation for FE alignment after backend Phase B is approved:
+
+- Prefer canonical route `/api/summary/reports`.
+- Prefer canonical search param `q`.
+- Continue compatibility only during migration if backend implements temporary aliases.
+- Align dashboard period values with backend-supported values unless a separate period-contract issue expands backend support.
+
+Phase B should be tracked as a new backend follow-up issue: “Backend: standardize dashboard summary search query param”.
+
+No Linear status change requested from this comment.

--- a/docs/superpowers/specs/2026-05-30-inf-155-dashboard-search-contract.md
+++ b/docs/superpowers/specs/2026-05-30-inf-155-dashboard-search-contract.md
@@ -1,0 +1,235 @@
+# INF-155 Dashboard Search Contract Investigation — 2026-05-30
+
+Phase: A — investigation only  
+Scope: dashboard search contract mismatch between Web FE summary dashboard caller and backend summary report API.  
+Non-runtime guarantee: this document records current behavior and recommended Phase B direction only. It does not change endpoint logic, query behavior, OpenAPI, or tests.
+
+## Goal
+
+Document the current backend and FE contract for dashboard summary report search, identify mismatches, and prepare a Phase B implementation decision without changing runtime behavior in this branch.
+
+## Current state backend
+
+### Route surface
+
+- Canonical report route: `GET /api/summary/reports`.
+- Deprecated compatibility alias: `GET /api/summary`.
+- Both route paths are registered through the same helper and call `getSummaryReport` with `verifyToken` and `roleGuard(['Admin', 'Management'])`.
+- Evidence: `src/routes/summary.routes.js:10-23`.
+
+### Query parameters read by `getSummaryReport`
+
+`getSummaryReport` currently destructures only:
+
+- `period`, default `30d`
+- `from`, default `null`
+- `to`, default `null`
+- `page`, default `1`
+- `limit`, default `10`
+
+Evidence: `src/controllers/summary.controller.js:153-166`.
+
+The controller does not read or apply any of these candidate search params:
+
+- `search`
+- `q`
+- `query`
+- `keyword`
+
+### Search behavior
+
+Current code evidence shows no backend search filter in `getSummaryReport`:
+
+- Aggregate summary queries use only `whereClause` based on the effective date window.
+- Detail report query uses the same `whereClause`, pagination `limit`, and `offset`.
+- No `User.full_name`, `User.email`, `nip_nim`, role, status, or category search condition is added.
+
+Evidence:
+
+- `whereClause` date-only construction: `src/controllers/summary.controller.js:173-178`
+- aggregate status/category queries: `src/controllers/summary.controller.js:183-210`
+- detail `findAndCountAll` query: `src/controllers/summary.controller.js:281-328`
+
+Phase A conclusion from code evidence: `search`, `q`, `query`, and `keyword` are accepted by HTTP transport as unknown query params, but are ignored by current summary report query logic. Runtime evidence is recorded separately in `docs/inf-155-evidence/RUN_2026-05-30.md`.
+
+### Search scope: per-page vs global dataset
+
+Because backend search is not currently implemented, there is no effective per-page or global dataset search behavior today.
+
+Recommended Phase B decision: if adopted, backend search should be applied before pagination at the database query layer, so pagination metadata reflects the filtered dataset rather than filtering only the current page.
+
+### Period relationship
+
+Backend summary report period contract currently accepts:
+
+- `30d`
+- `current_month`
+- `custom` with `from` and `to`
+
+`all` is not part of the backend historical window contract.
+
+Evidence:
+
+- `HISTORICAL_WINDOW_PERIODS`: `src/utils/historicalDateWindow.js:4`
+- validation message for unsupported period: `src/utils/historicalDateWindow.js:35-38`
+- controller validation before querying: `src/controllers/summary.controller.js:157-164`
+- OpenAPI contract test expects `['30d', 'current_month', 'custom']`: `tests/clientCriticalOpenApiContract.test.js:329-370`
+
+## Current state FE
+
+FE evidence source used for this investigation: clean local Web FE clone at `E:\skrisi\clonefee\Infinite_Track_Fe` on branch `develop`. A second clone at `E:\skrisi\clone_fe\Infinite_Track_Fe` has local modified files and was not used as source evidence.
+
+### FE service caller
+
+`ReportService.getSummaryReport()` currently defaults to:
+
+- `period = "all"`
+- `page = 1`
+- `limit = 10`
+- `search = ""`
+- optional `sortBy`
+- `sortOrder = "asc"`
+
+When search is non-empty, the FE sends all four search aliases at once:
+
+- `search`
+- `q`
+- `query`
+- `keyword`
+
+It calls the deprecated compatibility route `${API_CONFIG.BASE_URL}/summary`, not `/summary/reports`.
+
+Evidence: `E:\skrisi\clonefee\Infinite_Track_Fe\src\js\services\reportService.js:23-52`.
+
+### FE dashboard caller
+
+`dashboard.loadSummaryData()` sends:
+
+- `period: this.filters.period`
+- `page: this.filters.page`
+- `limit: this.filters.limit`
+- `search: this.searchQuery`
+- `sortBy: this.filters.sortBy`
+- `sortOrder: this.filters.sortOrder`
+
+Evidence: `E:\skrisi\clonefee\Infinite_Track_Fe\src\js\features\dashboard\dashboard.js:161-180`.
+
+### FE client-side filtering
+
+For the real API response path, dashboard maps backend rows directly into `attendanceData` / `reportData`; no client-side search filtering is applied after fetch.
+
+Evidence: `E:\skrisi\clonefee\Infinite_Track_Fe\src\js\features\dashboard\dashboard.js:210-281`.
+
+Client-side search filtering exists only in mock data generation (`getMockSummaryData()`), not in the real API path.
+
+Evidence: `E:\skrisi\clonefee\Infinite_Track_Fe\src\js\services\reportService.js:196-211`.
+
+### `period=all` influence
+
+FE default period is `all` in both component state and filters:
+
+- component state: `dashboard.js:23`
+- filter state: `dashboard.js:36-42`
+- UI options include `all`, `daily`, `weekly`, `monthly`: `dashboard.js:107-113`
+
+Backend summary report does not accept `all`, `daily`, `weekly`, or `monthly` in the current historical window contract. This means the period mismatch can block dashboard data before search behavior is even observable unless FE sends a backend-supported period.
+
+## Identified mismatches
+
+| Area | Backend current state | FE current state | Impact |
+| --- | --- | --- | --- |
+| Search canonical param | No search param implemented | Sends `search`, `q`, `query`, and `keyword` together | FE search input appears server-driven but backend ignores it. |
+| Search semantics | No per-page/global search semantics | Dashboard relies on backend response; no real API client-side filter | Search result rows and pagination do not reflect search intent. |
+| Canonical route | `/api/summary/reports` is canonical; `/api/summary` deprecated alias | Uses `/summary` | Works only through compatibility alias; migration remains incomplete. |
+| Period values | `30d`, `current_month`, `custom` | Defaults/options include `all`, `daily`, `weekly`, `monthly` | Backend may reject FE default period before search can work. |
+| Sort params | No backend sort params implemented in summary report | Sends optional `sortBy`, `sortOrder` | Sort intent is ignored today; should be separate from search scope unless Phase B explicitly includes it. |
+
+## Recommendation: canonical query param
+
+Recommend standardizing backend dashboard summary report search on `q` in Phase B.
+
+Rationale:
+
+- Short and conventional for free-text search.
+- Avoids collision with generic `query` naming in code and logs.
+- Keeps room for explicit future filters (`status`, `role`, `category`, `from`, `to`) without overloading `search`.
+- FE already sends `q` today, so backend can adopt `q` with minimal FE breakage.
+
+Recommended Phase B compatibility strategy:
+
+1. Canonical: `q`.
+2. Transitional aliases: accept `search`, `query`, and `keyword` for one migration window.
+3. Precedence if multiple aliases are present: `q` wins, then `search`, then `query`, then `keyword`.
+4. Add deprecation notes for non-`q` aliases in OpenAPI/docs.
+5. Emit no runtime behavior change in Phase A.
+
+## Recommended Phase B semantics
+
+If adopted in a new follow-up issue, `q` should:
+
+- Apply to the detail report row query before pagination.
+- Update `report.pagination.total_items` and `total_pages` based on filtered rows.
+- Search safe text fields only, such as user full name, NIP/NIM, email, role name, status name, and category name.
+- Preserve existing date-window semantics (`30d`, `current_month`, `custom`).
+- Avoid changing summary aggregate cards unless explicitly decided. Current recommendation: summary totals remain period-wide, while `report.data` and `report.pagination` reflect row search. This needs user/product decision because dashboard UX may expect either behavior.
+
+## Impact if adopted
+
+Phase B implementation would be API-significant and docs-significant.
+
+Expected updates:
+
+- Controller/search query logic in `src/controllers/summary.controller.js`.
+- Contract tests in `tests/summaryReportContract.test.js` or a new focused summary search contract test.
+- Route/OpenAPI documentation in `docs/openapi.yaml`.
+- Consumer guide update in `docs/reporting-analytics-boundary.md` if search semantics become a documented boundary rule.
+- Deprecation note for `search`, `query`, and `keyword` aliases if transitional support is accepted.
+- FE migration guidance for INF-160: prefer `/api/summary/reports`, `period=30d/current_month/custom`, and canonical `q`.
+
+DOCS/ADR update required for Phase B: yes, because this changes the API contract surface and dashboard/reporting boundary.
+
+## Risks
+
+- **Contract ambiguity risk:** accepting four aliases forever makes API behavior harder to document and test.
+- **Pagination risk:** filtering after pagination would produce confusing pages; filtering before pagination requires careful DB query/count behavior.
+- **Aggregate consistency risk:** deciding whether search affects summary cards as well as rows changes dashboard meaning.
+- **Period mismatch risk:** FE `period=all` may continue to fail even after search is implemented unless period contract is addressed separately.
+- **Performance risk:** broad LIKE search across joined user/status/category tables may need indexes or bounded limits if datasets grow.
+- **PII risk:** runtime evidence and logs must not store real emails, tokens, or raw employee identifiers.
+
+## Verification plan
+
+Phase A evidence:
+
+- Read current backend controller/route/validator/tests.
+- Read current FE caller behavior read-only.
+- Run smoke curl set for:
+  - `GET /api/summary/reports?search=nico`
+  - `GET /api/summary/reports?q=nico`
+  - `GET /api/summary/reports?query=nico`
+  - `GET /api/summary/reports?keyword=nico`
+- Sanitize tokens/emails/PII from captured response.
+- Run `npm run lint` to confirm no accidental runtime/code style changes.
+
+Phase B implementation verification, if approved later:
+
+- Unit/contract tests proving `q` filters before pagination.
+- Alias compatibility tests for `search`, `query`, and `keyword` if transitional support is chosen.
+- Test precedence when multiple aliases are present.
+- Test unsupported/blank `q` behavior.
+- Test interaction with `period=30d`, `period=current_month`, and `period=custom`.
+- OpenAPI contract tests for documented query params and deprecation notes.
+- Runtime smoke with sanitized seeded data.
+
+## Questions requiring user/product decision
+
+1. Should `q` search filter only `report.data` rows and pagination, or should it also filter top-level summary cards?
+2. Should backend keep accepting `search`, `query`, and `keyword` as transitional aliases? If yes, for how long?
+3. Should alias precedence be `q > search > query > keyword` when FE sends multiple aliases?
+4. Should Phase B also address FE/backend period mismatch (`all`, `daily`, `weekly`, `monthly`) or should that be a separate issue from INF-155?
+5. Should FE migrate from `/api/summary` to canonical `/api/summary/reports` in INF-160, or stay on compatibility alias until backend Phase B lands?
+6. Should backend implement sort params (`sortBy`, `sortOrder`) in the same follow-up issue, or keep sorting out of scope for dashboard search standardization?
+
+## Phase boundary
+
+Phase A output is investigation evidence and draft planning only. Do not infer from this document that `q` is implemented or already part of runtime behavior. Implementation belongs in a new Phase B follow-up issue.


### PR DESCRIPTION
## Summary

Phase A investigation only for INF-155 dashboard summary search contract mismatch.

This PR adds documentation and runtime evidence only. It does not change backend runtime logic, summary endpoint behavior, search behavior, OpenAPI, tests, or FE behavior.

## Findings

- Backend `GET /api/summary/reports` currently reads only `period`, `from`, `to`, `page`, and `limit`.
- Backend currently ignores `search`, `q`, `query`, and `keyword`.
- Runtime smoke shows all four aliases are accepted but return the same pagination and first-row fingerprint as baseline.
- Web FE currently sends all four aliases when dashboard search is non-empty.
- Web FE real API path does not apply client-side filtering after fetch.
- Additional mismatch: FE defaults/options include `period=all`, while backend accepts only `30d`, `current_month`, and `custom`.

## Files

- `docs/superpowers/specs/2026-05-30-inf-155-dashboard-search-contract.md`
- `docs/inf-155-evidence/RUN_2026-05-30.md`
- `docs/linear-sync/INF-155-investigation-2026-05-30.md`
- `docs/linear-sync/INF-155-followup-issue-draft-2026-05-30.md`

## Recommendation

Phase B should be a new follow-up implementation issue: Backend: standardize dashboard summary search query param.

Recommended canonical query param: `q`.

Recommended transitional aliases:
- `search`
- `query`
- `keyword`

Recommended precedence: `q > search > query > keyword`.

## Risk

- API contract ambiguity if all aliases remain supported forever.
- Pagination confusion if search is applied after pagination instead of before.
- Product decision needed: should search filter only `report.data` + pagination, or also top-level summary cards?
- Period mismatch (`period=all`) should be resolved separately or explicitly included in Phase B.

## Verification

- `npm run lint` — passed
- `npm test` — passed, 55 suites / 336 tests
- Runtime smoke evidence captured in `docs/inf-155-evidence/RUN_2026-05-30.md`
- No runtime logic changed

## Docs/ADR

Phase A adds investigation docs only.

Phase B will be API-significant and should update:
- `docs/openapi.yaml`
- summary/reporting boundary docs
- ADR/decision note if search-card semantics are product-significant

🤖 Generated with [Claude Code](https://claude.com/claude-code)