### PR TITLE
INF-129/INF-168 FAHP canonical hardening (Chang Extent + WIB timestamp)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Sistem ini memiliki empat pilar fungsionalitas utama yang membuatnya lebih dari 
 
 - Merekomendasikan lokasi WFA di sekitar pengguna.
 - Setiap lokasi dinilai oleh **FAHP murni** untuk menghasilkan **Skor Kelayakan**.
-- **Suitability Labels:** 5 tingkat (Sangat Rendah → Sangat Tinggi) berbasis interval sama.
+- **Suitability Labels:** 4 tingkat (Rendah, Cukup, Baik, Sangat Baik) dengan ambang interval sama 0–25–50–75.
 - **Multi-criteria Analysis (default):** Location type, Distance, Amenities.
 
 ### **⚡ 3. Proses Otomatis Malam Hari (Cron Jobs)**
@@ -53,8 +53,8 @@ Sistem ini memiliki empat pilar fungsionalitas utama yang membuatnya lebih dari 
 
 ### **🧠 Decision Engine**
 
-- **FAHP (Pure):** TFN pairwise → Fuzzy Geometric Mean (Buckley) → centroid defuzzification → normalized weights (∑w=1)
-- **Consistency Check:** CR dihitung dari matriks defuzzifikasi (eigenvalue approximation)
+- **FAHP (Pure):** TFN pairwise → synthetic extent → degree of possibility → minimum possibility → normalized crisp weights (∑w=1)
+- **Consistency Check:** CR dihitung dari matriks TFN yang didefuzzifikasi (eigenvalue approximation)
 
 ### **☁️ External Services**
 
@@ -218,7 +218,7 @@ GET /api/bookings/history?status=approved&sort_by=schedule_date&sort_order=DESC&
         "schedule_date": "2025-07-15",
         "status": "approved",
         "suitability_score": 87.5,
-        "suitability_label": "Sangat Direkomendasikan",
+        "suitability_label": "Sangat Baik",
         "location": {
           "description": "Starbucks Mall Panakkukang",
           "latitude": -5.1477,
@@ -257,7 +257,7 @@ GET /api/summary?period=monthly&start_date=2025-07-01&end_date=2025-07-31
         "total_present": 22,
         "total_late": 3,
         "discipline_score": 85.5,
-        "discipline_label": "Sangat Disiplin"
+        "discipline_label": "Sangat Baik"
       }
     ]
   }
@@ -339,18 +339,22 @@ src/
 // Core Intelligence Components
 Fuzzy AHP Engine
 ├── WFA Recommendation System
-│   ├── Location Type Scoring (70% weight)
-│   ├── Distance Factor (23% weight)
-│   └── Amenity Assessment (7% weight)
+│   ├── Location Type
+│   ├── Distance Factor
+│   └── Amenity Score
 ├── Discipline Index Calculator
-│   ├── Attendance Rate (40% weight)
-│   ├── Punctuality Score (35% weight)
-│   └── Consistency Analysis (25% weight)
+│   ├── Alpha Rate
+│   ├── Lateness Severity
+│   ├── Lateness Frequency
+│   └── Work Focus
 └── Smart Auto-Checkout Predictor
-    ├── Check-in Time Pattern (40% weight)
-    ├── Historical Hours (35% weight)
-    └── Work Duration Context (25% weight)
+    ├── Historical Pattern
+    ├── Check-in Pattern
+    ├── Context Signal
+    └── Transition Signal
 ```
+
+Bobot setiap komponen dihitung dari pairwise TFN backend menggunakan Chang’s Extent Analysis.
 
 ### **⚡ 6.3 Automated Job Processing**
 
@@ -365,29 +369,30 @@ Jobs Schedule
 
 ## FAHP (Fuzzy AHP) Engine
 
-- Method: TFN → FGM (Buckley) → defuzzify (centroid) → normalize (∑w=1) → CR check.
-- Normalization: min–max to [0,1] with benefit/cost; labeling equal-interval (5 classes).
+- Method: TFN → synthetic extent → degree of possibility → minimum possibility → normalized crisp weights (∑w=1) → CR check.
+- Normalization: min–max to [0,1] with benefit/cost; labeling equal-interval 4 bucket (`Rendah`, `Cukup`, `Baik`, `Sangat Baik`).
 - Public APIs:
   - `calculateWfaScore(place)` → `{ score(0..100), label, breakdown, weights, CR, warning? }`
   - `calculateDisciplineIndex(metrics)` → `{ score(0..100), label, breakdown, weights, CR, warning? }`
-  - `getWfaAhpWeights()`, `getDisciplineAhpWeights()` → `{... , consistency_ratio}`
+  - `getWfaAhpWeights()`, `getDisciplineAhpWeights()`, `getSmartAcAhpWeights()` → `{ ...weights, consistency_ratio, consistency_index, lambda_max }`
+  - `GET /api/analysis/fuzzy-ahp` → dashboard payload with `generated_at`, `window.start_at`, and `window.end_at` emitted as millisecond-precision WIB timestamps (`+07:00`).
 - Configuration: TFN scales and pairwise matrices in `src/analytics/config.fahp.js`.
-- Consistency: CR computed from defuzzified matrix; threshold is fixed in backend code at `0.10` because it is a theoretical FAHP guardrail, not an operational setting.
-- Auto-checkout: prediction removed; system flags likely-missed-checkout using time tolerance only.
+- Consistency: CR, CI, and λmax are computed from the defuzzified matrix; threshold is fixed in backend code at `0.10` because it is a theoretical FAHP guardrail, not an operational setting.
+- WFA analysis uses the static location catalog assumptions (`amenity_score=50`, `distance=1000`) when runtime visit telemetry is not applied; the response exposes `scope`, `window_applied`, and `data_source` to make that boundary explicit.
+- Auto-checkout: Smart Auto Checkout uses FAHP weighted prediction from historical, check-in, contextual, and transition signals; CR/CI/λmax are exposed as consistency diagnostics.
 
 ## 7. Fuzzy AHP Intelligence System
 
 ### **🎯 7.1 WFA Suitability Scoring**
 
-Setiap lokasi WFA dinilai menggunakan 5-tier scoring system:
+Setiap lokasi WFA dinilai menggunakan 4 bucket equal-interval:
 
-| **Suitability Label**     | **Score Range** | **Business Action**   |
-| ------------------------- | --------------- | --------------------- |
-| `Sangat Direkomendasikan` | 85-100          | Auto-approve kandidat |
-| `Direkomendasikan`        | 70-84           | Standard approval     |
-| `Cukup Direkomendasikan`  | 55-69           | Manual review needed  |
-| `Kurang Direkomendasikan` | 40-54           | Likely rejection      |
-| `Tidak Direkomendasikan`  | 0-39            | Auto-reject           |
+| **Suitability Label** | **Score Range** | **Business Action**           |
+| --------------------- | --------------- | ----------------------------- |
+| `Sangat Baik`         | 75-100          | Kandidat paling sesuai        |
+| `Baik`                | 50-74.99        | Kandidat sesuai               |
+| `Cukup`               | 25-49.99        | Perlu review tambahan         |
+| `Rendah`              | 0-24.99         | Kesesuaian rendah             |
 
 ### **📊 7.2 Discipline Index Components**
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -347,6 +347,26 @@ paths:
                         type: object
                         additionalProperties:
                           type: integer
+                      scope:
+                        type: string
+                        description: Present when the analysis uses a constrained source scope, such as static WFA location catalog data.
+                        example: place_catalog_static
+                      window_applied:
+                        type: boolean
+                        description: Indicates whether the requested analysis window was applied to the ranked data source.
+                        example: false
+                      data_source:
+                        type: object
+                        description: Optional source metadata and assumptions for analysis modes with constrained runtime data.
+                        additionalProperties: true
+                        example:
+                          type: location_catalog_static
+                          assumptions:
+                            - field: amenity_score
+                              value: 50
+                            - field: distance
+                              value: 1000
+                          warning: WFA analysis uses static location catalog assumptions because no runtime visit telemetry is applied.
                       ranking:
                         type: array
                         items:
@@ -372,16 +392,16 @@ paths:
                   data:
                     type: discipline
                     period: monthly
-                    generated_at: '2026-04-23T10:30:00+07:00'
+                    generated_at: '2026-04-23T10:30:00.000+07:00'
                     timezone: Asia/Jakarta
                     window:
-                      start_at: '2026-04-01T00:00:00+07:00'
-                      end_at: '2026-04-23T10:30:00+07:00'
+                      start_at: '2026-04-01T00:00:00.000+07:00'
+                      end_at: '2026-04-23T10:30:00.000+07:00'
                     entity_kind: user
                     consistency:
                       CR: 0.037
-                      CI: 0
-                      lambda_max: 0
+                      CI: 0.025
+                      lambda_max: 4.075
                       threshold: 0.1
                       is_consistent: true
                       verdict: 'Matriks perbandingan konsisten (CR < 0.10)'
@@ -390,17 +410,16 @@ paths:
                       values: [0.45, 0.25, 0.18, 0.12]
                       method: "Chang's Extent Analysis"
                     distribution:
-                      Sangat Tinggi: 1
-                      Tinggi: 0
-                      Sedang: 0
+                      Sangat Baik: 1
+                      Baik: 0
+                      Cukup: 0
                       Rendah: 0
-                      Sangat Rendah: 0
                     ranking:
                       - rank: 1
                         id: 7
                         name: Andi
                         score: 87.5
-                        label: Sangat Tinggi
+                        label: Sangat Baik
                         breakdown:
                           alpha_rate: 0
                           avg_lateness_minutes: 3
@@ -2056,14 +2075,14 @@ paths:
                                     example: 84
                                   label:
                                     type: string
-                                    example: Tinggi
+                                    example: Sangat Baik
                               distribution:
                                 type: object
                                 additionalProperties:
                                   type: integer
                                 example:
-                                  Tinggi: 1
-                                  Sedang: 1
+                                  Sangat Baik: 1
+                                  Baik: 1
                           wfa:
                             type: object
                             properties:
@@ -2127,14 +2146,14 @@ paths:
                                     example: 90
                                   label:
                                     type: string
-                                    example: Sangat Tinggi
+                                    example: Sangat Baik
                               distribution:
                                 type: object
                                 additionalProperties:
                                   type: integer
                                 example:
-                                  Sangat Tinggi: 1
-                                  Tinggi: 1
+                                  Sangat Baik: 1
+                                  Baik: 1
                           smart_ac:
                             type: object
                             properties:
@@ -2198,14 +2217,14 @@ paths:
                                     example: 72
                                   label:
                                     type: string
-                                    example: Tinggi
+                                    example: Baik
                               distribution:
                                 type: object
                                 additionalProperties:
                                   type: integer
                                 example:
-                                  Tinggi: 1
-                                  Sedang: 1
+                                  Baik: 1
+                                  Cukup: 1
                       insights:
                         type: object
                         properties:
@@ -2442,8 +2461,8 @@ paths:
                       discipline_index:
                         type: number
                         format: float
-                        example: 8.7
-                        description: Overall discipline index (0-10 scale)
+                        example: 87.0
+                        description: Overall discipline index (0-100 scale)
                       period:
                         type: object
                         properties:
@@ -3328,7 +3347,7 @@ components:
                   discipline_label:
                     type: string
                     nullable: true
-                    example: Tinggi
+                    example: Sangat Baik
                   discipline_breakdown:
                     type: object
                     nullable: true
@@ -3706,7 +3725,7 @@ components:
         suitability_label:
           type: string
           nullable: true
-          example: 'Sangat Sesuai'
+          example: 'Sangat Baik'
           description: Human-readable suitability assessment
         created_at:
           type: string
@@ -3760,12 +3779,12 @@ components:
         fuzzy_ahp_score:
           type: number
           format: float
-          example: 8.7
-          description: Overall Fuzzy AHP score (0-10 scale)
+          example: 87.0
+          description: Overall Fuzzy AHP score (0-100 scale)
         suitability_label:
           type: string
-          example: 'Sangat Sesuai'
-          enum: ['Tidak Sesuai', 'Kurang Sesuai', 'Cukup Sesuai', 'Sesuai', 'Sangat Sesuai']
+          example: 'Sangat Baik'
+          enum: ['Rendah', 'Cukup', 'Baik', 'Sangat Baik']
           description: Human-readable suitability assessment
         criteria_scores:
           type: object

--- a/src/analytics/fahp.js
+++ b/src/analytics/fahp.js
@@ -2,10 +2,6 @@ export function mulTFN([l1, m1, u1], [l2, m2, u2]) {
   return [l1 * l2, m1 * m2, u1 * u2];
 }
 
-export function powTFN([l, m, u], p) {
-  return [l ** p, m ** p, u ** p];
-}
-
 export function invTFN([l, m, u]) {
   return [1 / u, 1 / m, 1 / l];
 }
@@ -16,34 +12,6 @@ export function centroidTFN([l, m, u]) {
 
 export function defuzzifyMatrixTFN(matrixTFN) {
   return matrixTFN.map((row) => row.map((tfn) => centroidTFN(tfn)));
-}
-
-/**
- * Compute FGM (Fuzzy Geometric Mean) weights from TFN pairwise comparison matrix
- * @param {Array<Array<[number, number, number]>>} matrixTFN - NxN matrix of TFN triplets
- * @returns {Array<number>} - Normalized crisp weights (sum=1)
- */
-export function fgmWeightsTFN(matrixTFN) {
-  const n = matrixTFN.length;
-  if (n === 0) return [];
-
-  // Compute geometric mean for each row (as TFN)
-  const gmTFN = [];
-  for (let i = 0; i < n; i++) {
-    let productTFN = [1, 1, 1];
-    for (let j = 0; j < n; j++) {
-      productTFN = mulTFN(productTFN, matrixTFN[i][j]);
-    }
-    // Take nth root
-    gmTFN.push(powTFN(productTFN, 1 / n));
-  }
-
-  // Defuzzify each GM to crisp value
-  const gmCrisp = gmTFN.map(centroidTFN);
-
-  // Normalize to sum=1
-  const total = gmCrisp.reduce((a, b) => a + b, 0) || 1;
-  return gmCrisp.map((v) => v / total);
 }
 
 // Compute CR using eigenvalue approximation without external libs

--- a/src/analytics/labeling.js
+++ b/src/analytics/labeling.js
@@ -1,8 +1,7 @@
 export function labelEqualInterval(score01) {
   const s = Math.max(0, Math.min(1, score01));
-  if (s < 0.2) return 'Sangat Rendah';
-  if (s < 0.4) return 'Rendah';
-  if (s < 0.6) return 'Sedang';
-  if (s < 0.8) return 'Tinggi';
-  return 'Sangat Tinggi';
+  if (s < 0.25) return 'Rendah';
+  if (s < 0.5) return 'Cukup';
+  if (s < 0.75) return 'Baik';
+  return 'Sangat Baik';
 }

--- a/src/controllers/analysis.controller.js
+++ b/src/controllers/analysis.controller.js
@@ -4,21 +4,56 @@ import {
   buildWfaAnalysis
 } from '../services/fuzzyAhpAnalysis.service.js';
 
+function getWibParts(date) {
+  const parts = new Intl.DateTimeFormat('en-GB', {
+    timeZone: 'Asia/Jakarta',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hourCycle: 'h23'
+  }).formatToParts(date);
+
+  return Object.fromEntries(parts.map((part) => [part.type, part.value]));
+}
+
+function wibWallTimeToDate({ year, month, day, hour = 0, minute = 0, second = 0, millisecond = 0 }) {
+  return new Date(Date.UTC(year, month - 1, day, hour - 7, minute, second, millisecond));
+}
+
+function toWibIsoString(date) {
+  const parts = getWibParts(date);
+  const millisecond = String(date.getUTCMilliseconds()).padStart(3, '0');
+
+  return `${parts.year}-${parts.month}-${parts.day}T${parts.hour}:${parts.minute}:${parts.second}.${millisecond}+07:00`;
+}
+
 export function getAnalysisWindow(period) {
   const now = new Date();
-  const wibNow = new Date(now.toLocaleString('en-US', { timeZone: 'Asia/Jakarta' }));
+  const wibNow = getWibParts(now);
+  const year = Number(wibNow.year);
+  const month = Number(wibNow.month);
+  const day = Number(wibNow.day);
 
   if (period === 'weekly') {
-    const day = wibNow.getDay();
-    const mondayOffset = day === 0 ? -6 : 1 - day;
-    const start = new Date(wibNow);
-    start.setDate(wibNow.getDate() + mondayOffset);
-    start.setHours(0, 0, 0, 0);
-    return { startAt: start, endAt: wibNow };
+    const dayOfWeek = new Date(Date.UTC(year, month - 1, day)).getUTCDay();
+    const mondayOffset = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
+    const monday = new Date(Date.UTC(year, month - 1, day + mondayOffset));
+    const startAt = wibWallTimeToDate({
+      year: monday.getUTCFullYear(),
+      month: monday.getUTCMonth() + 1,
+      day: monday.getUTCDate()
+    });
+
+    return { startAt, endAt: now };
   }
 
-  const start = new Date(wibNow.getFullYear(), wibNow.getMonth(), 1, 0, 0, 0, 0);
-  return { startAt: start, endAt: wibNow };
+  return {
+    startAt: wibWallTimeToDate({ year, month, day: 1 }),
+    endAt: now
+  };
 }
 
 export async function getFuzzyAhpAnalysis(req, res, next) {
@@ -62,11 +97,11 @@ export async function getFuzzyAhpAnalysis(req, res, next) {
       data: {
         type,
         period,
-        generated_at: endAt.toISOString(),
+        generated_at: toWibIsoString(endAt),
         timezone: 'Asia/Jakarta',
         window: {
-          start_at: startAt.toISOString(),
-          end_at: endAt.toISOString()
+          start_at: toWibIsoString(startAt),
+          end_at: toWibIsoString(endAt)
         },
         ...result
       },

--- a/src/controllers/attendance.controller.js
+++ b/src/controllers/attendance.controller.js
@@ -18,8 +18,7 @@ import {
   calculateDistance,
   getJakartaTime,
   getJakartaDateString,
-  getCurrentTimeForDB,
-  toJakartaTime
+  getCurrentTimeForDB
 } from '../utils/geofence.js';
 import { formatWorkHour, calculateWorkHour, formatTimeOnly } from '../utils/workHourFormatter.js';
 import { applySearch } from '../utils/searchHelper.js';
@@ -34,9 +33,6 @@ import {
 import { runGeneralAlphaForDate } from '../jobs/createGeneralAlpha.job.js';
 import logger from '../utils/logger.js';
 import fuzzyEngine from '../utils/fuzzyAhpEngine.js';
-import { extentWeightsTFN } from '../analytics/fahp.extent.js';
-import { defuzzifyMatrixTFN, computeCR } from '../analytics/fahp.js';
-import { SMART_AC_PAIRWISE_TFN } from '../analytics/config.fahp.js';
 
 /**
  * Test endpoint to compute checkout prediction using weightedPrediction
@@ -49,7 +45,9 @@ export const testWeightedPrediction = async (req, res) => {
       weights,
       targetDate,
       timeIn,
-      fallbackEndStr = '18:00:00'
+      fallbackEndStr = '18:00:00',
+      scenario,
+      expected_range
     } = req.body || {};
 
     if (!targetDate || !timeIn) {
@@ -63,20 +61,34 @@ export const testWeightedPrediction = async (req, res) => {
     const parseTime = (value, dateStr) => {
       if (!value) return null;
       if (typeof value === 'string') {
-        // Accept "HH:mm:ss" or full ISO
         if (/^\d{2}:\d{2}:\d{2}$/.test(value)) {
           return new Date(`${dateStr}T${value}+07:00`);
         }
       }
       return new Date(value);
     };
-    const toWIBTimeString = (date) => {
+    const toWIBClock = (date) => {
       if (!date) return null;
-      const d = toJakartaTime(date);
-      const hh = String(d.getHours()).padStart(2, '0');
-      const mm = String(d.getMinutes()).padStart(2, '0');
-      const ss = String(d.getSeconds()).padStart(2, '0');
-      return `${hh}:${mm}:${ss}`;
+      const shifted = new Date(new Date(date).getTime() + 7 * 60 * 60 * 1000);
+      const hh = String(shifted.getUTCHours()).padStart(2, '0');
+      const mm = String(shifted.getUTCMinutes()).padStart(2, '0');
+      return `${hh}:${mm}`;
+    };
+    const clockToMinutes = (value) => {
+      if (typeof value !== 'string') return null;
+      const match = value.match(/^(\d{2}):(\d{2})(?::\d{2})?$/);
+      if (!match) return null;
+      return Number(match[1]) * 60 + Number(match[2]);
+    };
+    const isWithinExpectedRange = (clock, range) => {
+      if (!clock || typeof range !== 'string') return false;
+      const parts = range.split('-').map((item) => item.trim());
+      if (parts.length !== 2) return false;
+      const actual = clockToMinutes(clock);
+      const start = clockToMinutes(parts[0]);
+      const end = clockToMinutes(parts[1]);
+      if (actual == null || start == null || end == null) return false;
+      return actual >= start && actual <= end;
     };
     const cand = {
       HIST: parseTime(candidates.HIST, targetDate),
@@ -85,13 +97,16 @@ export const testWeightedPrediction = async (req, res) => {
       TRANSITION: parseTime(candidates.TRANSITION, targetDate)
     };
 
-    // Determine weights: use provided or default FAHP SMART_AC weights (extent method)
-    const defaultWeights = extentWeightsTFN(SMART_AC_PAIRWISE_TFN);
-    const W = Array.isArray(weights) && weights.length === 4 ? weights : defaultWeights;
-
-    // Compute CR for diagnostics
-    const crisp = defuzzifyMatrixTFN(SMART_AC_PAIRWISE_TFN);
-    const { CR } = computeCR(crisp);
+    const smartAcWeights = fuzzyEngine.getSmartAcAhpWeights();
+    const defaultWeights = [
+      smartAcWeights.history,
+      smartAcWeights.checkin_pattern,
+      smartAcWeights.context,
+      smartAcWeights.transition
+    ];
+    const usesCustomWeights = Array.isArray(weights) && weights.length === 4;
+    const W = usesCustomWeights ? weights : defaultWeights;
+    const CR = usesCustomWeights ? null : smartAcWeights.consistency_ratio;
 
     const predicted = fuzzyEngine.weightedPrediction(
       cand,
@@ -100,26 +115,23 @@ export const testWeightedPrediction = async (req, res) => {
       parseTime(timeIn, targetDate),
       fallbackEndStr
     );
+    const predictedCheckout = predicted ? toWIBClock(predicted) : null;
+    const normalizedExpectedRange = typeof expected_range === 'string' ? expected_range.trim() : null;
 
     return res.status(200).json({
       success: true,
       data: {
-        input: {
-          candidates: {
-            HIST: toWIBTimeString(cand.HIST),
-            CHECKIN: toWIBTimeString(cand.CHECKIN),
-            CONTEXT: toWIBTimeString(cand.CONTEXT),
-            TRANSITION: toWIBTimeString(cand.TRANSITION)
-          },
-          weights: W,
-          targetDate,
-          timeIn: toWIBTimeString(parseTime(timeIn, targetDate)),
-          fallbackEndStr
+        scenario: scenario || 'Smart Auto Checkout Test',
+        weights: {
+          HIST: Number((W[0] ?? 0).toFixed(4)),
+          CHECKIN: Number((W[1] ?? 0).toFixed(4)),
+          CONTEXT: Number((W[2] ?? 0).toFixed(4)),
+          TRANSITION: Number((W[3] ?? 0).toFixed(4))
         },
-        result_time: predicted ? toWIBTimeString(predicted) : null,
-        CR: parseFloat(CR.toFixed(3)),
-        CR_threshold: 0.1,
-        is_consistent: CR <= 0.1
+        cr: CR == null ? null : Number(CR.toFixed(3)),
+        predicted_checkout: predictedCheckout,
+        expected_range: normalizedExpectedRange,
+        match: normalizedExpectedRange ? isWithinExpectedRange(predictedCheckout, normalizedExpectedRange) : false
       },
       message: 'Smart Auto Checkout weighted prediction'
     });

--- a/src/controllers/discipline.controller.js
+++ b/src/controllers/discipline.controller.js
@@ -91,7 +91,7 @@ export const getUserDisciplineIndex = async (req, res, next) => {
         methodology: {
           engine: 'FAHP',
           criteria_weights: ahpWeights,
-          approach: 'TFN pairwise + Buckley + centroid; weighted normalization'
+          approach: 'TFN pairwise + Chang extent + weighted normalization'
         }
       },
       message: 'Indeks kedisiplinan berhasil dihitung menggunakan FAHP (tanpa FIS)'
@@ -117,29 +117,31 @@ export const getUserDisciplineIndex = async (req, res, next) => {
  */
 export const testDisciplineAhp = async (req, res, next) => {
   try {
-    const { metrics } = req.body || {};
+    const { metrics, scenario, expected } = req.body || {};
     if (!metrics) {
       return res.status(400).json({ success: false, message: 'Parameter metrics wajib diisi' });
     }
 
     const ahpWeights = fuzzyEngine.getDisciplineAhpWeights();
     const result = await fuzzyEngine.calculateDisciplineIndex(metrics, ahpWeights);
+    const category = result.label;
+    const normalizedExpected = typeof expected === 'string' ? expected.trim() : null;
 
     return res.status(200).json({
       success: true,
       data: {
-        discipline_result: result,
-        methodology: {
-          engine: 'FAHP',
-          criteria_weights: ahpWeights,
-          scoring_ranges: {
-            'Sangat Tinggi': '>=80',
-            Tinggi: '60-79.9',
-            Sedang: '40-59.9',
-            Rendah: '20-39.9',
-            'Sangat Rendah': '<20'
-          }
-        }
+        scenario: scenario || 'Discipline Test',
+        weights: {
+          alpha_rate: Number((ahpWeights.alpha_rate ?? result.weights?.[0] ?? 0).toFixed(4)),
+          lateness_severity: Number((ahpWeights.lateness_severity ?? result.weights?.[1] ?? 0).toFixed(4)),
+          lateness_frequency: Number((ahpWeights.lateness_frequency ?? result.weights?.[2] ?? 0).toFixed(4)),
+          work_focus: Number((ahpWeights.work_focus ?? result.weights?.[3] ?? 0).toFixed(4))
+        },
+        cr: result.CR ?? Number((ahpWeights.consistency_ratio ?? 0).toFixed(3)),
+        score: result.score,
+        category,
+        expected: normalizedExpected,
+        match: normalizedExpected ? category === normalizedExpected : false
       },
       message: 'Discipline Index computed from manual metrics'
     });
@@ -282,7 +284,7 @@ export const getAllDisciplineIndices = async (req, res, next) => {
         methodology: {
           engine: 'FAHP',
           criteria_weights: ahpWeights,
-          approach: 'TFN pairwise + Buckley + centroid; weighted normalization'
+          approach: 'TFN pairwise + Chang extent + weighted normalization'
         }
       },
       message: `Indeks kedisiplinan ${validResults.length} karyawan berhasil dihitung`
@@ -316,19 +318,18 @@ export const getDisciplineConfig = async (req, res, next) => {
       data: {
         criteria_weights: ahpWeights,
         criteria_definitions: {
-          lateness: 'Tingkat keterlambatan (persentase hari terlambat)',
-          absenteeism: 'Tingkat ketidakhadiran (persentase hari tidak hadir)',
-          overtime: 'Frekuensi lembur (persentase hari lembur)',
-          consistency: 'Konsistensi kehadiran (skor konsistensi 0-100)'
+          alpha_rate: 'Tingkat alpha terhadap total hari kerja dalam periode analisis',
+          lateness_severity: 'Rata-rata menit keterlambatan dari jam kerja WIB',
+          lateness_frequency: 'Frekuensi keterlambatan terhadap total hari kerja dalam periode analisis',
+          work_focus: 'Konsistensi jam kerja berdasarkan rata-rata durasi kerja tercatat'
         },
         scoring_ranges: {
-          'Sangat Disiplin': '85-100',
-          Disiplin: '70-84',
-          'Cukup Disiplin': '55-69',
-          'Kurang Disiplin': '40-54',
-          'Tidak Disiplin': '0-39'
+          Rendah: '0-24.99',
+          Cukup: '25-49.99',
+          Baik: '50-74.99',
+          'Sangat Baik': '75-100'
         },
-        fuzzy_logic_approach: 'Triangular membership functions with IF-THEN rules',
+        fuzzy_logic_approach: 'Fuzzy AHP dengan Chang’s Extent Analysis',
         consistency_ratio: ahpWeights.consistency_ratio,
         is_consistent: ahpWeights.consistency_ratio <= 0.1
       },
@@ -488,11 +489,10 @@ function calculateWorkingDays(startDate, endDate) {
  * @returns {string} Category
  */
 function getDisciplineCategory(score) {
-  if (score >= 85) return 'Excellent';
-  if (score >= 70) return 'Good';
-  if (score >= 55) return 'Average';
-  if (score >= 40) return 'Below Average';
-  return 'Poor';
+  if (score >= 75) return 'Sangat Baik';
+  if (score >= 50) return 'Baik';
+  if (score >= 25) return 'Cukup';
+  return 'Rendah';
 }
 
 /**
@@ -538,13 +538,10 @@ function calculateDisciplineSummary(results) {
 
   // Calculate distribution
   const distribution = {
-    'Sangat Disiplin': results.filter((r) => r.discipline_score >= 85).length,
-    Disiplin: results.filter((r) => r.discipline_score >= 70 && r.discipline_score < 85).length,
-    'Cukup Disiplin': results.filter((r) => r.discipline_score >= 55 && r.discipline_score < 70)
-      .length,
-    'Kurang Disiplin': results.filter((r) => r.discipline_score >= 40 && r.discipline_score < 55)
-      .length,
-    'Tidak Disiplin': results.filter((r) => r.discipline_score < 40).length
+    'Sangat Baik': results.filter((r) => r.discipline_score >= 75).length,
+    Baik: results.filter((r) => r.discipline_score >= 50 && r.discipline_score < 75).length,
+    Cukup: results.filter((r) => r.discipline_score >= 25 && r.discipline_score < 50).length,
+    Rendah: results.filter((r) => r.discipline_score < 25).length
   };
 
   return {

--- a/src/controllers/wfa.controller.js
+++ b/src/controllers/wfa.controller.js
@@ -195,12 +195,12 @@ export const getWfaRecommendations = async (req, res, next) => {
         scoredRecommendations.push(scoredPlace);
       } catch (error) {
         logger.warn(`Failed to score place ${place.properties?.name || 'unknown'}:`, error.message);
-        // Include place with default score if scoring fails
+        const fallbackScore = 25;
         scoredRecommendations.push({
           ...place,
           scoring_details: {
-            final_score: 50,
-            label: 'Cukup Direkomendasikan',
+            final_score: fallbackScore,
+            label: fuzzyEngine.getWfaScoreLabel(fallbackScore),
             breakdown: { error: error.message },
             distance_meters: place.properties?.distance || 1000
           }
@@ -313,7 +313,7 @@ export const getWfaRecommendations = async (req, res, next) => {
           recommendations_returned: sortedRecommendations.length
         },
         fahp_methodology: {
-          approach: 'Pure FAHP (TFN + Buckley + centroid)',
+          approach: 'Pure FAHP (TFN + Chang extent)',
           criteria_weights: ahpWeights
         }
       },
@@ -387,7 +387,7 @@ export const getWfaAhpConfig = async (req, res, next) => {
         },
         consistency_ratio: ahpWeights.consistency_ratio,
         is_consistent: ahpWeights.consistency_ratio <= 0.1,
-        method: 'FAHP (TFN + Buckley + centroid) - Comprehensive Amenity Assessment',
+        method: 'Fuzzy AHP dengan Chang’s Extent Analysis',
         criteria_explanation: {
           location_type:
             'Penilaian berdasarkan kategori tempat (cafe, hotel, coworking space, dll)',
@@ -395,7 +395,7 @@ export const getWfaAhpConfig = async (req, res, next) => {
             'Penilaian komprehensif fasilitas: WiFi, informasi bisnis, brand recognition, payment options, aksesibilitas, dan keragaman kategori',
           distance_factor: 'Penilaian berdasarkan jarak dari pusat pencarian'
         },
-        weight_calculation: 'Menggunakan AHP library dengan expert judgment matrix',
+        weight_calculation: 'Pembobotan kriteria berbasis pairwise TFN dengan Chang’s Extent Analysis',
         scoring_method: 'Weighted scoring model dengan normalisasi 0-100'
       },
       message: 'Konfigurasi Fuzzy AHP Engine berhasil diambil'
@@ -412,34 +412,37 @@ export const getWfaAhpConfig = async (req, res, next) => {
  */
 export const testFuzzyAhp = async (req, res, next) => {
   try {
-    const { place_data, custom_weights } = req.body;
+    const { place_data, custom_weights, scenario, expected } = req.body;
 
-    // Validasi input
     if (!place_data) {
       return res.status(400).json({
         success: false,
         message: 'Parameter place_data wajib diisi untuk testing'
       });
-    } // Gunakan custom weights jika disediakan, atau default weights
-    const weights = custom_weights || fuzzyEngine.getWfaAhpWeights();
+    }
 
-    // Test scoring dengan data yang disediakan
+    const usesCustomWeights = custom_weights != null;
+    const weights = usesCustomWeights ? custom_weights : fuzzyEngine.getWfaAhpWeights();
     const testResult = await fuzzyEngine.calculateWfaScore(place_data, weights);
+    const category = testResult.label;
+    const normalizedExpected = typeof expected === 'string' ? expected.trim() : null;
 
     res.status(200).json({
       success: true,
       data: {
-        test_result: testResult,
-        interpretation: {
-          score_range: '0-100',
-          score_meaning:
-            testResult.score >= 70
-              ? 'Recommended'
-              : testResult.score >= 50
-                ? 'Acceptable'
-                : 'Not recommended',
-          consistency_check: weights.consistency_ratio <= 0.1 ? 'Consistent' : 'Inconsistent'
-        }
+        scenario: scenario || place_data.properties?.name || 'WFA Test',
+        weights: {
+          location_type: Number((weights.location_type ?? testResult.weights?.[0] ?? 0).toFixed(4)),
+          distance_factor: Number((weights.distance_factor ?? testResult.weights?.[1] ?? 0).toFixed(4)),
+          amenity_score: Number((weights.amenity_score ?? testResult.weights?.[2] ?? 0).toFixed(4))
+        },
+        cr: usesCustomWeights
+          ? null
+          : testResult.CR ?? Number((weights.consistency_ratio ?? 0).toFixed(3)),
+        score: testResult.score,
+        category,
+        expected: normalizedExpected,
+        match: normalizedExpected ? category === normalizedExpected : false
       },
       message: 'Test Fuzzy AHP berhasil'
     });

--- a/src/jobs/autoCheckout.job.js
+++ b/src/jobs/autoCheckout.job.js
@@ -10,9 +10,6 @@ import { toJakartaTime } from '../utils/geofence.js';
 import fuzzyAhpEngine from '../utils/fuzzyAhpEngine.js';
 import logger from '../utils/logger.js';
 import { executeJobWithTimeout, processBatchRecords } from '../utils/jobHelper.js';
-import { defuzzifyMatrixTFN, computeCR } from '../analytics/fahp.js';
-import { extentWeightsTFN } from '../analytics/fahp.extent.js';
-import { SMART_AC_PAIRWISE_TFN } from '../analytics/config.fahp.js';
 
 function isManageableTask(task) {
   return Boolean(task && (typeof task.destroy === 'function' || typeof task.stop === 'function'));
@@ -150,16 +147,19 @@ export const triggerAutoCheckout = async () => {
 // ================= SMART AUTO CHECKOUT (FAHP + DOW) =================
 
 function getFahpWeights() {
-  const weights = extentWeightsTFN(SMART_AC_PAIRWISE_TFN);
-  // Optional CR logging for diagnostics
-  try {
-    const crisp = defuzzifyMatrixTFN(SMART_AC_PAIRWISE_TFN);
-    const { CR } = computeCR(crisp);
-    logger.info(`Smart Auto Checkout FAHP CR=${CR.toFixed(3)}`);
-  } catch (e) {
-    logger.debug(`CR computation failed: ${e?.message || e}`);
+  const weightsObj = fuzzyAhpEngine.getSmartAcAhpWeights();
+  const weights = [
+    weightsObj.history,
+    weightsObj.checkin_pattern,
+    weightsObj.context,
+    weightsObj.transition
+  ];
+
+  if (Number.isFinite(weightsObj.consistency_ratio)) {
+    logger.info(`Smart Auto Checkout FAHP CR=${weightsObj.consistency_ratio.toFixed(3)}`);
   }
-  return weights; // [w_hist, w_checkin, w_context, w_transition]
+
+  return weights;
 }
 
 function median(numbers) {

--- a/src/services/fuzzyAhpAnalysis.service.js
+++ b/src/services/fuzzyAhpAnalysis.service.js
@@ -1,19 +1,22 @@
 import { Op } from 'sequelize';
 
-import { Attendance, Location, LocationEvent, User } from '../models/index.js';
+import { Attendance, AttendanceCategory, Booking, Location, LocationEvent, User } from '../models/index.js';
 import fuzzyEngine from '../utils/fuzzyAhpEngine.js';
 
 const CR_THRESHOLD = parseFloat(process.env.AHP_CR_THRESHOLD || '0.10');
 
+const WORK_START_MINUTES_WIB = 8 * 60;
+
 const EMPTY_DISTRIBUTION = {
-  'Sangat Tinggi': 0,
-  Tinggi: 0,
-  Sedang: 0,
-  Rendah: 0,
-  'Sangat Rendah': 0
+  'Sangat Baik': 0,
+  Baik: 0,
+  Cukup: 0,
+  Rendah: 0
 };
 
 function buildConsistency({ CR, CI = 0, lambda_max = 0, threshold = CR_THRESHOLD }) {
+  const formattedThreshold = threshold.toFixed(2);
+
   return {
     CR,
     CI,
@@ -22,8 +25,8 @@ function buildConsistency({ CR, CI = 0, lambda_max = 0, threshold = CR_THRESHOLD
     is_consistent: CR <= threshold,
     verdict:
       CR <= threshold
-        ? 'Matriks perbandingan konsisten (CR < 0.10)'
-        : 'Matriks perbandingan belum konsisten (CR >= 0.10)'
+        ? `Matriks perbandingan konsisten (CR < ${formattedThreshold})`
+        : `Matriks perbandingan belum konsisten (CR >= ${formattedThreshold})`
   };
 }
 
@@ -32,6 +35,14 @@ function buildDistribution(ranking) {
     acc[item.label] = (acc[item.label] || 0) + 1;
     return acc;
   }, { ...EMPTY_DISTRIBUTION });
+}
+
+function buildConsistencyFromWeights(weightsObj) {
+  return buildConsistency({
+    CR: Number(weightsObj.consistency_ratio?.toFixed?.(3) || 0),
+    CI: Number(weightsObj.consistency_index?.toFixed?.(3) || 0),
+    lambda_max: Number(weightsObj.lambda_max?.toFixed?.(3) || 0)
+  });
 }
 
 function getWorkdayCount(startAt, endAt) {
@@ -47,8 +58,37 @@ function getWorkdayCount(startAt, endAt) {
   return count;
 }
 
+function toWibParts(date, options) {
+  const parts = new Intl.DateTimeFormat('en-GB', {
+    timeZone: 'Asia/Jakarta',
+    ...options
+  }).formatToParts(date);
+
+  return Object.fromEntries(parts.map((part) => [part.type, part.value]));
+}
+
+function toWibDateString(date) {
+  const values = toWibParts(date, {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit'
+  });
+
+  return `${values.year}-${values.month}-${values.day}`;
+}
+
+function toWibMinutesOfDay(date) {
+  const values = toWibParts(date, {
+    hour: '2-digit',
+    minute: '2-digit',
+    hourCycle: 'h23'
+  });
+
+  return Number(values.hour) * 60 + Number(values.minute);
+}
+
 function buildDateRange(startAt, endAt) {
-  return [startAt.toISOString().split('T')[0], endAt.toISOString().split('T')[0]];
+  return [toWibDateString(startAt), toWibDateString(endAt)];
 }
 
 function finalizeRanking(ranking) {
@@ -60,7 +100,7 @@ function finalizeRanking(ranking) {
   return ranking;
 }
 
-function buildAnalysisPayload({ entityKind, ranking, consistency, weights, scope, windowApplied }) {
+function buildAnalysisPayload({ entityKind, ranking, consistency, weights, scope, windowApplied, dataSource }) {
   const result = {
     entity_kind: entityKind,
     consistency,
@@ -77,6 +117,10 @@ function buildAnalysisPayload({ entityKind, ranking, consistency, weights, scope
     result.window_applied = windowApplied;
   }
 
+  if (dataSource != null) {
+    result.data_source = dataSource;
+  }
+
   return result;
 }
 
@@ -87,10 +131,7 @@ function buildDisciplineMetrics(attendances, startAt, endAt) {
 
   const avgLatenessMinutes = attendances.length
     ? attendances
-        .map((att) => {
-          const timeIn = new Date(att.time_in);
-          return timeIn.getUTCHours() * 60 + timeIn.getUTCMinutes();
-        })
+        .map((att) => Math.max(0, toWibMinutesOfDay(new Date(att.time_in)) - WORK_START_MINUTES_WIB))
         .reduce((sum, minutes) => sum + minutes, 0) / attendances.length
     : 0;
 
@@ -115,19 +156,27 @@ export async function buildDisciplineAnalysis({ startAt, endAt }) {
     weightsObj.work_focus
   ];
   const attendanceDateRange = buildDateRange(startAt, endAt);
+  const userIds = users.map((user) => user.id_users);
+  const attendanceRows = userIds.length
+    ? await Attendance.findAll({
+        where: {
+          user_id: { [Op.in]: userIds },
+          attendance_date: {
+            [Op.between]: attendanceDateRange
+          }
+        }
+      })
+    : [];
+  const attendancesByUser = attendanceRows.reduce((groups, attendance) => {
+    const userAttendances = groups.get(attendance.user_id) || [];
+    userAttendances.push(attendance);
+    groups.set(attendance.user_id, userAttendances);
+    return groups;
+  }, new Map());
   const ranking = [];
 
   for (const user of users) {
-    const attendances = await Attendance.findAll({
-      where: {
-        user_id: user.id_users,
-        attendance_date: {
-          [Op.between]: attendanceDateRange
-        }
-      }
-    });
-
-    const metrics = buildDisciplineMetrics(attendances, startAt, endAt);
+    const metrics = buildDisciplineMetrics(attendancesByUser.get(user.id_users) || [], startAt, endAt);
     const result = await fuzzyEngine.calculateDisciplineIndex(metrics, weightsObj);
 
     ranking.push({
@@ -144,11 +193,7 @@ export async function buildDisciplineAnalysis({ startAt, endAt }) {
   return buildAnalysisPayload({
     entityKind: 'user',
     ranking,
-    consistency: buildConsistency({
-      CR: Number(weightsObj.consistency_ratio?.toFixed?.(3) || 0),
-      CI: 0,
-      lambda_max: 0
-    }),
+    consistency: buildConsistencyFromWeights(weightsObj),
     weights: {
       criteria,
       values,
@@ -199,26 +244,72 @@ export async function buildWfaAnalysis(_window = {}) {
   return buildAnalysisPayload({
     entityKind: 'place',
     ranking,
-    consistency: buildConsistency({
-      CR: Number(weightsObj.consistency_ratio?.toFixed?.(3) || 0),
-      CI: 0,
-      lambda_max: 0
-    }),
+    consistency: buildConsistencyFromWeights(weightsObj),
     weights: {
       criteria,
       values,
       method: "Chang's Extent Analysis"
     },
     scope: 'place_catalog_static',
-    windowApplied: false
+    windowApplied: false,
+    dataSource: {
+      type: 'location_catalog_static',
+      assumptions: [
+        { field: 'amenity_score', value: 50 },
+        { field: 'distance', value: 1000 }
+      ],
+      warning: 'WFA analysis uses static location catalog assumptions because no runtime visit telemetry is applied.'
+    }
   });
 }
 
-function getSmartAcWeights() {
-  return [0.4, 0.2, 0.2, 0.2];
+function getSmartAcExpectedLocationId(attendance, targetDate) {
+  const categoryName = (attendance?.attendance_category?.category_name || '').toLowerCase();
+
+  if (categoryName.includes('wfo') || categoryName.includes('work from office')) {
+    return attendance.location_id || null;
+  }
+
+  if (categoryName.includes('wfa') || categoryName.includes('work from anywhere')) {
+    const booking = attendance.booking;
+    const bookingDate = booking?.schedule_date instanceof Date
+      ? toWibDateString(booking.schedule_date)
+      : booking?.schedule_date;
+
+    if (booking?.location_id && bookingDate === targetDate && Number(booking.status) === 1) {
+      return booking.location_id;
+    }
+  }
+
+  return null;
 }
 
-async function buildSmartAcMetrics(user, startAt, endAt) {
+async function getSmartAcTransitionEvent(userId, attendance, targetDate) {
+  const expectedLocationId = getSmartAcExpectedLocationId(attendance, targetDate);
+
+  if (expectedLocationId == null || !attendance?.time_in) {
+    return null;
+  }
+
+  const timeIn = new Date(attendance.time_in);
+  const dayStart = new Date(`${targetDate}T00:00:00.000Z`);
+  const dayEnd = new Date(`${targetDate}T23:59:59.999Z`);
+
+  return LocationEvent.findOne({
+    where: {
+      user_id: userId,
+      event_type: 'EXIT',
+      location_id: expectedLocationId,
+      event_timestamp: {
+        [Op.gte]: new Date(Math.max(timeIn.getTime(), dayStart.getTime())),
+        [Op.lte]: dayEnd
+      }
+    },
+    order: [['event_timestamp', 'DESC']]
+  });
+}
+
+async function buildSmartAcMetrics(user, startAt, endAt, weights) {
   const attendanceDateRange = buildDateRange(startAt, endAt);
   const attendances = await Attendance.findAll({
     where: {
@@ -226,44 +317,59 @@ async function buildSmartAcMetrics(user, startAt, endAt) {
       attendance_date: {
         [Op.between]: attendanceDateRange
       }
-    }
+    },
+    include: [
+      {
+        model: AttendanceCategory,
+        as: 'attendance_category',
+        attributes: ['category_name'],
+        required: false
+      },
+      {
+        model: Booking,
+        as: 'booking',
+        attributes: ['schedule_date', 'location_id', 'status'],
+        required: false
+      }
+    ],
+    order: [
+      ['attendance_date', 'DESC'],
+      ['time_in', 'DESC']
+    ]
   });
 
   const latest = attendances[0] || null;
-  const event = latest
-    ? await LocationEvent.findOne({
-        where: {
-          user_id: user.id_users
-        }
-      })
+  const targetDate = latest?.attendance_date instanceof Date
+    ? toWibDateString(latest.attendance_date)
+    : latest?.attendance_date;
+  const transitionEvent = latest ? await getSmartAcTransitionEvent(user.id_users, latest, targetDate) : null;
+  const transitionCandidate = transitionEvent?.event_timestamp ? new Date(transitionEvent.event_timestamp) : null;
+  const predictedCheckout = latest
+    ? fuzzyEngine.weightedPrediction(
+        {
+          HIST: latest.time_out ? new Date(latest.time_out) : null,
+          CHECKIN: latest.time_in ? new Date(latest.time_in) : null,
+          CONTEXT: transitionCandidate,
+          TRANSITION: transitionCandidate
+        },
+        weights,
+        targetDate,
+        latest.time_in,
+        '18:00:00'
+      )
     : null;
 
   return {
-    history_checkout_minutes: latest?.time_out ? new Date(latest.time_out).getUTCHours() * 60 : 0,
-    checkin_pattern_minutes: latest?.time_in ? new Date(latest.time_in).getUTCHours() * 60 : 0,
-    context_checkout_minutes: event?.event_timestamp ? new Date(event.event_timestamp).getUTCHours() * 60 : 0,
-    transition_checkout_minutes: latest?.notes?.includes('TRANSITION') ? 15 : 0
+    history_checkout_minutes: latest?.time_out ? toWibMinutesOfDay(new Date(latest.time_out)) : 0,
+    checkin_pattern_minutes: latest?.time_in ? toWibMinutesOfDay(new Date(latest.time_in)) : 0,
+    context_checkout_minutes: transitionCandidate ? toWibMinutesOfDay(transitionCandidate) : 0,
+    transition_checkout_minutes: transitionCandidate ? toWibMinutesOfDay(transitionCandidate) : 0,
+    predicted_checkout_minutes: predictedCheckout ? toWibMinutesOfDay(predictedCheckout) : 0
   };
 }
 
 function getSmartAcLabel(score) {
-  if (score >= 80) {
-    return 'Sangat Tinggi';
-  }
-
-  if (score >= 60) {
-    return 'Tinggi';
-  }
-
-  if (score >= 40) {
-    return 'Sedang';
-  }
-
-  if (score >= 20) {
-    return 'Rendah';
-  }
-
-  return 'Sangat Rendah';
+  return fuzzyEngine.getWfaScoreLabel(score);
 }
 
 function computeSmartAcScore(metrics, weights) {
@@ -285,12 +391,18 @@ function computeSmartAcScore(metrics, weights) {
 
 export async function buildSmartAcAnalysis({ startAt, endAt }) {
   const users = await User.findAll({});
-  const values = getSmartAcWeights();
+  const weightsObj = fuzzyEngine.getSmartAcAhpWeights();
+  const values = [
+    weightsObj.history,
+    weightsObj.checkin_pattern,
+    weightsObj.context,
+    weightsObj.transition
+  ];
   const criteria = ['history', 'checkin_pattern', 'context', 'transition'];
   const ranking = [];
 
   for (const user of users) {
-    const metrics = await buildSmartAcMetrics(user, startAt, endAt);
+    const metrics = await buildSmartAcMetrics(user, startAt, endAt, values);
     const result = computeSmartAcScore(metrics, values);
 
     ranking.push({
@@ -307,11 +419,7 @@ export async function buildSmartAcAnalysis({ startAt, endAt }) {
   return buildAnalysisPayload({
     entityKind: 'user',
     ranking,
-    consistency: buildConsistency({
-      CR: 0,
-      CI: 0,
-      lambda_max: 0
-    }),
+    consistency: buildConsistencyFromWeights(weightsObj),
     weights: {
       criteria,
       values,

--- a/src/utils/fuzzyAhpEngine.js
+++ b/src/utils/fuzzyAhpEngine.js
@@ -3,24 +3,34 @@ import { defuzzifyMatrixTFN, computeCR } from '../analytics/fahp.js';
 import { extentWeightsTFN } from '../analytics/fahp.extent.js';
 import { minMax } from '../analytics/normalization.js';
 import { labelEqualInterval } from '../analytics/labeling.js';
-import { WFA_PAIRWISE_TFN, DISC_PAIRWISE_TFN } from '../analytics/config.fahp.js';
-import { calculateDistance, toJakartaTime } from './geofence.js';
+import { WFA_PAIRWISE_TFN, DISC_PAIRWISE_TFN, SMART_AC_PAIRWISE_TFN } from '../analytics/config.fahp.js';
+import { calculateDistance } from './geofence.js';
 
 // Simple memoization for FAHP weights
 let cachedWfaWeights = null;
 let cachedDiscWeights = null;
-let cachedWfaCR = null;
-let cachedDiscCR = null;
+let cachedSmartAcWeights = null;
+let cachedWfaConsistency = null;
+let cachedDiscConsistency = null;
+let cachedSmartAcConsistency = null;
 
 const CR_THRESHOLD = 0.10;
 function selectWeights(matrixTFN) {
   return extentWeightsTFN(matrixTFN);
 }
 
+function deriveWeightsWithCr(matrixTFN) {
+  const weights = selectWeights(matrixTFN);
+  const crisp = defuzzifyMatrixTFN(matrixTFN);
+  const { CR, CI, lambdaMax } = computeCR(crisp);
+
+  return { weights, consistency: { CR, CI, lambdaMax } };
+}
+
 // --- Time utilities for Smart Auto Checkout weighted prediction ---
 function minutesSinceMidnightWIB(dateLike) {
-  const j = toJakartaTime(dateLike);
-  return j.getHours() * 60 + j.getMinutes();
+  const shifted = new Date(new Date(dateLike).getTime() + 7 * 60 * 60 * 1000);
+  return shifted.getUTCHours() * 60 + shifted.getUTCMinutes();
 }
 
 function clampCheckout(targetDate, candidate, timeIn, endBoundaryStr) {
@@ -53,24 +63,28 @@ function weightedPrediction(candidates, weights, targetDate, timeIn, fallbackEnd
 
 // --- Public API: getWfaAhpWeights (now returns FAHP weights) ---
 function getWfaAhpWeights() {
-  if (cachedWfaWeights && cachedWfaCR != null) {
+  if (cachedWfaWeights && cachedWfaConsistency) {
     return {
       location_type: cachedWfaWeights[0],
       distance_factor: cachedWfaWeights[1],
       amenity_score: cachedWfaWeights[2],
-      consistency_ratio: cachedWfaCR
+      consistency_ratio: cachedWfaConsistency.CR,
+      consistency_index: cachedWfaConsistency.CI,
+      lambda_max: cachedWfaConsistency.lambdaMax
     };
   }
-  const weights = selectWeights(WFA_PAIRWISE_TFN);
-  const crisp = defuzzifyMatrixTFN(WFA_PAIRWISE_TFN);
-  const { CR } = computeCR(crisp);
+
+  const { weights, consistency } = deriveWeightsWithCr(WFA_PAIRWISE_TFN);
   cachedWfaWeights = weights;
-  cachedWfaCR = CR;
+  cachedWfaConsistency = consistency;
+
   return {
     location_type: weights[0],
     distance_factor: weights[1],
     amenity_score: weights[2],
-    consistency_ratio: CR
+    consistency_ratio: consistency.CR,
+    consistency_index: consistency.CI,
+    lambda_max: consistency.lambdaMax
   };
 }
 
@@ -98,6 +112,22 @@ async function calculateWfaScore(placeDetails, ahpWeights = null) {
       categories.some((c) => c.includes('restaurant') || c.includes('food')) ||
       name.includes('restaurant') ||
       name.includes('restoran');
+    const isLowSuitability =
+      categories.some(
+        (c) =>
+          c.includes('industrial') ||
+          c.includes('warehouse') ||
+          c.includes('factory') ||
+          c.includes('manufacturing') ||
+          c.includes('storage') ||
+          c.includes('yard')
+      ) ||
+      name.includes('industrial') ||
+      name.includes('warehouse') ||
+      name.includes('factory') ||
+      name.includes('manufacturing') ||
+      name.includes('storage') ||
+      name.includes('yard');
 
     let loc01 = 0.4;
     if (isCafe) loc01 = 1.0;
@@ -106,6 +136,7 @@ async function calculateWfaScore(placeDetails, ahpWeights = null) {
     else if (isRestaurant) loc01 = 0.65;
     else if (categories.some((c) => c.includes('mall'))) loc01 = 0.6;
     else if (categories.some((c) => c.includes('park'))) loc01 = 0.45;
+    else if (isLowSuitability) loc01 = 0.1;
 
     // Distance fallback: use provided properties.distance or compute from coordinates
     let distanceMeters = placeDetails.properties?.distance;
@@ -155,32 +186,64 @@ async function calculateWfaScore(placeDetails, ahpWeights = null) {
     return result;
   } catch (error) {
     logger.error('Error calculating WFA score (FAHP):', error);
-    return { score: 50, label: 'Sedang', breakdown: { error: error.message } };
+    return { score: 25, label: getWfaScoreLabel(25), breakdown: { error: error.message } };
   }
 }
 
 // --- Public API: getDisciplineAhpWeights (now FAHP) ---
 function getDisciplineAhpWeights() {
-  if (cachedDiscWeights && cachedDiscCR != null) {
+  if (cachedDiscWeights && cachedDiscConsistency) {
     return {
       alpha_rate: cachedDiscWeights[0],
       lateness_severity: cachedDiscWeights[1],
       lateness_frequency: cachedDiscWeights[2],
       work_focus: cachedDiscWeights[3],
-      consistency_ratio: cachedDiscCR
+      consistency_ratio: cachedDiscConsistency.CR,
+      consistency_index: cachedDiscConsistency.CI,
+      lambda_max: cachedDiscConsistency.lambdaMax
     };
   }
-  const weights = selectWeights(DISC_PAIRWISE_TFN);
-  const crisp = defuzzifyMatrixTFN(DISC_PAIRWISE_TFN);
-  const { CR } = computeCR(crisp);
+
+  const { weights, consistency } = deriveWeightsWithCr(DISC_PAIRWISE_TFN);
   cachedDiscWeights = weights;
-  cachedDiscCR = CR;
+  cachedDiscConsistency = consistency;
+
   return {
     alpha_rate: weights[0],
     lateness_severity: weights[1],
     lateness_frequency: weights[2],
     work_focus: weights[3],
-    consistency_ratio: CR
+    consistency_ratio: consistency.CR,
+    consistency_index: consistency.CI,
+    lambda_max: consistency.lambdaMax
+  };
+}
+
+function getSmartAcAhpWeights() {
+  if (cachedSmartAcWeights && cachedSmartAcConsistency) {
+    return {
+      history: cachedSmartAcWeights[0],
+      checkin_pattern: cachedSmartAcWeights[1],
+      context: cachedSmartAcWeights[2],
+      transition: cachedSmartAcWeights[3],
+      consistency_ratio: cachedSmartAcConsistency.CR,
+      consistency_index: cachedSmartAcConsistency.CI,
+      lambda_max: cachedSmartAcConsistency.lambdaMax
+    };
+  }
+
+  const { weights, consistency } = deriveWeightsWithCr(SMART_AC_PAIRWISE_TFN);
+  cachedSmartAcWeights = weights;
+  cachedSmartAcConsistency = consistency;
+
+  return {
+    history: weights[0],
+    checkin_pattern: weights[1],
+    context: weights[2],
+    transition: weights[3],
+    consistency_ratio: consistency.CR,
+    consistency_index: consistency.CI,
+    lambda_max: consistency.lambdaMax
   };
 }
 
@@ -219,18 +282,14 @@ async function calculateDisciplineIndex(m) {
     return result;
   } catch (error) {
     logger.error('Error calculating Discipline Index (FAHP):', error);
-    return { score: 50, label: 'Sedang', breakdown: { error: error.message } };
+    return { score: 25, label: getDisciplineLabel(25), breakdown: { error: error.message } };
   }
 }
 
 // Utilities kept for controllers compatibility
 function getWfaScoreLabel(score) {
-  const s = Number(score);
-  if (s >= 80) return 'Sangat Tinggi';
-  if (s >= 60) return 'Tinggi';
-  if (s >= 40) return 'Sedang';
-  if (s >= 20) return 'Rendah';
-  return 'Sangat Rendah';
+  const s = Math.max(0, Math.min(100, Number(score)));
+  return labelEqualInterval(s / 100);
 }
 
 function getDisciplineLabel(score) {
@@ -285,6 +344,7 @@ export default {
   // Weights
   getWfaAhpWeights,
   getDisciplineAhpWeights,
+  getSmartAcAhpWeights,
 
   // Utils
   getWfaScoreLabel,

--- a/tests/analysisFuzzyAhpContract.test.js
+++ b/tests/analysisFuzzyAhpContract.test.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import { jest } from '@jest/globals';
+import { Op } from 'sequelize';
 import request from 'supertest';
 
 const mockVerifyToken = jest.fn((req, _res, next) => {
@@ -27,6 +28,7 @@ const mockLocation = {
   findAll: jest.fn()
 };
 const mockLocationEvent = {
+  findAll: jest.fn(),
   findOne: jest.fn()
 };
 const mockBooking = {
@@ -40,7 +42,14 @@ const mockFuzzyEngine = {
   getDisciplineAhpWeights: jest.fn(),
   calculateDisciplineIndex: jest.fn(),
   getWfaAhpWeights: jest.fn(),
+  getSmartAcAhpWeights: jest.fn(),
   calculateWfaScore: jest.fn(),
+  getWfaScoreLabel: jest.fn((score) => {
+    if (score < 25) return 'Rendah';
+    if (score < 50) return 'Cukup';
+    if (score < 75) return 'Baik';
+    return 'Sangat Baik';
+  }),
   weightedPrediction: jest.fn(),
   categorizePlace: jest.fn((place) => {
     const name = (place?.properties?.name || '').toLowerCase();
@@ -85,8 +94,16 @@ jest.unstable_mockModule('../src/utils/fuzzyAhpEngine.js', () => ({
 }));
 
 const { getFuzzyAhpAnalysis } = await import('../src/controllers/analysis.controller.js');
+const { buildDisciplineAnalysis, buildSmartAcAnalysis } = await import('../src/services/fuzzyAhpAnalysis.service.js');
 const { default: analysisRoutes } = await import('../src/routes/analysis.routes.js');
 const { default: mainRoutes } = await import('../src/routes/index.js');
+
+const WIB_TIMESTAMP_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}\+07:00$/;
+
+function expectWibTimestamp(value) {
+  expect(value).toEqual(expect.stringMatching(WIB_TIMESTAMP_PATTERN));
+  expect(value.endsWith('Z')).toBe(false);
+}
 
 const scopedApp = express();
 scopedApp.use('/api/analysis', analysisRoutes);
@@ -107,6 +124,7 @@ describe('analysis fuzzy ahp contract', () => {
     mockUser.findAll.mockResolvedValue([]);
     mockAttendance.findAll.mockResolvedValue([]);
     mockLocation.findAll.mockResolvedValue([]);
+    mockLocationEvent.findAll.mockResolvedValue([]);
     mockLocationEvent.findOne.mockResolvedValue(null);
     mockBooking.findAll.mockResolvedValue([]);
     mockSettings.findOne.mockResolvedValue(null);
@@ -116,11 +134,13 @@ describe('analysis fuzzy ahp contract', () => {
       lateness_severity: 0.25,
       lateness_frequency: 0.18,
       work_focus: 0.12,
-      consistency_ratio: 0.037
+      consistency_ratio: 0.037,
+      consistency_index: 0.025,
+      lambda_max: 4.075
     });
     mockFuzzyEngine.calculateDisciplineIndex.mockResolvedValue({
       score: 87.5,
-      label: 'Sangat Tinggi',
+      label: 'Sangat Baik',
       breakdown: {
         alpha_rate: 0,
         avg_lateness_minutes: 3,
@@ -133,11 +153,22 @@ describe('analysis fuzzy ahp contract', () => {
       location_type: 0.5,
       distance_factor: 0.3,
       amenity_score: 0.2,
-      consistency_ratio: 0.025
+      consistency_ratio: 0.025,
+      consistency_index: 0.014,
+      lambda_max: 3.028
+    });
+    mockFuzzyEngine.getSmartAcAhpWeights.mockReturnValue({
+      history: 0.31,
+      checkin_pattern: 0.27,
+      context: 0.18,
+      transition: 0.24,
+      consistency_ratio: 0.041,
+      consistency_index: 0.037,
+      lambda_max: 4.111
     });
     mockFuzzyEngine.calculateWfaScore.mockResolvedValue({
       score: 76.4,
-      label: 'Tinggi'
+      label: 'Sangat Baik'
     });
 
     mockFuzzyEngine.weightedPrediction.mockReturnValue(new Date('2026-04-21T10:15:00.000Z'));
@@ -165,6 +196,7 @@ describe('analysis fuzzy ahp contract', () => {
     mockUser.findAll.mockResolvedValue([{ id_users: 7, full_name: 'Andi' }]);
     mockAttendance.findAll.mockResolvedValue([
       {
+        user_id: 7,
         status_id: 1,
         time_in: '2026-04-01T01:03:00.000Z',
         time_out: '2026-04-01T09:00:00.000Z',
@@ -173,6 +205,7 @@ describe('analysis fuzzy ahp contract', () => {
         notes: ''
       },
       {
+        user_id: 7,
         status_id: 2,
         time_in: '2026-04-02T02:15:00.000Z',
         time_out: '2026-04-02T10:00:00.000Z',
@@ -192,6 +225,10 @@ describe('analysis fuzzy ahp contract', () => {
     await getFuzzyAhpAnalysis(req, res, next);
 
     expect(next).not.toHaveBeenCalled();
+    expect(mockFuzzyEngine.calculateDisciplineIndex).toHaveBeenCalledWith(
+      expect.objectContaining({ avg_lateness_minutes: 39 }),
+      expect.any(Object)
+    );
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -205,9 +242,9 @@ describe('analysis fuzzy ahp contract', () => {
             method: expect.any(String)
           }),
           consistency: expect.objectContaining({
-            CR: expect.any(Number),
-            CI: expect.any(Number),
-            lambda_max: expect.any(Number),
+            CR: 0.037,
+            CI: 0.025,
+            lambda_max: 4.075,
             threshold: expect.any(Number),
             is_consistent: expect.any(Boolean),
             verdict: expect.any(String)
@@ -218,7 +255,7 @@ describe('analysis fuzzy ahp contract', () => {
               id: 7,
               name: 'Andi',
               score: expect.any(Number),
-              label: expect.any(String),
+              label: 'Sangat Baik',
               breakdown: expect.objectContaining({
                 alpha_rate: expect.any(Number),
                 avg_lateness_minutes: expect.any(Number),
@@ -261,17 +298,30 @@ describe('analysis fuzzy ahp contract', () => {
           entity_kind: 'place',
           scope: 'place_catalog_static',
           window_applied: false,
+          data_source: expect.objectContaining({
+            type: 'location_catalog_static',
+            assumptions: expect.arrayContaining([
+              expect.objectContaining({ field: 'amenity_score', value: 50 }),
+              expect.objectContaining({ field: 'distance', value: 1000 })
+            ]),
+            warning: expect.stringContaining('static')
+          }),
+          consistency: expect.objectContaining({
+            CR: 0.025,
+            CI: 0.014,
+            lambda_max: 3.028
+          }),
           ranking: expect.arrayContaining([
             expect.objectContaining({
               rank: 1,
               id: 11,
               name: 'Cafe A',
               score: expect.any(Number),
-              label: expect.any(String),
+              label: 'Sangat Baik',
               breakdown: expect.objectContaining({
                 location_type: expect.any(String),
-                amenity_score: expect.any(Number),
-                distance: expect.any(Number)
+                amenity_score: 50,
+                distance: 1000
               })
             })
           ])
@@ -304,6 +354,10 @@ describe('analysis fuzzy ahp contract', () => {
 
     await getFuzzyAhpAnalysis(req, res, next);
 
+    expect(mockFuzzyEngine.getSmartAcAhpWeights).toHaveBeenCalledTimes(1);
+    expect(mockLocationEvent.findOne).not.toHaveBeenCalled();
+    expect(mockFuzzyEngine.weightedPrediction).toHaveBeenCalledTimes(1);
+    expect(mockFuzzyEngine.weightedPrediction.mock.calls[0][0].TRANSITION).toBeNull();
     expect(next).not.toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith(
@@ -312,9 +366,14 @@ describe('analysis fuzzy ahp contract', () => {
         data: expect.objectContaining({
           type: 'smart_ac',
           entity_kind: 'user',
+          consistency: expect.objectContaining({
+            CR: 0.041,
+            CI: 0.037,
+            lambda_max: 4.111
+          }),
           weights: expect.objectContaining({
             criteria: ['history', 'checkin_pattern', 'context', 'transition'],
-            values: expect.any(Array),
+            values: [0.31, 0.27, 0.18, 0.24],
             method: expect.any(String)
           }),
           ranking: expect.arrayContaining([
@@ -355,11 +414,10 @@ describe('analysis fuzzy ahp contract', () => {
         data: expect.objectContaining({
           ranking: [],
           distribution: {
-            'Sangat Tinggi': 0,
-            Tinggi: 0,
-            Sedang: 0,
-            Rendah: 0,
-            'Sangat Rendah': 0
+            'Sangat Baik': 0,
+            Baik: 0,
+            Cukup: 0,
+            Rendah: 0
           }
         })
       })
@@ -384,6 +442,9 @@ describe('analysis fuzzy ahp contract', () => {
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
     expect(res.body.data.type).toBe('discipline');
+    expectWibTimestamp(res.body.data.generated_at);
+    expectWibTimestamp(res.body.data.window.start_at);
+    expectWibTimestamp(res.body.data.window.end_at);
     expect(mockVerifyToken).toHaveBeenCalled();
   });
 
@@ -405,6 +466,112 @@ describe('analysis fuzzy ahp contract', () => {
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
     expect(res.body.data.type).toBe('discipline');
+  });
+
+  it('fetches discipline attendances with one scoped query for all ranked users', async () => {
+    mockUser.findAll.mockResolvedValue([
+      { id_users: 7, full_name: 'Andi' },
+      { id_users: 9, full_name: 'Sinta' }
+    ]);
+    mockAttendance.findAll.mockResolvedValue([
+      {
+        user_id: 7,
+        status_id: 1,
+        time_in: '2026-04-01T01:03:00.000Z',
+        time_out: '2026-04-01T09:00:00.000Z',
+        work_hour: 7.6,
+        attendance_date: '2026-04-01',
+        notes: ''
+      },
+      {
+        user_id: 9,
+        status_id: 2,
+        time_in: '2026-04-02T02:15:00.000Z',
+        time_out: '2026-04-02T10:00:00.000Z',
+        work_hour: 7.75,
+        attendance_date: '2026-04-02',
+        notes: ''
+      }
+    ]);
+
+    const req = {
+      query: { type: 'discipline', period: 'monthly' },
+      user: { id: 12, role_name: 'Admin' }
+    };
+    const res = makeRes();
+    const next = jest.fn();
+
+    await getFuzzyAhpAnalysis(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(mockAttendance.findAll).toHaveBeenCalledTimes(1);
+    expect(mockAttendance.findAll).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          user_id: expect.any(Object),
+          attendance_date: expect.any(Object)
+        })
+      })
+    );
+  });
+
+  it('uses WIB date-only bounds for discipline attendance queries', async () => {
+    mockUser.findAll.mockResolvedValue([{ id_users: 7, full_name: 'Andi' }]);
+    mockAttendance.findAll.mockResolvedValue([]);
+
+    await buildDisciplineAnalysis({
+      startAt: new Date('2026-04-30T17:00:00.000Z'),
+      endAt: new Date('2026-05-01T10:00:00.000Z')
+    });
+
+    const attendanceDate = mockAttendance.findAll.mock.calls[0][0].where.attendance_date;
+
+    expect(attendanceDate[Op.between]).toEqual(['2026-05-01', '2026-05-01']);
+  });
+
+  it('uses deterministic Smart AC attendance and context-event sources', async () => {
+    mockUser.findAll.mockResolvedValue([{ id_users: 9, full_name: 'Sinta' }]);
+    mockAttendance.findAll.mockResolvedValue([
+      {
+        user_id: 9,
+        location_id: 31,
+        time_in: '2026-05-01T01:00:00.000Z',
+        time_out: '2026-05-01T10:00:00.000Z',
+        attendance_date: '2026-05-01',
+        work_hour: 8,
+        notes: '[Smart AC] pred=17:00:00, used=17:15:00, basis=HIST,CONTEXT, dur=08:15:00',
+        attendance_category: {
+          category_name: 'WFO'
+        }
+      }
+    ]);
+    mockLocationEvent.findOne.mockResolvedValue({
+      event_timestamp: '2026-05-01T09:15:00.000Z'
+    });
+
+    await buildSmartAcAnalysis({
+      startAt: new Date('2026-04-30T17:00:00.000Z'),
+      endAt: new Date('2026-05-01T10:00:00.000Z')
+    });
+
+    const attendanceQuery = mockAttendance.findAll.mock.calls[0][0];
+    const eventQuery = mockLocationEvent.findOne.mock.calls[0][0];
+
+    expect(attendanceQuery.where.attendance_date[Op.between]).toEqual(['2026-05-01', '2026-05-01']);
+    expect(attendanceQuery.order).toEqual([
+      ['attendance_date', 'DESC'],
+      ['time_in', 'DESC']
+    ]);
+    expect(eventQuery.where).toEqual(
+      expect.objectContaining({
+        user_id: 9,
+        event_type: 'EXIT',
+        location_id: 31
+      })
+    );
+    expect(eventQuery.where.event_timestamp[Op.gte]).toEqual(new Date('2026-05-01T01:00:00.000Z'));
+    expect(eventQuery.where.event_timestamp[Op.lte]).toEqual(new Date('2026-05-01T23:59:59.999Z'));
+    expect(eventQuery.order).toEqual([['event_timestamp', 'DESC']]);
   });
 
   it('returns 403 for callers outside Admin and Management', async () => {

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -24,8 +24,10 @@ jest.unstable_mockModule('../src/middlewares/roleGuard.js', () => ({
 const { default: app } = await import('../src/app.js');
 
 describe('FAHP Dynamic Test Endpoint', () => {
-  it('POST /api/wfa/test-ahp returns expected JSON structure', async () => {
+  it('POST /api/wfa/test-ahp returns compact evidence payload', async () => {
     const body = {
+      scenario: 'WFA - Sangat Baik',
+      expected: 'Sangat Baik',
       place_data: {
         properties: {
           name: 'Coffee Lab',
@@ -42,15 +44,180 @@ describe('FAHP Dynamic Test Endpoint', () => {
 
     expect(res.status).toBe(200);
     expect(res.headers['content-type']).toMatch(/json/);
-
-    // Ensure shape includes score, label, breakdown, weights, CR
     expect(res.body).toHaveProperty('success', true);
-    expect(res.body).toHaveProperty('data.test_result');
-    const result = res.body.data.test_result;
-    expect(result).toHaveProperty('score');
-    expect(result).toHaveProperty('label');
-    expect(result).toHaveProperty('breakdown');
-    expect(result).toHaveProperty('weights');
-    expect(result).toHaveProperty('CR');
+    expect(res.body.data).toMatchObject({
+      scenario: 'WFA - Sangat Baik',
+      expected: 'Sangat Baik',
+      category: 'Sangat Baik',
+      match: true
+    });
+    expect(res.body.data).toHaveProperty('weights.location_type');
+    expect(res.body.data).toHaveProperty('weights.distance_factor');
+    expect(res.body.data).toHaveProperty('weights.amenity_score');
+    expect(res.body.data).toHaveProperty('cr');
+    expect(res.body.data).toHaveProperty('score');
+    expect(res.body.data).not.toHaveProperty('test_result');
+    expect(res.body.data).not.toHaveProperty('interpretation');
+  });
+
+  it('POST /api/wfa/test-ahp returns Rendah with canonical CR', async () => {
+    const body = {
+      scenario: 'WFA - Rendah',
+      expected: 'Rendah',
+      place_data: {
+        properties: {
+          name: 'Remote Industrial Yard',
+          categories: ['industrial'],
+          distance: 3000,
+          amenity_score: 0
+        },
+        geometry: { type: 'Point', coordinates: [106.8, -6.2] },
+        userLocation: { lat: -6.2, lon: 106.8 }
+      }
+    };
+
+    const res = await request(app).post('/api/wfa/test-ahp').send(body);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('success', true);
+    expect(res.body.data).toMatchObject({
+      scenario: 'WFA - Rendah',
+      expected: 'Rendah',
+      category: 'Rendah',
+      match: true
+    });
+    expect(res.body.data.cr).toBeCloseTo(0.058, 3);
+    expect(res.body.data).not.toHaveProperty('test_result');
+    expect(res.body.data).not.toHaveProperty('interpretation');
+  });
+
+  it('POST /api/wfa/test-ahp returns null CR for custom weights', async () => {
+    const body = {
+      scenario: 'WFA - Custom Weights',
+      custom_weights: {
+        location_type: 0.4,
+        distance_factor: 0.35,
+        amenity_score: 0.25
+      },
+      place_data: {
+        properties: {
+          name: 'Coffee Lab',
+          categories: ['cafe'],
+          distance: 200,
+          amenity_score: 90
+        },
+        geometry: { type: 'Point', coordinates: [106.8, -6.2] },
+        userLocation: { lat: -6.2, lon: 106.8 }
+      }
+    };
+
+    const res = await request(app).post('/api/wfa/test-ahp').send(body);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('success', true);
+    expect(res.body.data).toMatchObject({
+      scenario: 'WFA - Custom Weights',
+      cr: null
+    });
+    expect(res.body.data.weights).toMatchObject({
+      location_type: 0.4,
+      distance_factor: 0.35,
+      amenity_score: 0.25
+    });
+  });
+
+  it('POST /api/discipline/test-ahp returns compact evidence payload', async () => {
+    const body = {
+      scenario: 'Discipline - Baik',
+      expected: 'Baik',
+      metrics: {
+        alpha_rate: 30,
+        avg_lateness_minutes: 25,
+        lateness_frequency: 35,
+        work_hour_consistency: 50
+      }
+    };
+
+    const res = await request(app).post('/api/discipline/test-ahp').send(body);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('success', true);
+    expect(res.body.data).toMatchObject({
+      scenario: 'Discipline - Baik',
+      expected: 'Baik',
+      category: 'Baik',
+      match: true
+    });
+    expect(res.body.data).toHaveProperty('weights.alpha_rate');
+    expect(res.body.data).toHaveProperty('weights.lateness_severity');
+    expect(res.body.data).toHaveProperty('weights.lateness_frequency');
+    expect(res.body.data).toHaveProperty('weights.work_focus');
+    expect(res.body.data).toHaveProperty('cr');
+    expect(res.body.data).toHaveProperty('score');
+    expect(res.body.data).not.toHaveProperty('discipline_result');
+    expect(res.body.data).not.toHaveProperty('methodology');
+  });
+
+  it('POST /api/attendance/test-weighted-prediction returns compact evidence payload', async () => {
+    const body = {
+      scenario: 'Auto Checkout - Normal',
+      expected_range: '17:00-18:00',
+      targetDate: '2026-05-19',
+      timeIn: '2026-05-19T08:00:00+07:00',
+      candidates: {
+        HIST: '17:30:00',
+        CHECKIN: '17:15:00',
+        CONTEXT: '17:45:00',
+        TRANSITION: '17:20:00'
+      }
+    };
+
+    const res = await request(app).post('/api/attendance/test-weighted-prediction').send(body);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('success', true);
+    expect(res.body.data).toMatchObject({
+      scenario: 'Auto Checkout - Normal',
+      expected_range: '17:00-18:00',
+      match: true
+    });
+    expect(res.body.data).toHaveProperty('weights.HIST');
+    expect(res.body.data).toHaveProperty('weights.CHECKIN');
+    expect(res.body.data).toHaveProperty('weights.CONTEXT');
+    expect(res.body.data).toHaveProperty('weights.TRANSITION');
+    expect(res.body.data).toHaveProperty('cr');
+    expect(res.body.data).toHaveProperty('predicted_checkout');
+    expect(res.body.data).not.toHaveProperty('input');
+    expect(res.body.data).not.toHaveProperty('result_time');
+    expect(res.body.data).not.toHaveProperty('CR_threshold');
+    expect(res.body.data).not.toHaveProperty('is_consistent');
+  });
+
+  it('POST /api/attendance/test-weighted-prediction returns null CR for custom weights', async () => {
+    const body = {
+      scenario: 'Auto Checkout - Custom Weights',
+      expected_range: '17:00-18:00',
+      targetDate: '2026-05-19',
+      timeIn: '2026-05-19T08:00:00+07:00',
+      weights: [0.4, 0.25, 0.2, 0.15],
+      candidates: {
+        HIST: '17:30:00',
+        CHECKIN: '17:15:00',
+        CONTEXT: '17:45:00',
+        TRANSITION: '17:20:00'
+      }
+    };
+
+    const res = await request(app).post('/api/attendance/test-weighted-prediction').send(body);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('success', true);
+    expect(res.body.data).toMatchObject({
+      scenario: 'Auto Checkout - Custom Weights',
+      expected_range: '17:00-18:00',
+      cr: null,
+      match: true
+    });
+    expect(res.body.data).toHaveProperty('predicted_checkout');
   });
 });

--- a/tests/autoCheckout.test.js
+++ b/tests/autoCheckout.test.js
@@ -4,7 +4,13 @@ describe('Smart Auto Checkout FAHP Logic', () => {
   const targetDate = '2025-09-20';
   const timeIn = new Date('2025-09-20T09:00:00+07:00');
   const fallbackEndStr = '18:00:00';
-  const weights = [0.4, 0.2, 0.2, 0.2]; // [HIST, CHECKIN, CONTEXT, TRANSITION]
+  const smartAcWeights = fuzzyEngine.getSmartAcAhpWeights();
+  const weights = [
+    smartAcWeights.history,
+    smartAcWeights.checkin_pattern,
+    smartAcWeights.context,
+    smartAcWeights.transition
+  ];
 
   it('menggabungkan semua kandidat saat tersedia', () => {
     const candidates = {

--- a/tests/bookingsControllerReadiness.test.js
+++ b/tests/bookingsControllerReadiness.test.js
@@ -117,7 +117,7 @@ describe('booking controller readiness regressions', () => {
             },
             notes: 'Needs review',
             suitability_score: '80',
-            suitability_label: 'Tinggi',
+            suitability_label: 'Sangat Baik',
             created_at: new Date('2026-05-01T08:00:00.000Z'),
             processed_at: null,
             approved_by: null

--- a/tests/clientCriticalOpenApiContract.test.js
+++ b/tests/clientCriticalOpenApiContract.test.js
@@ -411,7 +411,7 @@ describe('client-critical OpenAPI contract', () => {
       information: { type: 'string', example: 'Work Duration: 8h' },
       notes: { type: 'string', example: '' },
       discipline_score: { type: 'number', format: 'float', nullable: true, example: 88 },
-      discipline_label: { type: 'string', nullable: true, example: 'Tinggi' },
+      discipline_label: { type: 'string', nullable: true, example: 'Sangat Baik' },
       discipline_breakdown: { type: 'object', nullable: true, additionalProperties: true }
     });
     expect(detailRowProperties).not.toHaveProperty('user');

--- a/tests/dashboardAnalyticsHelper.test.js
+++ b/tests/dashboardAnalyticsHelper.test.js
@@ -72,9 +72,9 @@ describe('dashboard analytics helper contract', () => {
         values: [0.6, 0.4]
       },
       ranking: [
-        { id: 9, name: 'Outsider', score: 99, label: 'Sangat Tinggi' },
-        { id: 7, name: 'Febri', score: 84, label: 'Tinggi' },
-        { id: 8, name: 'Diana', score: 80, label: 'Sedang' }
+        { id: 9, name: 'Outsider', score: 99, label: 'Sangat Baik' },
+        { id: 7, name: 'Febri', score: 84, label: 'Sangat Baik' },
+        { id: 8, name: 'Diana', score: 80, label: 'Sangat Baik' }
       ]
     });
 
@@ -85,8 +85,8 @@ describe('dashboard analytics helper contract', () => {
         values: [0.55, 0.45]
       },
       ranking: [
-        { id: 31, name: 'Cafe Satu', score: 90, label: 'Sangat Tinggi' },
-        { id: 32, name: 'Library Dua', score: 70, label: 'Tinggi' }
+        { id: 31, name: 'Cafe Satu', score: 90, label: 'Sangat Baik' },
+        { id: 32, name: 'Library Dua', score: 70, label: 'Baik' }
       ]
     });
 
@@ -97,9 +97,9 @@ describe('dashboard analytics helper contract', () => {
         values: [0.4, 0.6]
       },
       ranking: [
-        { id: 99, name: 'Untracked User', score: 95, label: 'Sangat Tinggi' },
-        { id: 8, name: 'Diana', score: 72, label: 'Tinggi' },
-        { id: 7, name: 'Febri', score: 65, label: 'Sedang' }
+        { id: 99, name: 'Untracked User', score: 95, label: 'Sangat Baik' },
+        { id: 8, name: 'Diana', score: 72, label: 'Baik' },
+        { id: 7, name: 'Febri', score: 65, label: 'Baik' }
       ]
     });
 
@@ -235,11 +235,10 @@ describe('dashboard analytics helper contract', () => {
           id: 7,
           name: 'Febri',
           score: 84,
-          label: 'Tinggi'
+          label: 'Sangat Baik'
         },
         distribution: {
-          Tinggi: 1,
-          Sedang: 1
+          'Sangat Baik': 2
         }
       },
       wfa: {
@@ -255,11 +254,11 @@ describe('dashboard analytics helper contract', () => {
           id: 31,
           name: 'Cafe Satu',
           score: 90,
-          label: 'Sangat Tinggi'
+          label: 'Sangat Baik'
         },
         distribution: {
-          'Sangat Tinggi': 1,
-          Tinggi: 1
+          'Sangat Baik': 1,
+          Baik: 1
         }
       },
       smart_ac: {
@@ -275,11 +274,10 @@ describe('dashboard analytics helper contract', () => {
           id: 8,
           name: 'Diana',
           score: 72,
-          label: 'Tinggi'
+          label: 'Baik'
         },
         distribution: {
-          Tinggi: 1,
-          Sedang: 1
+          Baik: 2
         }
       }
     });
@@ -320,11 +318,11 @@ describe('dashboard analytics helper contract', () => {
 
     mockLocationEventFindAll.mockResolvedValueOnce([]);
     mockBuildDisciplineAnalysis.mockResolvedValueOnce({
-      ranking: [{ id: 7, name: 'Febri', score: 55, label: 'Sedang' }]
+      ranking: [{ id: 7, name: 'Febri', score: 55, label: 'Baik' }]
     });
     mockBuildWfaAnalysis.mockResolvedValueOnce({ ranking: [] });
     mockBuildSmartAcAnalysis.mockResolvedValueOnce({
-      ranking: [{ id: 7, name: 'Febri', score: 40, label: 'Sedang' }]
+      ranking: [{ id: 7, name: 'Febri', score: 40, label: 'Cukup' }]
     });
     const result = await buildDashboardAnalytics({
       period: 'custom',

--- a/tests/discipline.test.js
+++ b/tests/discipline.test.js
@@ -11,7 +11,7 @@ describe('Discipline Index FAHP Logic', () => {
     jest.clearAllMocks();
   });
 
-  it('menghasilkan label "Sangat Rendah" untuk profil disiplin sangat buruk', async () => {
+  it('menghasilkan label "Rendah" untuk profil disiplin sangat buruk', async () => {
     const input = {
       alpha_rate: 90,
       avg_lateness_minutes: 55,
@@ -21,10 +21,10 @@ describe('Discipline Index FAHP Logic', () => {
     const result = await fuzzyEngine.calculateDisciplineIndex(input);
     expect(result).toHaveProperty('score');
     expect(result).toHaveProperty('label');
-    expect(result.label).toBe('Sangat Rendah');
+    expect(result.label).toBe('Rendah');
   });
 
-  it('menghasilkan label "Rendah" untuk profil disiplin rendah', async () => {
+  it('menghasilkan label "Cukup" untuk profil disiplin rendah', async () => {
     const input = {
       alpha_rate: 60,
       avg_lateness_minutes: 40,
@@ -32,10 +32,10 @@ describe('Discipline Index FAHP Logic', () => {
       work_hour_consistency: 20
     };
     const result = await fuzzyEngine.calculateDisciplineIndex(input);
-    expect(result.label).toBe('Sedang');
+    expect(result.label).toBe('Cukup');
   });
 
-  it('menghasilkan label "Sedang" untuk profil disiplin sedang', async () => {
+  it('menghasilkan label "Baik" untuk profil disiplin sedang', async () => {
     const input = {
       alpha_rate: 30,
       avg_lateness_minutes: 25,
@@ -43,10 +43,10 @@ describe('Discipline Index FAHP Logic', () => {
       work_hour_consistency: 50
     };
     const result = await fuzzyEngine.calculateDisciplineIndex(input);
-    expect(result.label).toBe('Tinggi');
+    expect(result.label).toBe('Baik');
   });
 
-  it('menghasilkan label "Tinggi" untuk profil disiplin baik', async () => {
+  it('menghasilkan label "Sangat Baik" untuk profil disiplin baik', async () => {
     const input = {
       alpha_rate: 15,
       avg_lateness_minutes: 10,
@@ -54,10 +54,10 @@ describe('Discipline Index FAHP Logic', () => {
       work_hour_consistency: 75
     };
     const result = await fuzzyEngine.calculateDisciplineIndex(input);
-    expect(result.label).toBe('Sangat Tinggi');
+    expect(result.label).toBe('Sangat Baik');
   });
 
-  it('menghasilkan label "Sangat Tinggi" untuk profil disiplin sangat baik', async () => {
+  it('menghasilkan label "Sangat Baik" untuk profil disiplin sangat baik', async () => {
     const input = {
       alpha_rate: 0,
       avg_lateness_minutes: 0,
@@ -65,6 +65,6 @@ describe('Discipline Index FAHP Logic', () => {
       work_hour_consistency: 100
     };
     const result = await fuzzyEngine.calculateDisciplineIndex(input);
-    expect(result.label).toBe('Sangat Tinggi');
+    expect(result.label).toBe('Sangat Baik');
   });
 });

--- a/tests/disciplineAllQueryPlan.test.js
+++ b/tests/disciplineAllQueryPlan.test.js
@@ -5,7 +5,7 @@ const mockAttendanceFindAll = jest.fn();
 const mockGetDisciplineAhpWeights = jest.fn(() => ({ lateness: 0.25 }));
 const mockCalculateDisciplineIndex = jest.fn(async () => ({
   score: 82,
-  label: 'Tinggi'
+  label: 'Sangat Baik'
 }));
 const mockLoggerInfo = jest.fn();
 

--- a/tests/fahp.test.js
+++ b/tests/fahp.test.js
@@ -1,23 +1,33 @@
-import { fgmWeightsTFN, computeCR, defuzzifyMatrixTFN } from '../src/analytics/fahp.js';
-import { TFN, WFA_PAIRWISE_TFN, DISC_PAIRWISE_TFN } from '../src/analytics/config.fahp.js';
+import { computeCR, defuzzifyMatrixTFN } from '../src/analytics/fahp.js';
+import { extentWeightsTFN } from '../src/analytics/fahp.extent.js';
+import { TFN, WFA_PAIRWISE_TFN, DISC_PAIRWISE_TFN, SMART_AC_PAIRWISE_TFN } from '../src/analytics/config.fahp.js';
 import { labelEqualInterval } from '../src/analytics/labeling.js';
 
-test('FGM produces normalized weights (sum=1) - custom matrix', () => {
-  const M = [
+test("Chang's extent produces normalized weights for a custom TFN matrix", () => {
+  const matrix = [
     [TFN.EQUAL, TFN.MODERATE, TFN.STRONG],
     [[1 / 4, 1 / 3, 1 / 2], TFN.EQUAL, TFN.MODERATE],
     [[1 / 7, 1 / 5, 1 / 3], [1 / 4, 1 / 3, 1 / 2], TFN.EQUAL]
   ];
-  const w = fgmWeightsTFN(M);
-  const sum = w.reduce((a, b) => a + b, 0);
+  const weights = extentWeightsTFN(matrix);
+  const sum = weights.reduce((a, b) => a + b, 0);
+
+  expect(weights).toHaveLength(3);
+  expect(weights.every((value) => value >= 0)).toBe(true);
   expect(Math.abs(sum - 1)).toBeLessThan(1e-6);
 });
 
-test('FGM normalized weights for WFA and DISC profiles', () => {
-  const wfaW = fgmWeightsTFN(WFA_PAIRWISE_TFN);
-  const discW = fgmWeightsTFN(DISC_PAIRWISE_TFN);
-  expect(Math.abs(wfaW.reduce((a,b)=>a+b,0) - 1)).toBeLessThan(1e-6);
-  expect(Math.abs(discW.reduce((a,b)=>a+b,0) - 1)).toBeLessThan(1e-6);
+test("Chang's extent is the official normalized weighting path for WFA, discipline, and Smart AC", () => {
+  const weightSets = [
+    extentWeightsTFN(WFA_PAIRWISE_TFN),
+    extentWeightsTFN(DISC_PAIRWISE_TFN),
+    extentWeightsTFN(SMART_AC_PAIRWISE_TFN)
+  ];
+
+  for (const weights of weightSets) {
+    expect(weights.every((value) => value >= 0)).toBe(true);
+    expect(Math.abs(weights.reduce((a, b) => a + b, 0) - 1)).toBeLessThan(1e-6);
+  }
 });
 
 test('CR is small for near-consistent crisp matrix', () => {
@@ -33,16 +43,20 @@ test('CR is small for near-consistent crisp matrix', () => {
 test('CR from defuzzified TFN matrices is reasonable', () => {
   const wfaCrisp = defuzzifyMatrixTFN(WFA_PAIRWISE_TFN);
   const discCrisp = defuzzifyMatrixTFN(DISC_PAIRWISE_TFN);
+  const smartAcCrisp = defuzzifyMatrixTFN(SMART_AC_PAIRWISE_TFN);
   const { CR: crWfa } = computeCR(wfaCrisp);
   const { CR: crDisc } = computeCR(discCrisp);
+  const { CR: crSmartAc } = computeCR(smartAcCrisp);
   expect(crWfa).toBeLessThan(0.2);
   expect(crDisc).toBeLessThan(0.2);
+  expect(crSmartAc).toBeLessThan(0.2);
 });
 
-test('Labeling equal interval works as expected', () => {
-  expect(labelEqualInterval(0.19)).toBe('Sangat Rendah');
-  expect(labelEqualInterval(0.21)).toBe('Rendah');
-  expect(labelEqualInterval(0.59)).toBe('Sedang');
-  expect(labelEqualInterval(0.61)).toBe('Tinggi');
-  expect(labelEqualInterval(0.81)).toBe('Sangat Tinggi');
+test('Labeling equal interval uses the 4-bucket threshold 0-25-50-75', () => {
+  expect(labelEqualInterval(0.24)).toBe('Rendah');
+  expect(labelEqualInterval(0.25)).toBe('Cukup');
+  expect(labelEqualInterval(0.49)).toBe('Cukup');
+  expect(labelEqualInterval(0.5)).toBe('Baik');
+  expect(labelEqualInterval(0.74)).toBe('Baik');
+  expect(labelEqualInterval(0.75)).toBe('Sangat Baik');
 });

--- a/tests/summaryDashboardAnalyticsSeam.test.js
+++ b/tests/summaryDashboardAnalyticsSeam.test.js
@@ -145,9 +145,9 @@ describe('summary dashboard analytics seam', () => {
         values: [0.6, 0.4]
       },
       ranking: [
-        { id: 9, name: 'Outsider', score: 99, label: 'Sangat Tinggi' },
-        { id: 7, name: 'Febri', score: 84, label: 'Tinggi' },
-        { id: 8, name: 'Diana', score: 80, label: 'Sedang' }
+        { id: 9, name: 'Outsider', score: 99, label: 'Sangat Baik' },
+        { id: 7, name: 'Febri', score: 84, label: 'Sangat Baik' },
+        { id: 8, name: 'Diana', score: 80, label: 'Sangat Baik' }
       ]
     });
 
@@ -158,8 +158,8 @@ describe('summary dashboard analytics seam', () => {
         values: [0.55, 0.45]
       },
       ranking: [
-        { id: 31, name: 'Cafe Satu', score: 90, label: 'Sangat Tinggi' },
-        { id: 32, name: 'Library Dua', score: 70, label: 'Tinggi' }
+        { id: 31, name: 'Cafe Satu', score: 90, label: 'Sangat Baik' },
+        { id: 32, name: 'Library Dua', score: 70, label: 'Baik' }
       ]
     });
 
@@ -170,9 +170,9 @@ describe('summary dashboard analytics seam', () => {
         values: [0.4, 0.6]
       },
       ranking: [
-        { id: 99, name: 'Untracked User', score: 95, label: 'Sangat Tinggi' },
-        { id: 8, name: 'Diana', score: 72, label: 'Tinggi' },
-        { id: 7, name: 'Febri', score: 65, label: 'Sedang' }
+        { id: 99, name: 'Untracked User', score: 95, label: 'Sangat Baik' },
+        { id: 8, name: 'Diana', score: 72, label: 'Baik' },
+        { id: 7, name: 'Febri', score: 65, label: 'Baik' }
       ]
     });
 
@@ -282,7 +282,7 @@ describe('summary dashboard analytics seam', () => {
             top_rank: {
               id: 7,
               name: 'Febri',
-              label: 'Tinggi'
+              label: 'Sangat Baik'
             }
           },
           wfa: {
@@ -290,7 +290,7 @@ describe('summary dashboard analytics seam', () => {
             top_rank: {
               id: 31,
               name: 'Cafe Satu',
-              label: 'Sangat Tinggi'
+              label: 'Sangat Baik'
             }
           },
           smart_ac: {
@@ -298,7 +298,7 @@ describe('summary dashboard analytics seam', () => {
             top_rank: {
               id: 8,
               name: 'Diana',
-              label: 'Tinggi'
+              label: 'Baik'
             }
           }
         },

--- a/tests/summaryReportContract.test.js
+++ b/tests/summaryReportContract.test.js
@@ -128,10 +128,15 @@ describe('summary report controller contract', () => {
     mockSettingsFindAll.mockResolvedValueOnce([]);
     mockCalculateDisciplineIndex.mockResolvedValueOnce({
       score: 88,
-      label: 'Tinggi',
+      label: 'Sangat Baik',
       breakdown: { alpha_rate: 0 }
     });
-    mockGetDisciplineLabel.mockReturnValue('Sedang');
+    mockGetDisciplineLabel.mockImplementation((score) => {
+      if (score < 25) return 'Rendah';
+      if (score < 50) return 'Cukup';
+      if (score < 75) return 'Baik';
+      return 'Sangat Baik';
+    });
     mockBuildUserAttendanceSummary.mockResolvedValueOnce([mockedSummaryRow]);
   });
 

--- a/tests/summarySettingsCache.test.js
+++ b/tests/summarySettingsCache.test.js
@@ -7,7 +7,7 @@ const mockUserFindAll = jest.fn();
 const mockDatabaseQuery = jest.fn();
 const mockFuzzyCalculate = jest.fn(async () => ({
   score: 88,
-  label: 'Sangat Tinggi',
+  label: 'Sangat Baik',
   breakdown: {}
 }));
 
@@ -26,6 +26,7 @@ jest.unstable_mockModule('../src/models/index.js', () => ({
   Photo: {},
   LocationEvent: {},
   AttendanceCategory: {},
+  Booking: {},
   AttendanceStatus: {},
   Division: {},
   Settings: {
@@ -46,7 +47,12 @@ jest.unstable_mockModule('../src/utils/workHourFormatter.js', () => ({
 jest.unstable_mockModule('../src/utils/fuzzyAhpEngine.js', () => ({
   default: {
     calculateDisciplineIndex: mockFuzzyCalculate,
-    getDisciplineLabel: jest.fn(() => 'Sedang')
+    getDisciplineLabel: jest.fn((score) => {
+      if (score < 25) return 'Rendah';
+      if (score < 50) return 'Cukup';
+      if (score < 75) return 'Baik';
+      return 'Sangat Baik';
+    })
   }
 }));
 

--- a/tests/wfa.test.js
+++ b/tests/wfa.test.js
@@ -16,25 +16,25 @@ describe('WFA Recommendation FAHP Logic', () => {
     userLocation: { lat: -6.2, lon: 106.8 }
   };
 
-  it('memberi label "Sangat Rendah" untuk lokasi tidak cocok dan jauh', async () => {
+  it('memberi label "Cukup" untuk lokasi tidak cocok dan jauh', async () => {
     const place = {
       ...basePlace,
       properties: { name: 'Remote Park', categories: ['park'], distance: 3000, amenity_score: 10 }
     };
     const result = await fuzzyEngine.calculateWfaScore(place);
-    expect(result.label).toBe('Rendah');
+    expect(result.label).toBe('Cukup');
   });
 
-  it('memberi label "Rendah" untuk lokasi kurang cocok', async () => {
+  it('memberi label "Baik" untuk lokasi kurang cocok', async () => {
     const place = {
       ...basePlace,
       properties: { name: 'Small Mall', categories: ['mall'], distance: 2500, amenity_score: 30 }
     };
     const result = await fuzzyEngine.calculateWfaScore(place);
-    expect(result.label).toBe('Sedang');
+    expect(result.label).toBe('Baik');
   });
 
-  it('memberi label "Sedang" untuk lokasi rata-rata', async () => {
+  it('memberi label "Baik" untuk lokasi rata-rata', async () => {
     const place = {
       ...basePlace,
       properties: {
@@ -45,24 +45,24 @@ describe('WFA Recommendation FAHP Logic', () => {
       }
     };
     const result = await fuzzyEngine.calculateWfaScore(place);
-    expect(result.label).toBe('Tinggi');
+    expect(result.label).toBe('Baik');
   });
 
-  it('memberi label "Tinggi" untuk lokasi baik', async () => {
+  it('memberi label "Baik" untuk lokasi baik', async () => {
     const place = {
       ...basePlace,
       properties: { name: 'Hotel Meeting', categories: ['hotel'], distance: 800, amenity_score: 70 }
     };
     const result = await fuzzyEngine.calculateWfaScore(place);
-    expect(result.label).toBe('Tinggi');
+    expect(result.label).toBe('Baik');
   });
 
-  it('memberi label "Sangat Tinggi" untuk cafe dekat dengan fasilitas bagus', async () => {
+  it('memberi label "Sangat Baik" untuk cafe dekat dengan fasilitas bagus', async () => {
     const place = {
       ...basePlace,
       properties: { name: 'Coffee Lab', categories: ['cafe'], distance: 200, amenity_score: 90 }
     };
     const result = await fuzzyEngine.calculateWfaScore(place);
-    expect(result.label).toBe('Sangat Tinggi');
+    expect(result.label).toBe('Sangat Baik');
   });
 });


### PR DESCRIPTION
Scope: GET /api/analysis/fuzzy-ahp canonical (discipline, wfa, smart_ac), WIB +07:00 timestamps, scoped attendance fetch, deterministic Smart AC source, consistency CR/CI/lambda_max/threshold/is_consistent/verdict, OpenAPI sync, contract tests. Out of scope: INF-172 read-only FAHP evidence script (tracked separately).