### PR TITLE
fix: scope summary report user attendance data

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -3602,7 +3602,7 @@ paths:
           schema:
             type: string
             example: nico
-          description: Canonical free-text search for report rows. Applies before pagination to `report.data` and `report.pagination`; top-level `summary` remains period-wide, while `analytics.discipline_analysis` reflects the visible report users for the current page.
+          description: Canonical free-text search for report rows. Applies before pagination to `report.data`, `report.pagination`, and `report.user_attendance_summary`; top-level `summary` remains period-wide, while `analytics.discipline_analysis` reflects the visible report users for the current page.
         - in: query
           name: search
           deprecated: true
@@ -5358,6 +5358,7 @@ components:
           type: object
           properties:
             user_attendance_summary:
+              description: Per-user attendance summaries limited to users visible in the filtered report scope for the requested query window.
               type: array
               items:
                 $ref: '#/components/schemas/SummaryReportUserAttendanceSummaryRow'

--- a/src/services/summaryReport.service.js
+++ b/src/services/summaryReport.service.js
@@ -811,7 +811,7 @@ export const buildSummaryReportSource = async (query = {}, options = {}) => {
     report: {
       data: transformedPaginatedRows,
       pagination: includePaginatedReport ? buildPagination({ count: paginatedResult.count, page, limit }) : null,
-      user_attendance_summary: userAttendanceSummary
+      user_attendance_summary: scopedUserSummaries
     },
     analytics: {
       discipline_analysis: buildAnalyticsDisciplineAnalysis({

--- a/tests/summaryReportPerformance.test.js
+++ b/tests/summaryReportPerformance.test.js
@@ -134,7 +134,7 @@ describe('getSummaryReport performance contract', () => {
       rows: [userTenPageRow, userElevenPageRow]
     });
     mockSettingsFindAll.mockResolvedValue([{ setting_key: 'checkin.start_time', setting_value: '08:00:00' }]);
-    mockBuildUserAttendanceSummary.mockResolvedValue([{ user_id: 10, total_attendance: 1 }]);
+    mockBuildUserAttendanceSummary.mockResolvedValue([{ user_id: 10, valid_attendance_days: 1, wfo_days: 1, latest_attendance_date: '2026-05-01' }]);
     mockCalculateDisciplineIndex.mockImplementation(async (metrics) => ({
       score: metrics.avg_lateness_minutes > 0 ? 70 : 95,
       label: metrics.avg_lateness_minutes > 0 ? 'Good' : 'Excellent',
@@ -178,7 +178,9 @@ describe('getSummaryReport performance contract', () => {
     expect(mockCalculateDisciplineIndex).toHaveBeenCalledTimes(2);
 
     const payload = res.json.mock.calls[0][0];
-    expect(payload.report.user_attendance_summary).toEqual([{ user_id: 10, total_attendance: 1 }]);
+    expect(payload.report.user_attendance_summary).toEqual([
+      { user_id: 10, valid_attendance_days: 1, wfo_days: 1, latest_attendance_date: '2026-05-01' }
+    ]);
     expect(payload.report.data).toHaveLength(2);
     expect(payload.report.data[0]).toEqual(
       expect.objectContaining({
@@ -306,5 +308,72 @@ describe('getSummaryReport performance contract', () => {
         discipline_label: 'Needs Attention'
       })
     );
+  });
+
+  test('limits report user attendance summary to users visible in the scoped report rows', async () => {
+    const visibleRow = makeAttendanceRow({
+      id: 1,
+      userId: 10,
+      fullName: 'Visible User',
+      date: '2026-05-02',
+      timeIn: '08:00'
+    });
+    mockAttendanceFindAll
+      .mockResolvedValueOnce([{ status: { attendance_status_name: 'tepat waktu' }, dataValues: { total: '1' } }])
+      .mockResolvedValueOnce([{ attendance_category: { category_name: 'WFO' }, dataValues: { total: '1' } }])
+      .mockResolvedValueOnce([visibleRow])
+      .mockResolvedValueOnce([
+        {
+          id_attendance: 1,
+          user_id: 10,
+          attendance_date: '2026-05-02',
+          time_in: new Date('2026-05-02T08:00:00'),
+          time_out: new Date('2026-05-02T17:00:00'),
+          work_hour: 8,
+          status: { attendance_status_name: 'tepat waktu' }
+        },
+        {
+          id_attendance: 2,
+          user_id: 11,
+          attendance_date: '2026-05-01',
+          time_in: new Date('2026-05-01T09:00:00'),
+          time_out: new Date('2026-05-01T17:00:00'),
+          work_hour: 7,
+          status: { attendance_status_name: 'terlambat' }
+        }
+      ]);
+    mockAttendanceFindAndCountAll.mockResolvedValue({ count: 1, rows: [visibleRow] });
+    mockSettingsFindAll.mockResolvedValue([{ setting_key: 'checkin.start_time', setting_value: '08:00:00' }]);
+    mockBuildUserAttendanceSummary.mockResolvedValue([
+      { user_id: 10, valid_attendance_days: 1, wfo_days: 1, latest_attendance_date: '2026-05-02' },
+      { user_id: 11, valid_attendance_days: 5, wfo_days: 5, latest_attendance_date: '2026-05-01' }
+    ]);
+    mockCalculateDisciplineIndex.mockResolvedValue({
+      score: 95,
+      label: 'Excellent',
+      breakdown: { metrics: { total_days: 1 } }
+    });
+    mockGetDisciplineLabel.mockReturnValue('Fallback');
+
+    const { getSummaryReport } = await import('../src/controllers/summary.controller.js');
+    const res = makeRes();
+
+    await getSummaryReport(
+      { query: { period: '30d', q: 'Visible', page: '1', limit: '10' } },
+      res,
+      jest.fn()
+    );
+
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.report.data).toHaveLength(1);
+    expect(payload.report.data[0]).toEqual(
+      expect.objectContaining({
+        user_id: 10,
+        full_name: 'Visible User'
+      })
+    );
+    expect(payload.report.user_attendance_summary).toEqual([
+      { user_id: 10, valid_attendance_days: 1, wfo_days: 1, latest_attendance_date: '2026-05-02' }
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- align `report.user_attendance_summary` with the filtered report scope in the canonical `GET /api/summary/reports` payload
- add focused regression coverage so period-wide user summaries do not leak into search-scoped report responses
- sync `docs/openapi.yaml` so `q` filter semantics explicitly cover `report.user_attendance_summary`

## Fact
- root cause was in `src/services/summaryReport.service.js`: the canonical payload exposed raw period-wide `userAttendanceSummary` even when `report.data` was already filtered by `q`
- the shared service already had scoped visibility context (`scopedUserIds` / `scopedUserSummaries`), so the smallest safe fix was to change the exposed payload field rather than the global summary helper

## Assumption
- `report.user_attendance_summary` is expected to behave as part of the `report.*` scope family, while period-wide semantics remain represented by `period_summary`

## Mismatch / Needs Verification
- before this change, runtime behavior and contract intent were mismatched: `report.data` was search-scoped, but `report.user_attendance_summary` stayed period-wide
- downstream clients should still be checked for any accidental reliance on the old behavior

## Risk
- this changes canonical API semantics for `report.user_attendance_summary`, so any client depending on the old period-wide payload may need adjustment
- blast radius is limited because the change is isolated to response assembly; the underlying period-wide helper logic is unchanged

## Files changed
- `src/services/summaryReport.service.js`
- `tests/summaryReportPerformance.test.js`
- `docs/openapi.yaml`

## Verification
- `npm run lint`
- `npm test -- --runTestsByPath tests/summaryReportPerformance.test.js tests/summaryReportContract.test.js`

Result:
- lint PASS
- test PASS
- `2 passed, 2 total` suites
- `5 passed, 5 total` tests

## Docs / ADR update note
- API-significant contract touched
- OpenAPI updated in this branch to reflect the new scope semantics for `report.user_attendance_summary`
- no separate ADR proposed; this is treated as a contract correction / clarification on the canonical report route

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how free-text search affects summary report results and pagination.
  * Updated report descriptions to better explain which users are included in attendance summaries.

* **Bug Fixes**
  * Ensured attendance summary data only includes users visible in the filtered report results.
  * Kept the overall summary period-wide while preserving page-based visibility for other report sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->