### PR TITLE
fix: restore legacy FAHP scoring guards after INF-170

### DIFF
--- a/src/services/fuzzyAhpAnalysis.service.js
+++ b/src/services/fuzzyAhpAnalysis.service.js
@@ -605,19 +605,41 @@ const buildSmartAcMetrics = async (user, startAt, endAt) => {
   });
 
   const latest = attendances[0] || null;
-  const event = latest
-    ? await LocationEvent.findOne({
-        where: {
-          user_id: user.id_users
-        }
+  const targetDate = latest?.attendance_date instanceof Date ? formatWibDateOnly(latest.attendance_date) : latest?.attendance_date;
+  const expectedLocation = latest
+    ? await resolveExpectedLocationEvidence({
+        attendance: latest,
+        userId: user.id_users,
+        targetDate
       })
     : null;
+  const eventStartAt = latest?.time_in
+    ? new Date(Math.max(new Date(latest.time_in).getTime(), startAt.getTime()))
+    : startAt;
+  const transitionDayEndAt = targetDate ? parseWibDateOnly(targetDate, true) : endAt;
+  const transitionUpperBoundAt = transitionDayEndAt.getTime() < endAt.getTime() ? transitionDayEndAt : endAt;
+  const transitionEvent =
+    latest?.time_in && expectedLocation?.location_id != null
+      ? await LocationEvent.findOne({
+          where: {
+            user_id: user.id_users,
+            event_type: 'EXIT',
+            location_id: expectedLocation.location_id,
+            event_timestamp: {
+              [Op.gte]: eventStartAt,
+              [Op.lte]: transitionUpperBoundAt
+            }
+          },
+          order: [['event_timestamp', 'DESC']]
+        })
+      : null;
+  const transitionCandidate = transitionEvent?.event_timestamp ? new Date(transitionEvent.event_timestamp) : null;
 
   return {
     history_checkout_minutes: latest?.time_out ? getJakartaMinutesOfDay(latest.time_out) : 0,
     checkin_pattern_minutes: latest?.time_in ? getJakartaMinutesOfDay(latest.time_in) : 0,
-    context_checkout_minutes: event?.event_timestamp ? getJakartaMinutesOfDay(event.event_timestamp) : 0,
-    transition_checkout_minutes: latest?.notes?.includes('TRANSITION') ? 15 : 0
+    context_checkout_minutes: transitionCandidate ? getJakartaMinutesOfDay(transitionCandidate) : 0,
+    transition_checkout_minutes: transitionCandidate ? getJakartaMinutesOfDay(transitionCandidate) : 0
   };
 };
 

--- a/src/utils/fuzzyAhpEngine.js
+++ b/src/utils/fuzzyAhpEngine.js
@@ -4,7 +4,7 @@ import { extentWeightsTFN } from '../analytics/fahp.extent.js';
 import { minMax } from '../analytics/normalization.js';
 import { labelEqualInterval } from '../analytics/labeling.js';
 import { WFA_PAIRWISE_TFN, DISC_PAIRWISE_TFN, SMART_AC_PAIRWISE_TFN } from '../analytics/config.fahp.js';
-import { calculateDistance, toJakartaTime } from './geofence.js';
+import { calculateDistance } from './geofence.js';
 
 // Simple memoization for FAHP weights
 let cachedWfaWeights = null;
@@ -83,6 +83,29 @@ function getWfaAhpWeights() {
   };
 }
 
+const parseFiniteNumber = (value, fieldName) => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  throw new Error(`${fieldName} must be numeric`);
+};
+
+const categoryTokens = (categories = []) =>
+  categories.flatMap((category) =>
+    String(category)
+      .toLowerCase()
+      .split(/[._-]/)
+      .filter(Boolean)
+  );
+
 // --- Public API: calculateWfaScore(place, ahpWeights?) ---
 async function calculateWfaScore(placeDetails, ahpWeights = null) {
   try {
@@ -91,6 +114,7 @@ async function calculateWfaScore(placeDetails, ahpWeights = null) {
 
     // r_loc: map simple categories to [0,1]
     const categories = placeDetails.properties?.categories || [];
+    const tokens = categoryTokens(categories);
     const name = (placeDetails.properties?.name || '').toLowerCase();
     const isCafe =
       categories.some((c) => c.includes('cafe') || c.includes('coffee')) ||
@@ -107,9 +131,17 @@ async function calculateWfaScore(placeDetails, ahpWeights = null) {
       categories.some((c) => c.includes('restaurant') || c.includes('food')) ||
       name.includes('restaurant') ||
       name.includes('restoran');
+    const isLowSuitability =
+      tokens.some((token) => ['industrial', 'warehouse', 'factory', 'manufacturing', 'storage', 'yard'].includes(token)) ||
+      name.includes('industrial') ||
+      name.includes('warehouse') ||
+      name.includes('factory') ||
+      name.includes('manufacturing') ||
+      name.includes('storage');
 
     let loc01 = 0.4;
-    if (isCafe) loc01 = 1.0;
+    if (isLowSuitability) loc01 = 0.1;
+    else if (isCafe) loc01 = 1.0;
     else if (isLibrary) loc01 = 0.85;
     else if (isHotel) loc01 = 0.75;
     else if (isRestaurant) loc01 = 0.65;
@@ -131,13 +163,14 @@ async function calculateWfaScore(placeDetails, ahpWeights = null) {
     } catch (e) {
       logger.debug(`Distance fallback failed: ${e.message}`);
     }
-    if (distanceMeters == null || Number.isNaN(distanceMeters)) distanceMeters = 1000;
+    if (distanceMeters == null) distanceMeters = 1000;
+    distanceMeters = parseFiniteNumber(distanceMeters, 'distance');
     const r_dist = minMax(distanceMeters, 0, 3000, 'cost');
 
     // Amenity score: expect 0..100 if provided; fallback simple inference
     let amen = 50;
     if (placeDetails.properties?.amenity_score != null) {
-      amen = Number(placeDetails.properties.amenity_score);
+      amen = parseFiniteNumber(placeDetails.properties.amenity_score, 'amenity_score');
     }
     const r_amen = Math.max(0, Math.min(1, amen / 100));
 
@@ -164,7 +197,11 @@ async function calculateWfaScore(placeDetails, ahpWeights = null) {
     return result;
   } catch (error) {
     logger.error('Error calculating WFA score (FAHP):', error);
-    return { score: 50, label: 'Sedang', breakdown: { error: error.message } };
+    return {
+      score: 0,
+      label: labelEqualInterval(0),
+      breakdown: { error: error.message }
+    };
   }
 }
 

--- a/tests/analysisFuzzyAhpContract.test.js
+++ b/tests/analysisFuzzyAhpContract.test.js
@@ -104,6 +104,7 @@ const makeRes = () => ({
 
 describe('analysis fuzzy ahp contract', () => {
   beforeEach(() => {
+    jest.useRealTimers();
     jest.clearAllMocks();
     allowRole = true;
 
@@ -305,19 +306,24 @@ describe('analysis fuzzy ahp contract', () => {
     );
   });
 
-  it('returns user-ranked analysis for smart_ac mode', async () => {
+  it('returns user-ranked analysis for smart_ac mode using the scoped transition event as both context and transition evidence', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-04-21T10:30:00.000Z'));
+
     mockUser.findAll.mockResolvedValue([{ id_users: 9, full_name: 'Sinta' }]);
     mockAttendance.findAll.mockResolvedValue([
       {
+        user_id: 9,
+        location_id: 5,
         time_in: '2026-04-21T01:00:00.000Z',
         time_out: '2026-04-21T10:00:00.000Z',
         attendance_date: '2026-04-21',
         work_hour: 8,
-        notes: '[Smart AC] pred=17:00:00, used=17:15:00, basis=HIST,TRANSITION, dur=08:15:00'
+        notes: '',
+        attendance_category: { category_name: 'WFO' }
       }
     ]);
     mockLocationEvent.findOne.mockResolvedValue({
-      event_timestamp: '2026-04-21T09:15:00.000Z'
+      event_timestamp: '2026-04-21T10:00:00.000Z'
     });
 
     const req = {
@@ -334,11 +340,29 @@ describe('analysis fuzzy ahp contract', () => {
     const response = res.json.mock.calls[0][0];
     const [rankedUser] = response.data.ranking;
 
+    expect(mockLocationEvent.findOne).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          user_id: 9,
+          event_type: 'EXIT',
+          location_id: 5,
+          event_timestamp: expect.objectContaining({
+            [Op.gte]: expect.any(Date),
+            [Op.lte]: expect.any(Date)
+          })
+        }),
+        order: [['event_timestamp', 'DESC']]
+      })
+    );
+
+    const eventQuery = mockLocationEvent.findOne.mock.calls[0][0].where.event_timestamp;
+    expect(eventQuery[Op.lte].toISOString()).toBe('2026-04-21T10:30:00.000Z');
+
     expect(rankedUser.breakdown).toEqual({
       history_checkout_minutes: 1020,
       checkin_pattern_minutes: 480,
-      context_checkout_minutes: 975,
-      transition_checkout_minutes: 15
+      context_checkout_minutes: 1020,
+      transition_checkout_minutes: 1020
     });
     expect(res.json).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -376,6 +400,8 @@ describe('analysis fuzzy ahp contract', () => {
         })
       })
     );
+
+    jest.useRealTimers();
   });
 
   it('returns 200 with empty ranking and zeroed distribution when no valid entities exist', async () => {

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -64,10 +64,10 @@ describe('FAHP Dynamic Test Endpoint', () => {
     expect(res.body.data).not.toHaveProperty('interpretation');
   });
 
-  it('POST /api/wfa/test-ahp returns Cukup with canonical CR', async () => {
+  it('POST /api/wfa/test-ahp returns Rendah with canonical CR for low-suitability places', async () => {
     const body = {
-      scenario: 'WFA - Cukup',
-      expected: 'Cukup',
+      scenario: 'WFA - Rendah',
+      expected: 'Rendah',
       place_data: {
         properties: {
           name: 'Remote Industrial Yard',
@@ -85,9 +85,9 @@ describe('FAHP Dynamic Test Endpoint', () => {
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty('success', true);
     expect(res.body.data).toMatchObject({
-      scenario: 'WFA - Cukup',
-      expected: 'Cukup',
-      category: 'Cukup',
+      scenario: 'WFA - Rendah',
+      expected: 'Rendah',
+      category: 'Rendah',
       match: true
     });
     expect(res.body.data.cr).toBeCloseTo(0.058, 3);

--- a/tests/wfa.test.js
+++ b/tests/wfa.test.js
@@ -1,5 +1,6 @@
 import { jest } from '@jest/globals';
 import fuzzyEngine from '../src/utils/fuzzyAhpEngine.js';
+import logger from '../src/utils/logger.js';
 
 describe('WFA Recommendation FAHP Logic', () => {
   beforeAll(() => {
@@ -8,6 +9,11 @@ describe('WFA Recommendation FAHP Logic', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.spyOn(logger, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   const basePlace = {
@@ -55,6 +61,179 @@ describe('WFA Recommendation FAHP Logic', () => {
     };
     const result = await fuzzyEngine.calculateWfaScore(place);
     expect(result.label).toBe('Baik');
+  });
+
+  it('memberi penalti eksplisit untuk lokasi low-suitability seperti warehouse', async () => {
+    const place = {
+      ...basePlace,
+      properties: {
+        name: 'Warehouse Yard',
+        categories: ['industrial.warehouse'],
+        distance: 1000,
+        amenity_score: 50
+      }
+    };
+    const result = await fuzzyEngine.calculateWfaScore(place);
+    expect(result.breakdown.location_score).toBe(10);
+  });
+
+  it('tetap memberi penalti low-suitability meski kategori juga mengandung park', async () => {
+    const place = {
+      ...basePlace,
+      properties: {
+        name: 'Industrial Park Yard',
+        categories: ['industrial.park'],
+        distance: 1000,
+        amenity_score: 50
+      }
+    };
+    const result = await fuzzyEngine.calculateWfaScore(place);
+    expect(result.breakdown.location_score).toBe(10);
+  });
+
+  it('memprioritaskan penalti low-suitability meski kategori juga mengandung cafe', async () => {
+    const place = {
+      ...basePlace,
+      properties: {
+        name: 'Factory Cafe Annex',
+        categories: ['cafe', 'industrial.factory'],
+        distance: 1000,
+        amenity_score: 50
+      }
+    };
+    const result = await fuzzyEngine.calculateWfaScore(place);
+    expect(result.breakdown.location_score).toBe(10);
+  });
+
+  it('tidak menghukum venue yang hanya kebetulan mengandung substring yard pada nama', async () => {
+    const place = {
+      ...basePlace,
+      properties: {
+        name: 'Courtyard Coffee',
+        categories: ['cafe'],
+        distance: 200,
+        amenity_score: 90
+      }
+    };
+    const result = await fuzzyEngine.calculateWfaScore(place);
+    expect(result.breakdown.location_score).toBe(100);
+  });
+
+  it('tidak menghukum kategori yang hanya kebetulan mengandung substring yard', async () => {
+    const place = {
+      ...basePlace,
+      properties: {
+        name: 'Vineyard Cafe',
+        categories: ['tourism.vineyard', 'cafe'],
+        distance: 200,
+        amenity_score: 90
+      }
+    };
+    const result = await fuzzyEngine.calculateWfaScore(place);
+    expect(result.breakdown.location_score).toBe(100);
+  });
+
+  it('fail-closed ke skor terendah ketika payload tempat malformed', async () => {
+    const result = await fuzzyEngine.calculateWfaScore(null);
+    expect(result.score).toBe(0);
+    expect(result.label).toBe('Rendah');
+    expect(result.breakdown).toEqual(expect.objectContaining({ error: expect.any(String) }));
+  });
+
+  it('fail-closed ketika distance bukan angka', async () => {
+    const place = {
+      ...basePlace,
+      properties: {
+        name: 'Broken Distance Cafe',
+        categories: ['cafe'],
+        distance: 'nearby',
+        amenity_score: 90
+      }
+    };
+    const result = await fuzzyEngine.calculateWfaScore(place);
+    expect(result.score).toBe(0);
+    expect(result.label).toBe('Rendah');
+    expect(result.breakdown).toEqual(expect.objectContaining({ error: expect.any(String) }));
+  });
+
+  it('fail-closed ketika distance string kosong', async () => {
+    const place = {
+      ...basePlace,
+      properties: {
+        name: 'Blank Distance Cafe',
+        categories: ['cafe'],
+        distance: '   ',
+        amenity_score: 90
+      }
+    };
+    const result = await fuzzyEngine.calculateWfaScore(place);
+    expect(result.score).toBe(0);
+    expect(result.label).toBe('Rendah');
+    expect(result.breakdown).toEqual(expect.objectContaining({ error: expect.any(String) }));
+  });
+
+  it('fail-closed ketika amenity_score bukan angka', async () => {
+    const place = {
+      ...basePlace,
+      properties: {
+        name: 'Unknown Amenity Cafe',
+        categories: ['cafe'],
+        distance: 200,
+        amenity_score: 'unknown'
+      }
+    };
+    const result = await fuzzyEngine.calculateWfaScore(place);
+    expect(result.score).toBe(0);
+    expect(result.label).toBe('Rendah');
+    expect(result.breakdown).toEqual(expect.objectContaining({ error: expect.any(String) }));
+  });
+
+  it('fail-closed ketika amenity_score string kosong', async () => {
+    const place = {
+      ...basePlace,
+      properties: {
+        name: 'Blank Amenity Cafe',
+        categories: ['cafe'],
+        distance: 200,
+        amenity_score: ' '
+      }
+    };
+    const result = await fuzzyEngine.calculateWfaScore(place);
+    expect(result.score).toBe(0);
+    expect(result.label).toBe('Rendah');
+    expect(result.breakdown).toEqual(expect.objectContaining({ error: expect.any(String) }));
+  });
+
+  it('fail-closed ketika distance bertipe boolean', async () => {
+    const place = {
+      ...basePlace,
+      properties: {
+        name: 'Boolean Distance Cafe',
+        categories: ['cafe'],
+        distance: false,
+        amenity_score: 90
+      }
+    };
+    const result = await fuzzyEngine.calculateWfaScore(place);
+    expect(result.score).toBe(0);
+    expect(result.label).toBe('Rendah');
+    expect(result.breakdown).toEqual(expect.objectContaining({ error: expect.any(String) }));
+  });
+
+  it('fail-closed ketika amenity_score bertipe boolean', async () => {
+    const place = {
+      ...basePlace,
+      properties: {
+        name: 'Boolean Amenity Cafe',
+        categories: ['cafe'],
+        distance: 200,
+        amenity_score: false
+      }
+    };
+    const result = await fuzzyEngine.calculateWfaScore(place);
+    expect(result.score).toBe(0);
+    expect(result.label).toBe('Rendah');
+    expect(result.breakdown).toEqual(expect.objectContaining({ error: expect.any(String) }));
   });
 
   it('memberi label "Sangat Baik" untuk cafe dekat dengan fasilitas bagus', async () => {


### PR DESCRIPTION
## Summary
- restore legacy Smart AC transition-event sourcing so legacy `/api/analysis/fuzzy-ahp?type=smart_ac` no longer reads arbitrary `LocationEvent` rows
- restore explicit low-suitability penalties in legacy WFA scoring for industrial / warehouse / factory / storage / yard-like places
- change malformed legacy WFA input handling from fail-open to fail-closed
- align the dynamic WFA regression fixture with the restored low-suitability rule

## Root-cause scope
This follow-up is intentionally narrow and targets the legacy compatibility/scoring surface after PR #51.

Fixed findings:
1. legacy Smart AC was querying `LocationEvent.findOne({ user_id })` without event type / expected location / bounded time window
2. legacy Smart AC transition metric had collapsed to a hardcoded `15` when notes contained `TRANSITION`
3. legacy WFA low-suitability places were no longer explicitly penalized
4. legacy WFA scorer could fail-open on malformed inputs

What I intentionally did **not** change:
- dedicated endpoint contracts
- RBAC / auth
- attendance final-state or scheduler semantics
- broader redesign of legacy Smart AC context vs transition semantics beyond restoring scoped event selection

## Files changed
- `src/services/fuzzyAhpAnalysis.service.js`
- `src/utils/fuzzyAhpEngine.js`
- `tests/analysisFuzzyAhpContract.test.js`
- `tests/wfa.test.js`
- `tests/api.test.js`

## Verification
Fresh verification on this branch:
- `npm test -- --runTestsByPath tests/wfa.test.js --runInBand`
- `npm test -- --runTestsByPath tests/analysisFuzzyAhpContract.test.js tests/wfa.test.js --runInBand`
- `npm run lint`
- `npm test`

Result:
- `70` test suites passed
- `461` tests passed
- `0` failed

## Risk / compatibility note
- This patch changes legacy FAHP scoring semantics to restore stricter, safer behavior.
- Legacy WFA now fail-closes for malformed numeric inputs instead of returning neutral-medium scores.
- Low-suitability category matching is stricter, including mixed-category overlap cases.

## Docs / ADR update note
**DOCS/ADR UPDATE REQUIRED**

This fix touches FAHP/scoring semantics and legacy compatibility behavior. At minimum, the PR/review trail should record:
- what legacy behavior was restored
- what was intentionally left unchanged as out-of-scope redesign
- the fresh verification evidence above

## Refs
- follow-up to PR #51
- INF-170


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Smart AC checkout time metrics by deriving them from actual location events within proper time windows.
  * Enhanced WFA location suitability scoring to better identify and penalize unsuitable work environments.
  * Strengthened input validation with fail-safe error handling for malformed data in score calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->