### PR TITLE
feat: lock dashboard-only contract surfaces

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1204,6 +1204,138 @@ paths:
         '403':
           $ref: '#/components/responses/Forbidden'
 
+  /api/analysis/fuzzy-ahp/dashboard:
+    get:
+      tags:
+        - Analysis
+      summary: Get dashboard recap for Fuzzy AHP analysis
+      description: Retrieve a dashboard-specific monthly recap for a single FAHP type. This additive route reuses the legacy `type` query values `discipline`, `wfa`, and `smart_ac`, applies the monthly window internally, and does not expose the full dedicated detail payloads.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: type
+          required: true
+          description: Required dashboard recap type selector using the legacy combined-contract values.
+          schema:
+            type: string
+            enum: [discipline, wfa, smart_ac]
+      responses:
+        '200':
+          description: Fuzzy AHP dashboard recap retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                        enum: [discipline, wfa, smart_ac]
+                      type_label:
+                        type: string
+                        example: Discipline
+                      generated_at:
+                        type: string
+                        format: date-time
+                      timezone:
+                        type: string
+                        example: Asia/Jakarta
+                      requested_window:
+                        type: object
+                        properties:
+                          period:
+                            type: string
+                            example: monthly
+                      executed_window:
+                        type: object
+                        properties:
+                          start_at:
+                            type: string
+                            format: date-time
+                          end_at:
+                            type: string
+                            format: date-time
+                      status:
+                        type: string
+                        example: ready
+                      needs_data:
+                        type: boolean
+                        example: false
+                      consistency:
+                        type: object
+                        properties:
+                          CR:
+                            type: number
+                            format: float
+                          threshold:
+                            type: number
+                            format: float
+                          is_consistent:
+                            type: boolean
+                          summary_label:
+                            type: string
+                            example: Konsistensi dapat diterima
+                      criteria_weights:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            key:
+                              type: string
+                            label:
+                              type: string
+                            display_label:
+                              type: string
+                              example: Disiplin Kehadiran
+                            value:
+                              type: number
+                              format: float
+                      ranking_preview:
+                        type: object
+                        properties:
+                          top_n:
+                            type: integer
+                            example: 5
+                          items:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                rank:
+                                  type: integer
+                                id:
+                                  type: integer
+                                  nullable: true
+                                name:
+                                  type: string
+                                  nullable: true
+                                score:
+                                  type: number
+                                  format: float
+                                  nullable: true
+                                label:
+                                  type: string
+                                  nullable: true
+                      distribution:
+                        type: object
+                        additionalProperties:
+                          type: integer
+                  message:
+                    type: string
+                    example: Fuzzy AHP dashboard recap retrieved successfully
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
   # Attendance Endpoints
   /api/attendance/today-locations:
     get:
@@ -1318,6 +1450,152 @@ paths:
                         latitude: -0.8917
                         longitude: 119.8707
                   message: 'Today locations retrieved successfully'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /api/attendance/geofence-evidence:
+    get:
+      tags:
+        - Attendance
+      summary: Get historical geofence evidence snapshot
+      description: Retrieve context-only geofence enter/exit evidence for a selected historical attendance window. This endpoint supports historical window queries and is not the final attendance authority.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: period
+          schema:
+            type: string
+            enum: [daily, weekly, monthly, range, 30d, current_month, custom]
+            default: 30d
+          description: Historical evidence window. Canonical values are `daily`, `weekly`, `monthly`, and `range` with `from`/`to`. Legacy values `30d`, `current_month`, and `custom` remain temporarily supported. `all` is not supported.
+        - in: query
+          name: from
+          schema:
+            type: string
+            format: date
+            example: '2026-04-01'
+          description: Custom range start date in `YYYY-MM-DD` format. Required when period=range or deprecated period=custom.
+        - in: query
+          name: to
+          schema:
+            type: string
+            format: date
+            example: '2026-04-03'
+          description: Custom range end date in `YYYY-MM-DD` format. Required when period=range or deprecated period=custom.
+      responses:
+        '200':
+          description: Geofence evidence retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  requested_window:
+                    type: object
+                    properties:
+                      period:
+                        type: string
+                        example: custom
+                      from:
+                        type: string
+                        format: date
+                        nullable: true
+                        example: '2026-04-01'
+                      to:
+                        type: string
+                        format: date
+                        nullable: true
+                        example: '2026-04-03'
+                  executed_window:
+                    type: object
+                    properties:
+                      from:
+                        type: string
+                        format: date
+                        nullable: true
+                        example: '2026-04-01'
+                      to:
+                        type: string
+                        format: date
+                        nullable: true
+                        example: '2026-04-03'
+                  data:
+                    type: object
+                    properties:
+                      status:
+                        type: string
+                        enum: [available, needs_data]
+                        example: available
+                      needs_data:
+                        type: boolean
+                        example: false
+                      reason:
+                        type: string
+                        nullable: true
+                        example: null
+                      authority:
+                        type: string
+                        example: context_only
+                      final_attendance_authority:
+                        type: string
+                        example: attendance_records
+                      window:
+                        type: object
+                        properties:
+                          from:
+                            type: string
+                            format: date
+                            nullable: true
+                            example: '2026-04-01'
+                          to:
+                            type: string
+                            format: date
+                            nullable: true
+                            example: '2026-04-03'
+                      raw_counts:
+                        type: object
+                        properties:
+                          total_events:
+                            type: integer
+                            example: 3
+                          enter_events:
+                            type: integer
+                            example: 1
+                          exit_events:
+                            type: integer
+                            example: 2
+                          unique_users:
+                            type: integer
+                            example: 2
+                      operational_context:
+                        type: object
+                        properties:
+                          activity_label:
+                            type: string
+                            example: Active
+                          activity_note:
+                            type: string
+                            example: 2 users generated 3 geofence events in this range.
+                          enter_context:
+                            type: string
+                            example: ENTER events support check-in reminder monitoring.
+                          exit_context:
+                            type: string
+                            example: EXIT events support active-session exit warning monitoring.
+                          dashboard_note:
+                            type: string
+                            example: Location context only. Final attendance validity remains determined by backend attendance records.
+                  message:
+                    type: string
+                    example: Geofence evidence retrieved successfully
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -2811,6 +3089,24 @@ paths:
                               unique_users:
                                 type: integer
                                 example: 2
+                          operational_context:
+                            type: object
+                            properties:
+                              activity_label:
+                                type: string
+                                example: Active
+                              activity_note:
+                                type: string
+                                example: 2 users generated 3 geofence events in this range.
+                              enter_context:
+                                type: string
+                                example: ENTER events support check-in reminder monitoring.
+                              exit_context:
+                                type: string
+                                example: EXIT events support active-session exit warning monitoring.
+                              dashboard_note:
+                                type: string
+                                example: Location context only. Final attendance validity remains determined by backend attendance records.
                       fuzzy_ahp_snapshot:
                         type: object
                         properties:

--- a/docs/reporting-analytics-boundary.md
+++ b/docs/reporting-analytics-boundary.md
@@ -14,15 +14,19 @@ Infinite Track exposes related but distinct read surfaces for reporting, dashboa
 | --- | --- | --- |
 | Historical attendance report, paginated rows, export payloads, legacy summary totals, and per-user attendance summary for the selected report window | `GET /api/summary/reports` | Canonical reporting/export surface. Uses dashboard-native report window semantics: period=daily, period=weekly, period=monthly, or period=range with from/to. Legacy 30d, current_month, and custom remain temporarily supported for backend compatibility. |
 | Transitional access to the same reporting contract during consumer migration | `GET /api/summary` | Deprecated compatibility alias. Must stay behaviorally equivalent to `/api/summary/reports` for the same query. |
-| Dashboard cards, historical trend, mode mix, geofence evidence context, insights, and lightweight FAHP snapshots | `GET /api/summary/dashboard-analytics` | Cockpit/dashboard aggregate surface. Returns top-level `requested_window` and `executed_window`, then section-based analytics under `data.*`; it does not own `map_context` or `today_locations`. |
+| Dashboard cards, historical trend, mode mix, insights, and lightweight FAHP snapshots | `GET /api/summary/dashboard-analytics` | Cockpit/dashboard aggregate surface. Returns top-level `requested_window` and `executed_window`, then section-based analytics under `data.*`; it does not own geofence evidence, `map_context`, or `today_locations`. |
+| Geofence evidence snapshot for a selected historical attendance window | `GET /api/attendance/geofence-evidence` | Dedicated attendance-owned context surface for geofence enter/exit evidence. This is supporting evidence only; final attendance authority remains attendance records. |
 | Today-only/live snapshot map for users who already checked in on the current Jakarta date | `GET /api/attendance/today-locations` | Dedicated operational snapshot surface for the current day. This is context-only map evidence, not a historical aggregation endpoint, final attendance authority, or fraud authority. |
 | Dedicated FAHP analysis contracts | `GET /api/analysis/fuzzy-ahp/discipline`, `GET /api/analysis/fuzzy-ahp/wfa`, `GET /api/analysis/fuzzy-ahp/smart-ac` | Dedicated FAHP surfaces separate discipline evidence, live WFA provider validation, and Smart AC evidence sufficiency. The legacy combined endpoint remains transition-only. |
+| Lightweight monthly FAHP dashboard recap | `GET /api/analysis/fuzzy-ahp/dashboard` | Additive recap-only dashboard surface. Accepts only `type` and is not the canonical detail-analysis contract. |
 
 ## Dashboard analytics contract notes
 - `requested_window` preserves raw client query intent.
 - `executed_window` shows the effective historical window the backend actually executed after resolving defaults.
 - `data.geofence_evidence_context` is contextual evidence only. Final attendance authority remains attendance records.
+- `data.geofence_evidence_context.operational_context` is UI-ready copy derived from geofence event counts, not a separate analytics authority.
 - `data.map_context` and `data.today_locations` are not part of the dashboard analytics contract in this phase.
+- Clients that need geofence evidence must call `/api/attendance/geofence-evidence` directly.
 - Clients that need today/live map points must call `/api/attendance/today-locations` directly.
 
 ## Fuzzy AHP Endpoints Contract
@@ -31,6 +35,7 @@ Infinite Track exposes related but distinct read surfaces for reporting, dashboa
   - `GET /api/analysis/fuzzy-ahp/discipline`
   - `GET /api/analysis/fuzzy-ahp/wfa`
   - `GET /api/analysis/fuzzy-ahp/smart-ac`
+`GET /api/analysis/fuzzy-ahp/dashboard` owns the lightweight monthly dashboard recap contract only; it is not the canonical detail-analysis surface. The recap may add display-friendly fields such as `type_label`, `consistency.summary_label`, and `criteria_weights[].display_label` without changing the underlying detail-analysis contract.
 - The Postman collection `Infinite Track`, folder `FuzzyAhp`, is the primary manual smoke surface for the dedicated FAHP endpoints and contains curated Discipline, WFA, and Smart AC requests.
 - Dedicated FAHP endpoint smoke requests require a Bearer token authorized for `Admin` or `Management` access.
 - This repo document records only route ownership and source-of-truth boundary. Keep detailed per-endpoint validation, examples, and run guidance in Postman instead of duplicating a manual guide here.
@@ -43,12 +48,16 @@ Infinite Track exposes related but distinct read surfaces for reporting, dashboa
 - Do not use `period=all` for `/api/summary/reports`; use `daily`, `weekly`, `monthly`, or `range`.
 - Search filters `report.data` and `report.pagination`; top-level `summary` remains period-wide, while `analytics.discipline_analysis` reflects the visible report users on the current page.
 - Treat `/api/summary` as a temporary deprecated alias during migration; it must return the same contract as `/api/summary/reports`.
-- Use `/api/summary/dashboard-analytics` for dashboard analytics cards, charts, mode mix, geofence evidence context, insights, and FAHP snapshot panels.
+- Use `/api/summary/dashboard-analytics` for dashboard analytics cards, charts, mode mix, insights, and FAHP snapshot panels.
+- Use `/api/attendance/geofence-evidence` for geofence evidence context panels bound to a historical attendance window.
 - Use `/api/attendance/today-locations` for today-focused map widgets or hero maps.
 - Do not pass `period`, `from`, or `to` to `/api/attendance/today-locations`; use `?limit=` only for display cap control.
+- Use `/api/analysis/fuzzy-ahp/dashboard?type=...` only for lightweight monthly dashboard recap panels.
+- Do not pass `period`, `from`, or `to` to `/api/analysis/fuzzy-ahp/dashboard`; only `type` is allowed.
 - Do not treat `/api/summary/dashboard-analytics` as a substitute for reporting/export rows.
 - Do not expect `data.map_context` or `data.today_locations` from `/api/summary/dashboard-analytics`.
-- Do not treat `geofence_evidence_context` or today-locations map presence as final attendance truth or fraud evidence.
+- Do not treat `geofence_evidence_context`, `/api/attendance/geofence-evidence`, or today-locations map presence as final attendance truth or fraud evidence.
+- Do not treat `/api/analysis/fuzzy-ahp/dashboard` as a canonical detail-analysis surface.
 
 ## Map View Contract
 - Consumer: Web FE dashboard cockpit Map View.

--- a/src/controllers/analysis.controller.js
+++ b/src/controllers/analysis.controller.js
@@ -1,6 +1,7 @@
 import {
   buildDisciplineAnalysis,
   buildDisciplineFahpPayload,
+  buildFuzzyAhpDashboardRecapPayload,
   buildSmartAcAnalysis,
   buildSmartAcFahpPayload,
   buildWfaAnalysis,
@@ -8,6 +9,7 @@ import {
   formatWibDateTime,
   getAnalysisWindow
 } from '../services/fuzzyAhpAnalysis.service.js';
+import logger from '../utils/logger.js';
 
 export const getDisciplineFahp = async (req, res, next) => {
   try {
@@ -58,6 +60,25 @@ export const getSmartAcFahp = async (_req, res, next) => {
       message: 'Smart AC Fuzzy AHP analysis retrieved successfully'
     });
   } catch (error) {
+    next(error);
+  }
+};
+
+export const getFuzzyAhpDashboardRecap = async (req, res, next) => {
+  try {
+    const { type } = req.query;
+    const data = await buildFuzzyAhpDashboardRecapPayload({ type });
+
+    return res.status(200).json({
+      success: true,
+      data,
+      message: 'Fuzzy AHP dashboard recap retrieved successfully'
+    });
+  } catch (error) {
+    logger.error('Failed to build FAHP dashboard recap', {
+      error: error.message,
+      query: req.query
+    });
     next(error);
   }
 };

--- a/src/controllers/attendance.controller.js
+++ b/src/controllers/attendance.controller.js
@@ -24,6 +24,7 @@ import { formatWorkHour, calculateWorkHour, formatTimeOnly } from '../utils/work
 import { applySearch } from '../utils/searchHelper.js';
 import { getOperationalSettings } from '../utils/settings.js';
 import { isAttendanceDuplicateConstraintError } from '../utils/attendanceDuplicateError.js';
+import { buildGeofenceEvidenceSnapshot } from '../utils/geofenceEvidenceSnapshot.js';
 import { buildTodayLocationsSnapshot } from '../utils/todayLocationsSnapshot.js';
 import { triggerAutoCheckout, runSmartAutoCheckoutForDate } from '../jobs/autoCheckout.job.js';
 import {
@@ -1267,6 +1268,27 @@ export const getTodayLocations = async (req, res, next) => {
       message: 'Today locations retrieved successfully'
     });
   } catch (error) {
+    next(error);
+  }
+};
+
+export const getGeofenceEvidence = async (req, res, next) => {
+  try {
+    const { period = '30d', from = null, to = null } = req.query;
+    const snapshot = await buildGeofenceEvidenceSnapshot({ period, from, to });
+
+    return res.status(200).json({
+      success: true,
+      requested_window: snapshot.requested_window,
+      executed_window: snapshot.executed_window,
+      data: snapshot.data,
+      message: 'Geofence evidence retrieved successfully'
+    });
+  } catch (error) {
+    logger.error('Failed to build geofence evidence snapshot', {
+      error: error.message,
+      query: req.query
+    });
     next(error);
   }
 };

--- a/src/middlewares/validator.js
+++ b/src/middlewares/validator.js
@@ -522,6 +522,27 @@ export const wfaFahpValidation = [
     .withMessage('radius_meters must be an integer between 100 and 50000')
 ];
 
+export const fuzzyAhpDashboardRecapValidation = [
+  query().custom((_, { req }) => {
+    const queryKeys = Object.keys(req.query ?? {});
+
+    if (!queryKeys.includes('type')) {
+      throw new Error('type is required');
+    }
+
+    const unsupportedQueryKey = queryKeys.find((key) => key !== 'type');
+    if (unsupportedQueryKey) {
+      throw new Error('only type query parameter is allowed');
+    }
+
+    if (!['discipline', 'wfa', 'smart_ac'].includes(req.query.type)) {
+      throw new Error('type must be one of discipline, wfa, smart_ac');
+    }
+
+    return true;
+  })
+];
+
 // Check-out validation rules
 export const checkOutValidation = [
   body('latitude')

--- a/src/routes/analysis.routes.js
+++ b/src/routes/analysis.routes.js
@@ -3,12 +3,18 @@ import express from 'express';
 import {
   getDisciplineFahp,
   getFuzzyAhpAnalysis,
+  getFuzzyAhpDashboardRecap,
   getSmartAcFahp,
   getWfaFahp
 } from '../controllers/analysis.controller.js';
 import { verifyToken } from '../middlewares/authJwt.js';
 import roleGuard from '../middlewares/roleGuard.js';
-import { disciplineFahpValidation, validate, wfaFahpValidation } from '../middlewares/validator.js';
+import {
+  disciplineFahpValidation,
+  fuzzyAhpDashboardRecapValidation,
+  validate,
+  wfaFahpValidation
+} from '../middlewares/validator.js';
 
 const router = express.Router();
 
@@ -29,5 +35,12 @@ router.get(
   getWfaFahp
 );
 router.get('/fuzzy-ahp/smart-ac', roleGuard(['Admin', 'Management']), getSmartAcFahp);
+router.get(
+  '/fuzzy-ahp/dashboard',
+  roleGuard(['Admin', 'Management']),
+  fuzzyAhpDashboardRecapValidation,
+  validate,
+  getFuzzyAhpDashboardRecap
+);
 
 export default router;

--- a/src/routes/attendance.routes.js
+++ b/src/routes/attendance.routes.js
@@ -18,7 +18,8 @@ import {
   logLocationEvent,
   getSmartEngineConfig,
   getEnhancedAutoCheckoutSettings,
-  getTodayLocations
+  getTodayLocations,
+  getGeofenceEvidence
 } from '../controllers/attendance.controller.js';
 import { verifyToken } from '../middlewares/authJwt.js';
 import roleGuard from '../middlewares/roleGuard.js';
@@ -27,7 +28,8 @@ import {
   checkOutValidation,
   validate,
   locationEventValidation,
-  todayLocationsValidation
+  todayLocationsValidation,
+  dashboardAnalyticsValidation
 } from '../middlewares/validator.js';
 
 const router = express.Router();
@@ -45,6 +47,12 @@ router.get(
   roleGuard(['Admin', 'Management']),
   todayLocationsValidation,
   getTodayLocations
+);
+router.get(
+  '/geofence-evidence',
+  roleGuard(['Admin', 'Management']),
+  dashboardAnalyticsValidation,
+  getGeofenceEvidence
 );
 
 router.post('/check-in', checkInValidation, validate, checkIn);

--- a/src/services/fuzzyAhpAnalysis.service.js
+++ b/src/services/fuzzyAhpAnalysis.service.js
@@ -872,3 +872,114 @@ export const buildSmartAcFahpPayload = async () => {
     ranking
   };
 };
+
+const buildDashboardRecapRankingItem = (rankedItem) => {
+  const entityId = rankedItem.id ?? rankedItem.user_id ?? rankedItem.place_id ?? null;
+
+  return {
+    rank: rankedItem.rank ?? 1,
+    ...(entityId != null ? { id: entityId } : {}),
+    name: rankedItem.name ?? null,
+    score: rankedItem.score ?? null,
+    label: rankedItem.label ?? null
+  };
+};
+
+const DASHBOARD_TYPE_LABELS = {
+  discipline: 'Discipline',
+  wfa: 'WFA',
+  smart_ac: 'Smart AC'
+};
+
+const DASHBOARD_CRITERIA_DISPLAY_LABELS = {
+  alpha_rate: 'Disiplin Kehadiran',
+  lateness_severity: 'Tingkat Keterlambatan',
+  lateness_frequency: 'Frekuensi Keterlambatan',
+  work_focus: 'Fokus Kerja',
+  location_type: 'Tipe Lokasi',
+  distance_factor: 'Faktor Jarak',
+  amenity_score: 'Skor Fasilitas',
+  attendance: 'Attendance'
+};
+
+const buildConsistencySummaryLabel = (consistency) => {
+  if (!consistency || typeof consistency.is_consistent !== 'boolean') {
+    return null;
+  }
+
+  return consistency.is_consistent
+    ? 'Konsistensi dapat diterima'
+    : 'Konsistensi perlu ditinjau';
+};
+
+const buildDashboardCriteriaWeights = (weights) => {
+  const criteria = Array.isArray(weights?.criteria) ? weights.criteria : [];
+  const values = Array.isArray(weights?.values) ? weights.values : [];
+
+  return criteria.map((key, index) => ({
+    key,
+    label: key,
+    display_label: DASHBOARD_CRITERIA_DISPLAY_LABELS[key] || key,
+    value: Number(values[index] ?? 0)
+  }));
+};
+
+const buildDashboardConsistency = (consistency) => {
+  if (!consistency) {
+    return null;
+  }
+
+  return {
+    CR: consistency.CR,
+    threshold: consistency.threshold,
+    is_consistent: consistency.is_consistent,
+    summary_label: buildConsistencySummaryLabel(consistency)
+  };
+};
+
+const buildDashboardRankingPreview = (ranking) => ({
+  top_n: 5,
+  items: Array.isArray(ranking) ? ranking.slice(0, 5).map(buildDashboardRecapRankingItem) : []
+});
+
+export const buildFuzzyAhpDashboardRecapPayload = async ({ type }) => {
+  const { startAt, endAt } = getAnalysisWindow('monthly');
+
+  let result;
+  switch (type) {
+    case 'discipline':
+      result = await buildDisciplineAnalysis({ startAt, endAt, includeLegacyId: false });
+      break;
+    case 'wfa':
+      result = await buildWfaAnalysis();
+      break;
+    default:
+      result = await buildSmartAcAnalysis({ startAt, endAt });
+      break;
+  }
+
+  const ranking = Array.isArray(result?.ranking) ? result.ranking : [];
+  const rankingPreview = buildDashboardRankingPreview(ranking);
+  const hasData = rankingPreview.items.length > 0;
+  const consistency = buildDashboardConsistency(result?.consistency ?? null);
+
+  return {
+    type,
+    type_label: DASHBOARD_TYPE_LABELS[type] || type,
+    generated_at: formatWibDateTime(endAt),
+    timezone: 'Asia/Jakarta',
+    requested_window: {
+      period: 'monthly'
+    },
+    executed_window: {
+      start_at: formatWibDateTime(startAt),
+      end_at: formatWibDateTime(endAt)
+    },
+    status: hasData ? 'ready' : 'empty',
+    needs_data: !hasData,
+    consistency,
+    criteria_weights: buildDashboardCriteriaWeights(result?.weights),
+    ranking_preview: rankingPreview,
+    distribution: result?.distribution ?? { ...EMPTY_DISTRIBUTION }
+  };
+};

--- a/src/utils/dashboardAnalytics.js
+++ b/src/utils/dashboardAnalytics.js
@@ -19,6 +19,7 @@ import {
   enumerateDateRange,
   formatDateOnly
 } from './historicalDateWindow.js';
+import { buildGeofenceEvidenceData } from './geofenceEvidenceSnapshot.js';
 
 const STATUS_ALPHA = new Set(['alpa', 'alpha']);
 const STATUS_LATE = new Set(['terlambat', 'late']);
@@ -140,42 +141,11 @@ const buildSnapshotCard = ({ analysis, effectiveWindow, generatedAt, allowedIds 
   };
 };
 
-const buildGeofenceEvidenceContext = ({ effectiveWindow, locationEvents }) => {
-  const uniqueUsers = new Set();
-  let enterEvents = 0;
-  let exitEvents = 0;
-
-  for (const event of locationEvents) {
-    if (event.user_id != null) {
-      uniqueUsers.add(String(event.user_id));
-    }
-
-    if (event.event_type === 'ENTER') {
-      enterEvents += 1;
-    }
-
-    if (event.event_type === 'EXIT') {
-      exitEvents += 1;
-    }
-  }
-
-  const hasEvents = locationEvents.length > 0;
-
-  return {
-    status: hasEvents ? 'available' : 'needs_data',
-    needs_data: !hasEvents,
-    reason: hasEvents ? null : 'NO_GEOFENCE_EVENTS',
-    authority: 'context_only',
-    final_attendance_authority: 'attendance_records',
-    window: buildExecutedWindow(effectiveWindow),
-    raw_counts: {
-      total_events: locationEvents.length,
-      enter_events: enterEvents,
-      exit_events: exitEvents,
-      unique_users: uniqueUsers.size
-    }
-  };
-};
+const buildGeofenceEvidenceContext = ({ effectiveWindow, locationEvents }) =>
+  buildGeofenceEvidenceData({
+    effectiveWindow,
+    locationEvents
+  });
 
 const buildInsights = ({ executiveKpis, modeMix }) => {
   const items = [];

--- a/src/utils/geofenceEvidenceSnapshot.js
+++ b/src/utils/geofenceEvidenceSnapshot.js
@@ -1,0 +1,99 @@
+import { Op } from 'sequelize';
+
+import { LocationEvent } from '../models/index.js';
+import {
+  addUtcDays,
+  buildEffectiveWindow,
+  buildJakartaDayStartUtc,
+  buildRequestedWindow,
+  formatDateOnly
+} from './historicalDateWindow.js';
+
+const buildExecutedWindow = (effectiveWindow) => ({
+  from: effectiveWindow.startDateStr,
+  to: effectiveWindow.endDateStr
+});
+
+const buildOperationalContext = ({ needsData, totalEvents, uniqueUsers }) => ({
+  activity_label: needsData ? 'Needs Data' : 'Active',
+  activity_note: `${uniqueUsers} users generated ${totalEvents} geofence events in this range.`,
+  enter_context: 'ENTER events support check-in reminder monitoring.',
+  exit_context: 'EXIT events support active-session exit warning monitoring.',
+  dashboard_note:
+    'Location context only. Final attendance validity remains determined by backend attendance records.'
+});
+
+export const buildGeofenceEvidenceData = ({ effectiveWindow, locationEvents }) => {
+  const uniqueUsers = new Set();
+  let enterEvents = 0;
+  let exitEvents = 0;
+
+  for (const event of locationEvents) {
+    if (event.user_id != null) {
+      uniqueUsers.add(String(event.user_id));
+    }
+
+    if (event.event_type === 'ENTER') {
+      enterEvents += 1;
+    }
+
+    if (event.event_type === 'EXIT') {
+      exitEvents += 1;
+    }
+  }
+
+  const totalEvents = locationEvents.length;
+  const hasEvents = totalEvents > 0;
+
+  return {
+    status: hasEvents ? 'available' : 'needs_data',
+    needs_data: !hasEvents,
+    reason: hasEvents ? null : 'NO_GEOFENCE_EVENTS',
+    authority: 'context_only',
+    final_attendance_authority: 'attendance_records',
+    window: buildExecutedWindow(effectiveWindow),
+    raw_counts: {
+      total_events: totalEvents,
+      enter_events: enterEvents,
+      exit_events: exitEvents,
+      unique_users: uniqueUsers.size
+    },
+    operational_context: buildOperationalContext({
+      needsData: !hasEvents,
+      totalEvents,
+      uniqueUsers: uniqueUsers.size
+    })
+  };
+};
+
+export const buildGeofenceEvidenceSnapshot = async ({ period = '30d', from = null, to = null } = {}) => {
+  const requestedWindow = buildRequestedWindow({ period, from, to });
+  const effectiveWindow = buildEffectiveWindow({ period, from, to });
+  const geofenceStartInclusive = buildJakartaDayStartUtc(effectiveWindow.startDateStr);
+  const geofenceEndExclusive = buildJakartaDayStartUtc(formatDateOnly(addUtcDays(effectiveWindow.endDate, 1)));
+
+  const locationEvents = await LocationEvent.findAll({
+    where: {
+      event_timestamp: {
+        [Op.gte]: geofenceStartInclusive,
+        [Op.lt]: geofenceEndExclusive
+      }
+    },
+    attributes: ['user_id', 'event_type'],
+    order: [['event_timestamp', 'ASC']]
+  });
+
+  return {
+    requested_window: requestedWindow,
+    executed_window: buildExecutedWindow(effectiveWindow),
+    data: buildGeofenceEvidenceData({
+      effectiveWindow,
+      locationEvents
+    })
+  };
+};
+
+export default {
+  buildGeofenceEvidenceData,
+  buildGeofenceEvidenceSnapshot
+};

--- a/tests/analysisFuzzyAhpContract.test.js
+++ b/tests/analysisFuzzyAhpContract.test.js
@@ -174,6 +174,50 @@ describe('analysis fuzzy ahp contract', () => {
     });
   });
 
+  it('returns a lightweight dashboard recap consistency object without leaking detail-analysis fields', async () => {
+    mockUser.findAll.mockResolvedValue([
+      { id_users: 7, full_name: 'Andi' },
+      { id_users: 8, full_name: 'Budi' }
+    ]);
+    mockAttendance.findAll.mockResolvedValue([
+      {
+        user_id: 7,
+        status_id: 1,
+        time_in: '2026-04-01T01:03:00.000Z',
+        time_out: '2026-04-01T09:00:00.000Z',
+        work_hour: 7.6,
+        attendance_date: '2026-04-01',
+        notes: ''
+      },
+      {
+        user_id: 7,
+        status_id: 2,
+        time_in: '2026-04-02T02:15:00.000Z',
+        time_out: '2026-04-02T10:00:00.000Z',
+        work_hour: 7.75,
+        attendance_date: '2026-04-02',
+        notes: ''
+      }
+    ]);
+
+    const response = await request(scopedApp).get('/api/analysis/fuzzy-ahp/dashboard?type=discipline');
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(response.body.data.type).toBe('discipline');
+    expect(response.body.data.type_label).toBe('Discipline');
+    expect(response.body.data.requested_window).toEqual({ period: 'monthly' });
+    expect(response.body.data.consistency).toEqual({
+      CR: 0.037,
+      threshold: 0.1,
+      is_consistent: true,
+      summary_label: 'Konsistensi dapat diterima'
+    });
+    expect(response.body.data.consistency).not.toHaveProperty('CI');
+    expect(response.body.data.consistency).not.toHaveProperty('lambda_max');
+    expect(response.body.data.consistency).not.toHaveProperty('verdict');
+  });
+
   it('returns user-ranked analysis for discipline mode', async () => {
     mockUser.findAll.mockResolvedValue([
       { id_users: 7, full_name: 'Andi' },

--- a/tests/analysisFuzzyAhpControllerValidation.test.js
+++ b/tests/analysisFuzzyAhpControllerValidation.test.js
@@ -1,6 +1,28 @@
 import { jest } from '@jest/globals';
 
-import { getFuzzyAhpAnalysis } from '../src/controllers/analysis.controller.js';
+const mockBuildFuzzyAhpDashboardRecapPayload = jest.fn();
+const mockLoggerError = jest.fn();
+
+jest.unstable_mockModule('../src/services/fuzzyAhpAnalysis.service.js', () => ({
+  buildDisciplineAnalysis: jest.fn(),
+  buildDisciplineFahpPayload: jest.fn(),
+  buildFuzzyAhpDashboardRecapPayload: mockBuildFuzzyAhpDashboardRecapPayload,
+  buildSmartAcAnalysis: jest.fn(),
+  buildSmartAcFahpPayload: jest.fn(),
+  buildWfaAnalysis: jest.fn(),
+  buildWfaFahpPayload: jest.fn(),
+  formatWibDateTime: jest.fn(),
+  getAnalysisWindow: jest.fn()
+}));
+
+jest.unstable_mockModule('../src/utils/logger.js', () => ({
+  __esModule: true,
+  default: {
+    error: mockLoggerError
+  }
+}));
+
+const { getFuzzyAhpAnalysis, getFuzzyAhpDashboardRecap } = await import('../src/controllers/analysis.controller.js');
 
 describe('analysis fuzzy ahp controller validation', () => {
   it('returns 400 for invalid type values', async () => {
@@ -43,5 +65,165 @@ describe('analysis fuzzy ahp controller validation', () => {
       success: false,
       message: 'period must be one of: weekly, monthly'
     });
+  });
+
+  it('delegates dashboard recap payload and returns additive display fields in the success envelope', async () => {
+    mockBuildFuzzyAhpDashboardRecapPayload.mockResolvedValueOnce({
+      type: 'discipline',
+      type_label: 'Discipline',
+      generated_at: '2026-06-26T00:00:00+07:00',
+      timezone: 'Asia/Jakarta',
+      requested_window: { period: 'monthly' },
+      executed_window: {
+        start_at: '2026-06-01T00:00:00+07:00',
+        end_at: '2026-06-26T00:00:00+07:00'
+      },
+      status: 'ready',
+      needs_data: false,
+      consistency: {
+        CR: 0.01,
+        threshold: 0.1,
+        is_consistent: true,
+        summary_label: 'Konsistensi dapat diterima'
+      },
+      criteria_weights: [
+        {
+          key: 'alpha_rate',
+          label: 'alpha_rate',
+          display_label: 'Disiplin Kehadiran',
+          value: 0.317
+        }
+      ],
+      ranking_preview: { top_n: 5, items: [] },
+      distribution: {
+        'Sangat Tinggi': 0,
+        Tinggi: 0,
+        Sedang: 0,
+        Rendah: 0,
+        'Sangat Rendah': 0
+      }
+    });
+
+    const req = { query: { type: 'discipline' } };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis()
+    };
+    const next = jest.fn();
+
+    await getFuzzyAhpDashboardRecap(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(mockBuildFuzzyAhpDashboardRecapPayload).toHaveBeenCalledWith({ type: 'discipline' });
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      data: {
+        type: 'discipline',
+        type_label: 'Discipline',
+        generated_at: '2026-06-26T00:00:00+07:00',
+        timezone: 'Asia/Jakarta',
+        requested_window: { period: 'monthly' },
+        executed_window: {
+          start_at: '2026-06-01T00:00:00+07:00',
+          end_at: '2026-06-26T00:00:00+07:00'
+        },
+        status: 'ready',
+        needs_data: false,
+        consistency: {
+          CR: 0.01,
+          threshold: 0.1,
+          is_consistent: true,
+          summary_label: 'Konsistensi dapat diterima'
+        },
+        criteria_weights: [
+          {
+            key: 'alpha_rate',
+            label: 'alpha_rate',
+            display_label: 'Disiplin Kehadiran',
+            value: 0.317
+          }
+        ],
+        ranking_preview: { top_n: 5, items: [] },
+        distribution: {
+          'Sangat Tinggi': 0,
+          Tinggi: 0,
+          Sedang: 0,
+          Rendah: 0,
+          'Sangat Rendah': 0
+        }
+      },
+      message: 'Fuzzy AHP dashboard recap retrieved successfully'
+    });
+  });
+
+  it('keeps additive display fields present for empty dashboard recap payloads', async () => {
+    mockBuildFuzzyAhpDashboardRecapPayload.mockResolvedValueOnce({
+      type: 'wfa',
+      type_label: 'WFA',
+      generated_at: '2026-06-26T00:00:00+07:00',
+      timezone: 'Asia/Jakarta',
+      requested_window: { period: 'monthly' },
+      executed_window: {
+        start_at: '2026-06-01T00:00:00+07:00',
+        end_at: '2026-06-26T00:00:00+07:00'
+      },
+      status: 'empty',
+      needs_data: true,
+      consistency: {
+        CR: 0.21,
+        threshold: 0.1,
+        is_consistent: false,
+        summary_label: 'Konsistensi perlu ditinjau'
+      },
+      criteria_weights: [
+        {
+          key: 'location_type',
+          label: 'location_type',
+          display_label: 'Tipe Lokasi',
+          value: 0.5
+        }
+      ],
+      ranking_preview: { top_n: 5, items: [] },
+      distribution: {
+        'Sangat Tinggi': 0,
+        Tinggi: 0,
+        Sedang: 0,
+        Rendah: 0,
+        'Sangat Rendah': 0
+      }
+    });
+
+    const req = { query: { type: 'wfa' } };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis()
+    };
+    const next = jest.fn();
+
+    await getFuzzyAhpDashboardRecap(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        data: expect.objectContaining({
+          type: 'wfa',
+          type_label: 'WFA',
+          status: 'empty',
+          needs_data: true,
+          consistency: expect.objectContaining({
+            summary_label: 'Konsistensi perlu ditinjau'
+          }),
+          criteria_weights: [
+            expect.objectContaining({
+              key: 'location_type',
+              display_label: 'Tipe Lokasi'
+            })
+          ]
+        })
+      })
+    );
   });
 });

--- a/tests/analysisFuzzyAhpDashboardRecapRoute.test.js
+++ b/tests/analysisFuzzyAhpDashboardRecapRoute.test.js
@@ -1,0 +1,294 @@
+import express from 'express';
+import { jest } from '@jest/globals';
+import request from 'supertest';
+
+const ALLOWED_TYPES = ['discipline', 'wfa', 'smart_ac'];
+
+const mockVerifyToken = jest.fn((req, _res, next) => {
+  req.user = { id: 12, role_name: req.get('x-test-role') || 'Admin' };
+  next();
+});
+
+const mockRoleGuard = jest.fn((allowedRoles) => (req, res, next) => {
+  const userRole = req.user?.role_name || req.user?.role?.name;
+  if (!allowedRoles.includes(userRole)) {
+    return res.status(403).json({ success: false, message: 'Forbidden' });
+  }
+  next();
+});
+
+const mockGetFuzzyAhpDashboardRecap = jest.fn((req, res) => {
+  res.status(200).json({
+    success: true,
+    data: {
+      type: req.query.type,
+      type_label: 'Discipline',
+      generated_at: '2026-06-26T00:00:00+07:00',
+      timezone: 'Asia/Jakarta',
+      requested_window: {
+        period: 'monthly'
+      },
+      executed_window: {
+        start_at: '2026-06-01T00:00:00+07:00',
+        end_at: '2026-06-26T00:00:00+07:00'
+      },
+      status: 'ready',
+      needs_data: false,
+      consistency: {
+        CR: 0.01,
+        threshold: 0.1,
+        is_consistent: true,
+        summary_label: 'Konsistensi dapat diterima'
+      },
+      criteria_weights: [
+        { key: 'attendance', label: 'attendance', display_label: 'Attendance', value: 0.4 }
+      ],
+      ranking_preview: {
+        top_n: 5,
+        items: [
+          {
+            rank: 1,
+            id: 7,
+            name: 'Andi',
+            score: 87.5,
+            label: 'Sangat Tinggi'
+          }
+        ]
+      },
+      distribution: {
+        'Sangat Tinggi': 1,
+        Tinggi: 0,
+        Sedang: 0,
+        Rendah: 0,
+        'Sangat Rendah': 0
+      }
+    },
+    message: 'Fuzzy AHP dashboard recap retrieved successfully'
+  });
+});
+
+const mockFuzzyAhpDashboardRecapValidation = jest.fn((req, _res, next) => {
+  const queryKeys = Object.keys(req.query);
+
+  if (!queryKeys.includes('type')) {
+    req.validationError = 'type is required';
+    return next();
+  }
+
+  if (queryKeys.some((key) => key !== 'type')) {
+    req.validationError = 'only type query parameter is allowed';
+    return next();
+  }
+
+  if (!ALLOWED_TYPES.includes(req.query.type)) {
+    req.validationError = 'type must be one of discipline, wfa, smart_ac';
+    return next();
+  }
+
+  return next();
+});
+
+const mockValidate = jest.fn((req, res, next) => {
+  if (!req.validationError) {
+    return next();
+  }
+
+  return res.status(400).json({
+    success: false,
+    code: 'E_VALIDATION',
+    message: req.validationError
+  });
+});
+
+jest.unstable_mockModule('../src/controllers/analysis.controller.js', () => ({
+  getDisciplineFahp: jest.fn(),
+  getFuzzyAhpAnalysis: jest.fn(),
+  getFuzzyAhpDashboardRecap: mockGetFuzzyAhpDashboardRecap,
+  getSmartAcFahp: jest.fn(),
+  getWfaFahp: jest.fn()
+}));
+
+jest.unstable_mockModule('../src/middlewares/authJwt.js', () => ({
+  verifyToken: mockVerifyToken
+}));
+
+jest.unstable_mockModule('../src/middlewares/roleGuard.js', () => ({
+  __esModule: true,
+  default: mockRoleGuard
+}));
+
+jest.unstable_mockModule('../src/middlewares/validator.js', () => ({
+  disciplineFahpValidation: [],
+  fuzzyAhpDashboardRecapValidation: [mockFuzzyAhpDashboardRecapValidation],
+  validate: mockValidate,
+  wfaFahpValidation: []
+}));
+
+const { default: analysisRoutes } = await import('../src/routes/analysis.routes.js');
+
+const createAnalysisRoutesApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/analysis', analysisRoutes);
+  return app;
+};
+
+const createDashboardRecapHarnessApp = () => {
+  const app = express();
+  app.use(express.json());
+
+  app.use('/api/analysis', mockVerifyToken);
+  app.get(
+    '/api/analysis/fuzzy-ahp/dashboard',
+    mockRoleGuard(['Admin', 'Management']),
+    mockFuzzyAhpDashboardRecapValidation,
+    mockValidate,
+    mockGetFuzzyAhpDashboardRecap
+  );
+
+  return app;
+};
+
+const expectValidationFailure = async (app, path, expectedMessage) => {
+  const res = await request(app).get(path);
+
+  expect(res.status).toBe(400);
+  expect(res.body).toEqual({
+    success: false,
+    code: 'E_VALIDATION',
+    message: expectedMessage
+  });
+  expect(mockGetFuzzyAhpDashboardRecap).not.toHaveBeenCalled();
+
+  return res;
+};
+
+describe('analysis fuzzy ahp dashboard recap route validation scaffold', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 400 E_VALIDATION when type query is missing', async () => {
+    const app = createDashboardRecapHarnessApp();
+
+    await expectValidationFailure(
+      app,
+      '/api/analysis/fuzzy-ahp/dashboard',
+      'type is required'
+    );
+    expect(mockFuzzyAhpDashboardRecapValidation).toHaveBeenCalled();
+    expect(mockValidate).toHaveBeenCalled();
+  });
+
+  it('returns 400 E_VALIDATION when type is outside discipline, wfa, and smart_ac', async () => {
+    const app = createDashboardRecapHarnessApp();
+
+    await expectValidationFailure(
+      app,
+      '/api/analysis/fuzzy-ahp/dashboard?type=attendance',
+      'type must be one of discipline, wfa, smart_ac'
+    );
+  });
+
+  it.each([
+    '/api/analysis/fuzzy-ahp/dashboard?type=discipline&period=monthly',
+    '/api/analysis/fuzzy-ahp/dashboard?type=discipline&from=2026-06-01',
+    '/api/analysis/fuzzy-ahp/dashboard?type=discipline&to=2026-06-30'
+  ])('returns 400 E_VALIDATION when extra query params are present: %s', async (path) => {
+    const app = createDashboardRecapHarnessApp();
+
+    await expectValidationFailure(app, path, 'only type query parameter is allowed');
+  });
+
+  it('returns 200 success response for a valid type query', async () => {
+    const app = createDashboardRecapHarnessApp();
+
+    const res = await request(app).get('/api/analysis/fuzzy-ahp/dashboard?type=discipline');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      success: true,
+      data: {
+        type: 'discipline',
+        type_label: 'Discipline',
+        generated_at: '2026-06-26T00:00:00+07:00',
+        timezone: 'Asia/Jakarta',
+        requested_window: {
+          period: 'monthly'
+        },
+        executed_window: {
+          start_at: '2026-06-01T00:00:00+07:00',
+          end_at: '2026-06-26T00:00:00+07:00'
+        },
+        status: 'ready',
+        needs_data: false,
+        consistency: {
+          CR: 0.01,
+          threshold: 0.1,
+          is_consistent: true,
+          summary_label: 'Konsistensi dapat diterima'
+        },
+        criteria_weights: [
+          {
+            key: 'attendance',
+            label: 'attendance',
+            display_label: 'Attendance',
+            value: 0.4
+          }
+        ],
+        ranking_preview: {
+          top_n: 5,
+          items: [
+            {
+              rank: 1,
+              id: 7,
+              name: 'Andi',
+              score: 87.5,
+              label: 'Sangat Tinggi'
+            }
+          ]
+        },
+        distribution: {
+          'Sangat Tinggi': 1,
+          Tinggi: 0,
+          Sedang: 0,
+          Rendah: 0,
+          'Sangat Rendah': 0
+        }
+      },
+      message: 'Fuzzy AHP dashboard recap retrieved successfully'
+    });
+    expect(mockGetFuzzyAhpDashboardRecap).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 403 for callers outside Admin and Management before validation or handler execution', async () => {
+    const app = createDashboardRecapHarnessApp();
+
+    const res = await request(app)
+      .get('/api/analysis/fuzzy-ahp/dashboard?type=discipline')
+      .set('x-test-role', 'User');
+
+    expect(res.status).toBe(403);
+    expect(mockFuzzyAhpDashboardRecapValidation).not.toHaveBeenCalled();
+    expect(mockValidate).not.toHaveBeenCalled();
+    expect(mockGetFuzzyAhpDashboardRecap).not.toHaveBeenCalled();
+  });
+});
+
+describe('analysis fuzzy ahp dashboard recap real router wiring', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('mounts the dashboard recap route on the real analysis router', async () => {
+    const app = createAnalysisRoutesApp();
+
+    const res = await request(app).get('/api/analysis/fuzzy-ahp/dashboard?type=discipline');
+
+    expect(res.status).toBe(200);
+    expect(mockVerifyToken).toHaveBeenCalled();
+    expect(mockFuzzyAhpDashboardRecapValidation).toHaveBeenCalled();
+    expect(mockValidate).toHaveBeenCalled();
+    expect(mockGetFuzzyAhpDashboardRecap).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/attendanceGeofenceEvidenceRoute.test.js
+++ b/tests/attendanceGeofenceEvidenceRoute.test.js
@@ -1,0 +1,215 @@
+import express from 'express';
+import { jest } from '@jest/globals';
+import request from 'supertest';
+
+let authFails = false;
+const mockVerifyToken = jest.fn((req, res, next) => {
+  if (authFails) {
+    return res.status(401).json({ success: false, message: 'Unauthorized' });
+  }
+
+  req.user = { id: 1, role_name: 'Admin' };
+  return next();
+});
+
+let allowRole = true;
+const mockRoleGuard = () => (_req, res, next) => {
+  if (!allowRole) {
+    return res.status(403).json({ success: false, message: 'Forbidden' });
+  }
+  next();
+};
+
+const mockDashboardAnalyticsValidation = (req, res, next) => {
+  const { period = '30d', from = null, to = null } = req.query ?? {};
+
+  if (period === 'custom' && (!from || !to)) {
+    return res.status(400).json({
+      success: false,
+      code: 'E_VALIDATION',
+      message: 'from and to are required when period is custom'
+    });
+  }
+
+  return next();
+};
+
+const mockGetGeofenceEvidence = jest.fn((req, res) => {
+  res.status(200).json({
+    success: true,
+    requested_window: {
+      period: req.query.period ?? '30d',
+      from: req.query.from ?? null,
+      to: req.query.to ?? null
+    },
+    executed_window: {
+      from: '2026-04-01',
+      to: '2026-04-03'
+    },
+    data: {
+      status: 'available',
+      needs_data: false,
+      reason: null,
+      authority: 'context_only',
+      final_attendance_authority: 'attendance_records',
+      window: {
+        from: '2026-04-01',
+        to: '2026-04-03'
+      },
+      raw_counts: {
+        total_events: 4,
+        enter_events: 2,
+        exit_events: 2,
+        unique_users: 2
+      },
+      operational_context: {
+        activity_label: 'Active',
+        activity_note: '2 users generated 4 geofence events in this range.',
+        enter_context: 'ENTER events support check-in reminder monitoring.',
+        exit_context: 'EXIT events support active-session exit warning monitoring.',
+        dashboard_note: 'Location context only. Final attendance validity remains determined by backend attendance records.'
+      }
+    },
+    message: 'Geofence evidence retrieved successfully'
+  });
+});
+
+jest.unstable_mockModule('../src/controllers/attendance.controller.js', () => ({
+  getAttendanceHistory: jest.fn(),
+  getAttendanceStatus: jest.fn(),
+  checkIn: jest.fn(),
+  checkOut: jest.fn(),
+  debugCheckInTime: jest.fn(),
+  deleteAttendance: jest.fn(),
+  getAllAttendances: jest.fn(),
+  manualAutoCheckout: jest.fn(),
+  getAutoCheckoutSettings: jest.fn(),
+  manualResolveWfaBookings: jest.fn(),
+  manualGeneralAlphaForDate: jest.fn(),
+  manualResolveWfaForDate: jest.fn(),
+  manualSmartAutoCheckoutForDate: jest.fn(),
+  logLocationEvent: jest.fn(),
+  getSmartEngineConfig: jest.fn(),
+  getEnhancedAutoCheckoutSettings: jest.fn(),
+  getTodayLocations: jest.fn(),
+  getGeofenceEvidence: mockGetGeofenceEvidence,
+  testWeightedPrediction: jest.fn()
+}));
+
+jest.unstable_mockModule('../src/middlewares/authJwt.js', () => ({
+  verifyToken: mockVerifyToken
+}));
+
+jest.unstable_mockModule('../src/middlewares/roleGuard.js', () => ({
+  __esModule: true,
+  default: mockRoleGuard
+}));
+
+jest.unstable_mockModule('../src/middlewares/validator.js', () => ({
+  upload: { single: jest.fn(() => (req, _res, next) => next()) },
+  safeUrlField: jest.fn(() => []),
+  registerValidation: [],
+  loginValidation: [],
+  validateLogin: [],
+  validate: jest.fn((req, _res, next) => next()),
+  validateFaceImage: jest.fn((req, _res, next) => next()),
+  userRegistrationValidation: [],
+  validateUpdateUser: [],
+  validateCreateUser: [],
+  checkInValidation: [],
+  createBookingValidation: [],
+  updateStatusValidation: [],
+  checkOutValidation: [],
+  locationEventValidation: [],
+  todayLocationsValidation: [],
+  dashboardAnalyticsValidation: [mockDashboardAnalyticsValidation]
+}));
+
+const { default: attendanceRoutes } = await import('../src/routes/attendance.routes.js');
+
+const app = express();
+app.use(express.json());
+app.use('/api/attendance', attendanceRoutes);
+
+describe('attendance geofence evidence route', () => {
+  beforeEach(() => {
+    authFails = false;
+    allowRole = true;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 401 before RBAC or handler when authentication fails', async () => {
+    authFails = true;
+
+    const res = await request(app).get('/api/attendance/geofence-evidence');
+
+    expect(res.status).toBe(401);
+    expect(mockVerifyToken).toHaveBeenCalled();
+    expect(mockGetGeofenceEvidence).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 for non-admin non-management callers', async () => {
+    allowRole = false;
+
+    const res = await request(app).get('/api/attendance/geofence-evidence');
+
+    expect(res.status).toBe(403);
+    expect(mockGetGeofenceEvidence).not.toHaveBeenCalled();
+  });
+
+  it('serves geofence evidence through attendance ownership with historical window queries', async () => {
+    const res = await request(app)
+      .get('/api/attendance/geofence-evidence')
+      .query({ period: 'custom', from: '2026-04-01', to: '2026-04-03' });
+
+    expect(res.status).toBe(200);
+    expect(mockVerifyToken).toHaveBeenCalled();
+    expect(mockGetGeofenceEvidence).toHaveBeenCalled();
+    expect(res.body).toMatchObject({
+      success: true,
+      requested_window: {
+        period: 'custom',
+        from: '2026-04-01',
+        to: '2026-04-03'
+      },
+      executed_window: {
+        from: '2026-04-01',
+        to: '2026-04-03'
+      },
+      data: {
+        authority: 'context_only',
+        final_attendance_authority: 'attendance_records',
+        raw_counts: {
+          total_events: 4,
+          enter_events: 2,
+          exit_events: 2,
+          unique_users: 2
+        },
+        operational_context: {
+          activity_label: 'Active',
+          activity_note: '2 users generated 4 geofence events in this range.',
+          enter_context: 'ENTER events support check-in reminder monitoring.',
+          exit_context: 'EXIT events support active-session exit warning monitoring.',
+          dashboard_note: 'Location context only. Final attendance validity remains determined by backend attendance records.'
+        }
+      },
+      message: 'Geofence evidence retrieved successfully'
+    });
+  });
+
+  it('returns 400 E_VALIDATION for incomplete custom historical range', async () => {
+    const res = await request(app)
+      .get('/api/attendance/geofence-evidence')
+      .query({ period: 'custom', from: '2026-04-01' });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({
+      success: false,
+      code: 'E_VALIDATION'
+    });
+    expect(mockGetGeofenceEvidence).not.toHaveBeenCalled();
+  });
+});

--- a/tests/clientCriticalOpenApiContract.test.js
+++ b/tests/clientCriticalOpenApiContract.test.js
@@ -153,6 +153,64 @@ describe('client-critical OpenAPI contract', () => {
     });
   });
 
+  test('documents attendance geofence-evidence owner endpoint in the public OpenAPI contract', () => {
+    const geofenceOperation = openapi.paths['/api/attendance/geofence-evidence'].get;
+    const geofenceSchema = schemaAt(geofenceOperation);
+    const dataSchema = geofenceSchema.properties.data;
+    const parameterNames = geofenceOperation.parameters.map((parameter) => parameter.name);
+
+    expect(parameterNames).toEqual(expect.arrayContaining(['period', 'from', 'to']));
+    expect(parameterNames).not.toContain('limit');
+    expect(geofenceOperation.responses).toHaveProperty('400');
+    expect(geofenceSchema.properties).toMatchObject({
+      success: { type: 'boolean', example: true },
+      requested_window: { type: 'object' },
+      executed_window: { type: 'object' },
+      data: { type: 'object' },
+      message: {
+        type: 'string',
+        example: 'Geofence evidence retrieved successfully'
+      }
+    });
+    expect(dataSchema.properties).toMatchObject({
+      status: {
+        type: 'string',
+        enum: ['available', 'needs_data'],
+        example: 'available'
+      },
+      needs_data: {
+        type: 'boolean',
+        example: false
+      },
+      reason: {
+        type: 'string',
+        nullable: true,
+        example: null
+      },
+      authority: {
+        type: 'string',
+        example: 'context_only'
+      },
+      final_attendance_authority: {
+        type: 'string',
+        example: 'attendance_records'
+      },
+      window: { type: 'object' },
+      raw_counts: { type: 'object' },
+      operational_context: { type: 'object' }
+    });
+    expect(dataSchema.properties.operational_context.properties).toMatchObject({
+      activity_label: { type: 'string', example: 'Active' },
+      activity_note: { type: 'string', example: '2 users generated 3 geofence events in this range.' },
+      enter_context: { type: 'string', example: 'ENTER events support check-in reminder monitoring.' },
+      exit_context: { type: 'string', example: 'EXIT events support active-session exit warning monitoring.' },
+      dashboard_note: {
+        type: 'string',
+        example: 'Location context only. Final attendance validity remains determined by backend attendance records.'
+      }
+    });
+  });
+
   test('does not document canceled summary dashboard-map endpoint', () => {
     expect(openapi.paths).not.toHaveProperty('/api/summary/dashboard-map');
   });
@@ -338,6 +396,19 @@ describe('client-critical OpenAPI contract', () => {
       final_attendance_authority: {
         type: 'string',
         example: 'attendance_records'
+      },
+      operational_context: {
+        type: 'object'
+      }
+    });
+    expect(dataSchema.properties.geofence_evidence_context.properties.operational_context.properties).toMatchObject({
+      activity_label: { type: 'string', example: 'Active' },
+      activity_note: { type: 'string', example: '2 users generated 3 geofence events in this range.' },
+      enter_context: { type: 'string', example: 'ENTER events support check-in reminder monitoring.' },
+      exit_context: { type: 'string', example: 'EXIT events support active-session exit warning monitoring.' },
+      dashboard_note: {
+        type: 'string',
+        example: 'Location context only. Final attendance validity remains determined by backend attendance records.'
       }
     });
     expect(dataSchema.properties).not.toHaveProperty('today_locations');
@@ -657,6 +728,57 @@ describe('client-critical OpenAPI contract', () => {
     expect(rankingProperties).toHaveProperty('predicted_time_out');
     expect(rankingProperties).toHaveProperty('evidence_summary');
     expect(rankingProperties).toHaveProperty('needs_data');
+  });
+
+  test('documents dashboard recap query contract and additive display fields', () => {
+    const operation = openapi.paths['/api/analysis/fuzzy-ahp/dashboard'].get;
+    const responseSchema = schemaAt(operation);
+    const dataSchema = responseSchema.properties.data;
+    const typeParameter = operation.parameters.find((parameter) => parameter.name === 'type');
+
+    expect(typeParameter.required).toBe(true);
+    expect(typeParameter.schema.enum).toEqual(['discipline', 'wfa', 'smart_ac']);
+    expect(operation.parameters).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'period' }),
+        expect.objectContaining({ name: 'from' }),
+        expect.objectContaining({ name: 'to' })
+      ])
+    );
+    expect(operation.description.toLowerCase()).toContain('dashboard-specific');
+    expect(operation.description.toLowerCase()).toContain('monthly');
+    expect(dataSchema.properties).toMatchObject({
+      type: { type: 'string' },
+      type_label: { type: 'string', example: 'Discipline' },
+      generated_at: { type: 'string', format: 'date-time' },
+      timezone: { type: 'string', example: 'Asia/Jakarta' },
+      requested_window: { type: 'object' },
+      executed_window: { type: 'object' },
+      status: { type: 'string', example: 'ready' },
+      needs_data: { type: 'boolean', example: false },
+      consistency: { type: 'object' },
+      criteria_weights: { type: 'array' },
+      ranking_preview: { type: 'object' },
+      distribution: { type: 'object' }
+    });
+    expect(dataSchema.properties.consistency.properties).toMatchObject({
+      CR: { type: 'number', format: 'float' },
+      threshold: { type: 'number', format: 'float' },
+      is_consistent: { type: 'boolean' },
+      summary_label: { type: 'string', example: 'Konsistensi dapat diterima' }
+    });
+    expect(dataSchema.properties.consistency.properties).not.toHaveProperty('CI');
+    expect(dataSchema.properties.consistency.properties).not.toHaveProperty('lambda_max');
+    expect(dataSchema.properties.consistency.properties).not.toHaveProperty('verdict');
+    expect(dataSchema.properties.criteria_weights.items.properties).toMatchObject({
+      key: { type: 'string' },
+      label: { type: 'string' },
+      display_label: { type: 'string', example: 'Disiplin Kehadiran' },
+      value: { type: 'number', format: 'float' }
+    });
+    expect(dataSchema.properties).not.toHaveProperty('ranking');
+    expect(dataSchema.properties).not.toHaveProperty('weights');
+    expect(dataSchema.properties).not.toHaveProperty('entity_kind');
   });
 
 });

--- a/tests/dashboardAnalyticsHelper.test.js
+++ b/tests/dashboardAnalyticsHelper.test.js
@@ -216,6 +216,13 @@ describe('dashboard analytics helper contract', () => {
         enter_events: 1,
         exit_events: 2,
         unique_users: 2
+      },
+      operational_context: {
+        activity_label: 'Active',
+        activity_note: '2 users generated 3 geofence events in this range.',
+        enter_context: 'ENTER events support check-in reminder monitoring.',
+        exit_context: 'EXIT events support active-session exit warning monitoring.',
+        dashboard_note: 'Location context only. Final attendance validity remains determined by backend attendance records.'
       }
     });
 
@@ -431,6 +438,13 @@ describe('dashboard analytics helper contract', () => {
         enter_events: 0,
         exit_events: 0,
         unique_users: 0
+      },
+      operational_context: {
+        activity_label: 'Needs Data',
+        activity_note: '0 users generated 0 geofence events in this range.',
+        enter_context: 'ENTER events support check-in reminder monitoring.',
+        exit_context: 'EXIT events support active-session exit warning monitoring.',
+        dashboard_note: 'Location context only. Final attendance validity remains determined by backend attendance records.'
       }
     });
   });
@@ -557,6 +571,13 @@ describe('dashboard analytics helper contract', () => {
         enter_events: 0,
         exit_events: 0,
         unique_users: 0
+      },
+      operational_context: {
+        activity_label: 'Needs Data',
+        activity_note: '0 users generated 0 geofence events in this range.',
+        enter_context: 'ENTER events support check-in reminder monitoring.',
+        exit_context: 'EXIT events support active-session exit warning monitoring.',
+        dashboard_note: 'Location context only. Final attendance validity remains determined by backend attendance records.'
       }
     });
 

--- a/tests/geofenceEvidenceSnapshot.test.js
+++ b/tests/geofenceEvidenceSnapshot.test.js
@@ -1,0 +1,39 @@
+import { buildGeofenceEvidenceData } from '../src/utils/geofenceEvidenceSnapshot.js';
+
+describe('geofence evidence operational context', () => {
+  test('returns Needs Data operational context when no location events exist in the selected window', () => {
+    const result = buildGeofenceEvidenceData({
+      effectiveWindow: {
+        startDateStr: '2026-04-01',
+        endDateStr: '2026-04-03'
+      },
+      locationEvents: []
+    });
+
+    expect(result).toEqual({
+      status: 'needs_data',
+      needs_data: true,
+      reason: 'NO_GEOFENCE_EVENTS',
+      authority: 'context_only',
+      final_attendance_authority: 'attendance_records',
+      window: {
+        from: '2026-04-01',
+        to: '2026-04-03'
+      },
+      raw_counts: {
+        total_events: 0,
+        enter_events: 0,
+        exit_events: 0,
+        unique_users: 0
+      },
+      operational_context: {
+        activity_label: 'Needs Data',
+        activity_note: '0 users generated 0 geofence events in this range.',
+        enter_context: 'ENTER events support check-in reminder monitoring.',
+        exit_context: 'EXIT events support active-session exit warning monitoring.',
+        dashboard_note:
+          'Location context only. Final attendance validity remains determined by backend attendance records.'
+      }
+    });
+  });
+});

--- a/tests/postmanFuzzyAhpDocumentationContract.test.js
+++ b/tests/postmanFuzzyAhpDocumentationContract.test.js
@@ -35,8 +35,8 @@ const meaningfulFahpLines = fahpSection
 const sectionSubheadingPattern = /^\s*#{3,6}\s+/m;
 const markdownTableRowPattern = /^\s*\|.*\|\s*$/m;
 
-const endpointBulletPattern = /^\s+-\s+`(GET \/api\/analysis\/fuzzy-ahp(?:\/[a-z-]+)?)`/gm;
-const endpointBullets = [...fahpSection.matchAll(endpointBulletPattern)].map((match) => match[1]);
+const endpointPathPattern = /`(GET \/api\/analysis\/fuzzy-ahp(?:\/[a-z_-]+)?)`/g;
+const endpointBullets = [...new Set([...fahpSection.matchAll(endpointPathPattern)].map((match) => match[1]))];
 
 describe('Postman Fuzzy AHP documentation contract', () => {
   test('keeps the FAHP documentation section short', () => {

--- a/tests/summaryDashboardAnalyticsContract.test.js
+++ b/tests/summaryDashboardAnalyticsContract.test.js
@@ -106,6 +106,13 @@ const responseShell = {
       enter_events: 0,
       exit_events: 0,
       unique_users: 0
+    },
+    operational_context: {
+      activity_label: 'Needs Data',
+      activity_note: '0 users generated 0 geofence events in this range.',
+      enter_context: 'ENTER events support check-in reminder monitoring.',
+      exit_context: 'EXIT events support active-session exit warning monitoring.',
+      dashboard_note: 'Location context only. Final attendance validity remains determined by backend attendance records.'
     }
   },
   fuzzy_ahp_snapshot: {

--- a/tests/summaryDashboardAnalyticsSeam.test.js
+++ b/tests/summaryDashboardAnalyticsSeam.test.js
@@ -274,6 +274,13 @@ describe('summary dashboard analytics seam', () => {
             enter_events: 1,
             exit_events: 2,
             unique_users: 2
+          },
+          operational_context: {
+            activity_label: 'Active',
+            activity_note: '2 users generated 3 geofence events in this range.',
+            enter_context: 'ENTER events support check-in reminder monitoring.',
+            exit_context: 'EXIT events support active-session exit warning monitoring.',
+            dashboard_note: 'Location context only. Final attendance validity remains determined by backend attendance records.'
           }
         },
         fuzzy_ahp_snapshot: {


### PR DESCRIPTION
## Summary
- lock dashboard-only backend contract surfaces without pulling reporting/export scope into this branch
- add attendance-owned `GET /api/attendance/geofence-evidence` as historical context-only evidence
- add `GET /api/analysis/fuzzy-ahp/dashboard?type=...` as lightweight monthly FAHP dashboard recap surface
- add display-friendly FAHP recap fields for dashboard clients:
  - `type_label`
  - `consistency.summary_label`
  - `criteria_weights[].display_label`
- align boundary docs and OpenAPI with the locked dashboard-only contract

## Scope
### In scope
- `/api/summary/dashboard-analytics`
- `/api/attendance/geofence-evidence`
- `/api/attendance/today-locations`
- `/api/analysis/fuzzy-ahp/dashboard`
- dedicated/legacy FAHP boundaries only as needed to preserve dashboard recap ownership

### Explicitly out of scope
- `/api/summary/reports`
- deprecated `/api/summary` reporting alias
- report search/filter/pagination/export semantics
- `report.user_attendance_summary`
- any new `/api/summary/dashboard-map` runtime surface
- any redesign of dedicated FAHP detail-analysis contracts

## Contract details
### Geofence evidence
- keeps top-level envelope: `success`, `requested_window`, `executed_window`, `data`, `message`
- preserves raw evidence counts under `raw_counts`
- adds `operational_context` for UI-ready operational monitoring copy
- remains `authority: context_only`
- keeps `final_attendance_authority: attendance_records`
- does **not** become fraud authority, final attendance truth, or behavior analytics owner

### FAHP dashboard recap v2
- stays recap-only and additive
- keeps query contract `type` only
- does not accept `period`, `from`, or `to`
- keeps existing fields and adds:
  - `type_label`
  - `consistency.summary_label`
  - `criteria_weights[].display_label`
- keeps dedicated FAHP endpoints canonical for detail-analysis
- keeps legacy combined FAHP endpoint compatibility-only

## Type/display mappings
### `type_label`
- `discipline` -> `Discipline`
- `wfa` -> `WFA`
- `smart_ac` -> `Smart AC`

### `consistency.summary_label`
- `is_consistent=true` -> `Konsistensi dapat diterima`
- `is_consistent=false` -> `Konsistensi perlu ditinjau`

### `criteria_weights[].display_label`
- `alpha_rate` -> `Disiplin Kehadiran`
- `lateness_severity` -> `Tingkat Keterlambatan`
- `lateness_frequency` -> `Frekuensi Keterlambatan`
- `work_focus` -> `Fokus Kerja`
- `location_type` -> `Tipe Lokasi`
- `distance_factor` -> `Faktor Jarak`
- `amenity_score` -> `Skor Fasilitas`
- `attendance` -> `Attendance`

## Verification
- `npm run lint`
- `npm test -- --runTestsByPath tests/geofenceEvidenceSnapshot.test.js tests/attendanceGeofenceEvidenceRoute.test.js`
- `npm test -- --runTestsByPath tests/analysisFuzzyAhpDashboardRecapRoute.test.js tests/analysisFuzzyAhpControllerValidation.test.js tests/clientCriticalOpenApiContract.test.js tests/analysisFuzzyAhpContract.test.js`
- focused geofence/dashboard contract suites passing during implementation

## Notes
- runtime `/api/summary/dashboard-map` was **not** introduced; stale host references must not override runtime truth
- reporting/export work remains intentionally separate
- this branch is safe to review as dashboard-only contract-lock work

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a monthly dashboard recap for Fuzzy AHP analysis with clearer labels and summary details.
  * Added a geofence evidence view with historical filtering and user-friendly context text.
  * Enhanced dashboard analytics responses with geofence context guidance.

* **Bug Fixes**
  * Improved response consistency for dashboard analytics and geofence-related endpoints.
  * Tightened parameter handling so invalid query combinations are rejected more clearly.

* **Documentation**
  * Updated endpoint guidance and usage notes to better route users to the correct analytics surfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->