### PR TITLE
Align backend master release path and DOCR runtime contract

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,12 +1,12 @@
 name: Deploy to Production
 
 on:
-  workflow_dispatch:
-    inputs:
-      confirm:
-        description: 'Type "deploy-to-production" to confirm'
-        required: true
-        default: ''
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 permissions:
   contents: read
@@ -22,22 +22,9 @@ env:
   PRODUCTION_EXPECTED_IP: ${{ vars.PRODUCTION_EXPECTED_IP }}
 
 jobs:
-  validate:
-    name: Validate Deployment Request
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Check confirmation
-        run: |
-          if [ "${{ github.event.inputs.confirm }}" != "deploy-to-production" ]; then
-            echo "Deployment not confirmed. Type 'deploy-to-production' exactly."
-            exit 1
-          fi
-
   test:
     name: Lint & Test
     runs-on: ubuntu-latest
-    needs: validate
 
     steps:
       - name: Checkout code
@@ -72,6 +59,7 @@ jobs:
     name: Build & Push Docker Image
     runs-on: ubuntu-latest
     needs: test
+    if: github.event_name != 'pull_request'
 
     steps:
       - name: Checkout code
@@ -103,6 +91,7 @@ jobs:
     name: Deploy to Production Droplet
     runs-on: ubuntu-latest
     needs: build-push
+    if: github.event_name != 'pull_request'
 
     environment:
       name: production
@@ -181,7 +170,7 @@ jobs:
   notify-failure:
     name: Notify on Failure
     runs-on: ubuntu-latest
-    needs: [validate, test, build-push, deploy-production]
+    needs: [test, build-push, deploy-production]
     if: failure()
 
     steps:
@@ -189,7 +178,7 @@ jobs:
         run: |
           echo "## Production Deployment Failed" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "The production release path is blocked until confirmation, lint, test, image publication, droplet rollout, migrations, and smoke verification all pass." >> $GITHUB_STEP_SUMMARY
+          echo "The production release path is blocked until lint, test, image publication, droplet rollout, migrations, and smoke verification all pass." >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Investigate:" >> $GITHUB_STEP_SUMMARY
           echo "- DOCR image publication logs" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -7,7 +7,6 @@ on:
   pull_request:
     branches:
       - master
-  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@ yarn-error.log*
 .env.test.local
 .env.production.local
 
+# Deploy runtime env baselines (local-only, never commit real secrets)
+deploy/env/*.env
+!deploy/env/*.example
+
 # Logs
 logs/
 *.log
@@ -58,6 +62,9 @@ docker-compose.override.yml
 .claude/settings.local.json
 .claude/worktrees/
 .worktrees/
+
+# Local orchestration scratch
+.superpowers/
 
 # Kubernetes secrets (never commit real secrets)
 k8s/secret.yaml

--- a/README.md
+++ b/README.md
@@ -451,6 +451,9 @@ const disciplineFactors = {
 
 Infinit Track Backend menggunakan **GitOps-style deployment** berbasis **DigitalOcean Container Registry (DOCR) + droplet-hosted Docker Compose runtime + host Nginx**. Image backend dibangun di CI, dipush ke `registry.digitalocean.com/infinit-track/infinit-track-backend`, lalu runtime droplet menarik image immutable melalui `BACKEND_IMAGE_TAG`.
 
+Official backend release path: `develop -> review -> master -> deploy`.
+Staging and production both derive from `master`; `master` should only receive reviewed, verified release candidates.
+
 ```
 Development → Image Build → Staging Droplet → Production Droplet
      ↓             ↓              ↓                    ↓
@@ -505,13 +508,9 @@ git push origin master
 # → push ke master memicu workflow staging:
 #   lint + test + DOCR publish + droplet rollout + migrate + blocking smoke gate
 
-# Optional: run staging workflow manually from GitHub Actions
-# → workflow_dispatch pada "Deploy to Staging"
-
 # Production / approved release flow
-# Trigger workflow "Deploy to Production" secara manual,
-# isi konfirmasi deploy-to-production,
-# lalu workflow menjalankan lint + test + DOCR publish + droplet rollout + migrate + blocking smoke gate.
+# → merge/push reviewed, verified release candidate to master
+# → workflow menjalankan lint + test + DOCR publish + production droplet rollout + migrate + blocking smoke gate.
 ```
 
 ### **🎯 8.3 Deployment Workflows**
@@ -556,7 +555,7 @@ Canonical production release should do this in order:
 | **Database**       | Staging DB (test data) | Production DB (**separate**) |
 | **JWT_SECRET**     | Staging secret         | **Different** secret         |
 | **CORS_ORIGIN**    | Staging frontend       | Production frontend          |
-| **Deploy Trigger** | Automatic              | Manual + Approval            |
+| **Deploy Trigger** | Automatic from `master` | Automatic from `master` after reviewed, verified promotion |
 | **Instance Count** | 1                      | 2+ (HA)                      |
 | **Log Level**      | `info`                 | `warn`                       |
 
@@ -564,7 +563,7 @@ Canonical production release should do this in order:
 
 - Reuse production secrets in staging
 - Mix production & staging databases
-- Auto-deploy to production
+- Merge unreviewed or unverified changes to `master`
 
 ### **📊 8.5 Monitoring & Health Checks**
 
@@ -667,8 +666,8 @@ git push origin master
 git revert <commit-hash>
 git push origin master
 
-# Staging: Auto-deploys
-# Production: Manual trigger required
+# Staging: Auto-deploys from master
+# Production: Auto-deploys from master after reviewed, verified promotion
 ```
 
 #### **Database Rollback (Emergency)**
@@ -731,8 +730,8 @@ git push origin feature/new-feature
 # → Verify canonical staging host after rollout completes
 
 # 4. Production Deploy (when ready)
-# → Manual trigger via GitHub Actions: "Deploy to Production"
-# → Type deploy-to-production for confirmation
+# → Merge/push reviewed, verified release candidate to master
+# → Production deploy runs automatically from master after required evidence is green
 # → Monitor live host and logs after smoke gate passes
 ```
 
@@ -963,7 +962,7 @@ _Infinite Track Backend adalah solusi enterprise-grade untuk manajemen kehadiran
 **Deployment Status:**
 
 - ✅ Staging: Auto-deploy dari master branch
-- ✅ Production: Manual deploy dengan approval workflow
+- ✅ Production: Automatic deploy from `master` after a reviewed and verified promotion
 - ✅ Database: Managed MySQL dengan automated backups
 - ✅ Monitoring: Real-time logs dan health checks
 - ✅ Security: CORS, security headers, rate limiting, JWT auth

--- a/deploy/env/backend.production.example
+++ b/deploy/env/backend.production.example
@@ -1,3 +1,6 @@
+# Copy this template to deploy/env/backend.production.env on the target runtime.
+# The copied .env file is local-only runtime state and should remain untracked.
+
 # Runtime
 NODE_ENV=production
 PORT=3005

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,17 @@
 services:
   app:
-    image: ${BACKEND_IMAGE:-infinit-track-backend}:${BACKEND_IMAGE_TAG:-latest}
-    build:
-      context: .
-      target: production
-      network: host
+    image: ${BACKEND_IMAGE:-registry.digitalocean.com/infinit-track/infinit-track-backend}:${BACKEND_IMAGE_TAG:?BACKEND_IMAGE_TAG is required}
+    # Canonical droplet runtime is image-first via DOCR + immutable BACKEND_IMAGE_TAG.
+    # This compose file is the droplet runtime surface, so it must fail fast when the
+    # selected immutable tag is missing instead of silently falling back to `latest`.
     container_name: infinit-track-app
     restart: unless-stopped
     network_mode: host
     # Intentionally defaults to the real droplet env path.
     # Operators should copy deploy/env/backend.production.example to
-    # deploy/env/backend.production.env before first startup; missing env file
-    # should fail fast instead of booting with placeholder values.
+    # deploy/env/backend.production.env before first startup and keep that
+    # resulting env file local-only/untracked; missing env file should fail
+    # fast instead of booting with placeholder values.
     env_file:
       - ${BACKEND_ENV_FILE:-./deploy/env/backend.production.env}
     environment:

--- a/docs/PRODUCTION_DEPLOYMENT.md
+++ b/docs/PRODUCTION_DEPLOYMENT.md
@@ -15,6 +15,18 @@ Backend deployment truth for the current phase is:
 
 This document should not be used to justify new App Platform deployment work unless that direction is intentionally reactivated later.
 
+## Official Release Path
+
+The backend uses a single official release path:
+
+`develop -> review -> master -> deploy`
+
+- `develop` is the integration and review surface.
+- `master` is the release branch.
+- staging deploy is automatic from `master`.
+- production deploy is automatic from `master`.
+- all required evidence is green before merge into `master`.
+
 ## Current Deployment Model
 
 ### Phase 1: Publish image to DOCR
@@ -49,7 +61,7 @@ They are not part of the supported active backend deploy path and should be trea
 
 ### What this document does not claim
 - that the publish-only workflow (`docker-deploy.yml`) deploys the runtime to the droplet by itself
-- that production rollout is already automated in the same way the staging droplet workflow is
+- that automatic production rollout removes the required review and evidence gate before merge into `master`
 - that Kubernetes is an active deployment path
 
 ## Deployment Readiness Checklist

--- a/docs/droplet-docr-runtime.md
+++ b/docs/droplet-docr-runtime.md
@@ -8,7 +8,9 @@ Compose file adalah bagian dari image-based runtime procedure. Local host-run de
 ## Image contract
 - Repository: `registry.digitalocean.com/infinit-track/infinit-track-backend`
 - Runtime tag source: `BACKEND_IMAGE_TAG`
-- `latest` hanya convenience; deploy aktual harus pin SHA image yang immutable.
+- Default compose image should resolve to the DOCR repository above unless an operator intentionally overrides `BACKEND_IMAGE` for a local/manual scenario.
+- `BACKEND_IMAGE_TAG` wajib di-set ke SHA image immutable sebelum runtime pull/recreate dijalankan.
+- `latest` hanya convenience untuk publication/discovery, bukan fallback runtime deploy.
 
 ## Health contract
 - `/livez` = process liveness

--- a/docs/infra-config-truth-audit.md
+++ b/docs/infra-config-truth-audit.md
@@ -1,5 +1,7 @@
 # INF-32 Backend Config Truth Audit
 
+> Historical audit snapshot dated 2026-04-20. Some findings below are retained for provenance and have since been superseded by live runtime code. In particular, the current runtime now reads `DB_SSL` and `DB_SSL_REJECT_UNAUTHORIZED` through `src/config/index.js` and `src/config/database.js`.
+
 ## Scope
 Audit runtime/config truth across these surfaces:
 - local development
@@ -27,7 +29,7 @@ This means staging deployment can succeed or fail depending on which surface an 
 |---|---|---|---|---|---|---|---|
 | `DB_HOST` | `.env.example`, `.do/app*.yaml`, `docker-compose.yml` env | `src/config/index.js`, `src/config/database.js` | defaults to local MySQL expectation | compose sets `db`; droplet target likely needs external DB host | `ci.yml` sets `localhost`; deploy-* workflows and `.do` surfaces imply other runtime targets | `CLAUDE.md` points to `.do/app*.yaml`, while this rollout targets droplet staging | same concept but surface-dependent value, no single canonical source |
 | `DB_USER`, `DB_PASS`, `DB_NAME` | `.env.example`, `.do/app*.yaml`, `docker-compose.yml` | `src/config/index.js` | env-driven | compose defaults to sample values | `ci.yml` sets test values; deploy-* workflows and `.do` imply runtime values elsewhere | docs mention env-driven workflow | no explicit staging source-of-truth document |
-| `DB_SSL` | `.env.example`, `.do/app-production.yaml`, `k8s/configmap.yaml` | **not read by active runtime config** | no effect | no effect unless future code reads it | not used in `ci.yml` | production app spec assumes it exists | declared but unused by `src/config/index.js` / `database.js` |
+| `DB_SSL` | `.env.example`, `.do/app-production.yaml`, `k8s/configmap.yaml` | `src/config/index.js`, `src/config/database.js`, `src/config/database-cli.cjs` | toggles TLS locally when env is set | controls managed-DB TLS behavior for droplet/runtime and sequelize-cli migrations | not used in `ci.yml` | production app spec assumes it exists | historical audit row was stale before runtime code caught up; current runtime does read it |
 | `JWT_SECRET` | `.env.example`, `.do/app*.yaml` | `src/config/index.js` / auth middleware | validated only in production; functionally required wherever JWT sign/verify flows run | required in droplet runtime for auth-enabled deployments | `ci.yml` sets a test secret | docs imply backend-only secret | wording must distinguish prod-only validation from broader runtime requirement |
 | `JWT_TTL_SECONDS` | `.env.example`, `.do/app*.yaml` | `src/config/index.js` | defaults to 86400 | env-driven | `ci.yml` does not set it | consistent enough | low drift |
 | `CORS_ORIGIN` | `.env.example`, `.do/app*.yaml`, README | `src/config/index.js`, `src/middlewares/security.js` | defaults to `*` | compose does not set explicit value | `ci.yml` does not set it | production guidance exists | dangerous local default can leak into staging if not explicitly set |

--- a/docs/superpowers/specs/2026-06-30-backend-master-release-path-design.md
+++ b/docs/superpowers/specs/2026-06-30-backend-master-release-path-design.md
@@ -1,0 +1,216 @@
+# Backend Master Release Path Design
+
+**Date:** 2026-06-30  
+**Repo:** `Infinit_Track_BE`  
+**Status:** Draft for user review  
+**Scope:** Backend deploy/release-path alignment only
+
+## 1. Purpose
+
+Lock a single official backend release path so branch policy, runtime policy, and operator expectations stop drifting.
+
+Target operating model:
+
+```text
+develop -> review -> master -> deploy
+```
+
+In this model:
+- `develop` is the integration and review surface.
+- `master` is the release branch.
+- deployment is only legitimate from `master`.
+- both staging and production are deployed automatically from `master`.
+- merge into `master` is only allowed after all required evidence is green.
+
+This design is intentionally bounded. It does not redesign the backend application itself, database schema, auth/session semantics, attendance final-state semantics, scheduler semantics, or FAHP behavior.
+
+## 2. Problem Statement
+
+The current backend deploy story is technically functional but operationally ambiguous.
+
+Confirmed facts from repo and runtime evidence:
+- canonical backend runtime is droplet-based, not Kubernetes.
+- DOCR exists and is part of the active backend release story.
+- the public staging host is alive and healthy.
+- the repository still contains multiple historical or parallel-looking deploy surfaces.
+- repo governance states `develop` is the integration/review surface and `master` is the release-ready branch.
+- current deploy workflow behavior has historically been easier to read as `master`-centric than `develop`-centric.
+
+This creates a risk that different operators infer different release rules from the same repository.
+
+The issue is not “backend cannot deploy.”
+The issue is “backend deploy authority can still be read in more than one way.”
+
+## 3. Design Goal
+
+Establish one release-path truth for backend deployment:
+
+```text
+feature/fix work -> develop -> review and verification -> master -> automatic staging deploy -> automatic production deploy
+```
+
+This does **not** mean every GitHub workflow must collapse into one file.
+It means all valid release behavior must point back to the same branch/release rule.
+
+## 4. Non-Goals
+
+This design does not attempt to:
+- merge staging and production workflows into a single YAML file.
+- redesign DigitalOcean infrastructure.
+- introduce a new environment topology.
+- move staging deployment authority back to `develop`.
+- introduce App Platform as an active backend runtime path.
+- preserve local build-in-place as an equal release path to DOCR image deployment.
+
+## 5. Chosen Design
+
+### 5.1 Branch and release model
+
+The official backend release path is:
+
+```text
+develop -> review -> master -> deploy
+```
+
+Rules:
+- all normal implementation work lands in feature/fix branches and returns to `develop` first.
+- `develop` is where integration and review confidence is built.
+- promotion to `master` is a release act, not a normal feature-development act.
+- `master` is the only branch that can legitimately trigger deployment behavior.
+
+### 5.2 Deployment trigger model
+
+Deployment remains `master`-driven.
+
+Rules:
+- staging deploy is automatic from `master`.
+- production deploy is automatic from `master`.
+- no other branch should be treated as a valid deploy source.
+- if separate workflows remain, they must still be unambiguous about `master` being the only release source branch.
+
+### 5.3 Verification gate before `master`
+
+Merge into `master` is only valid when all required evidence is green.
+
+Minimum gate:
+- review approval exists.
+- backend lint is green.
+- backend test suite is green.
+- required smoke/runtime verification evidence exists.
+- deploy/runtime contract changes are explicitly called out when touched.
+- unresolved risk is named rather than silently ignored.
+
+This means `master` is not a test playground.
+It is a promotion branch that should only receive reviewed, verified release candidates.
+
+### 5.4 Runtime-path rule
+
+The backend runtime path must remain singular in meaning even if the repo contains multiple historical artifacts.
+
+Canonical backend runtime:
+- droplet-hosted Docker Compose
+- DOCR-backed image pull
+- managed MySQL behind the runtime
+- host-level ingress in front of the containerized app
+
+Implications:
+- App Platform backend artifacts are historical unless intentionally reactivated later.
+- Kubernetes backend artifacts are historical/non-active unless intentionally reactivated later.
+- local build-in-place may remain possible for local/operator scenarios, but it is not a peer release path.
+- release documentation and contract tests should reinforce that the release runtime is image-first and tag-driven.
+
+### 5.5 Contract interpretation rule
+
+"Only one deploy path" in this design means:
+- one official release branch path
+- one official runtime meaning
+- one official deploy-source branch
+
+It does **not** require:
+- one workflow file only
+- one environment only
+- one host only
+
+As long as all valid deployment behavior resolves to the same release truth, the design is satisfied.
+
+## 6. Operational Consequences
+
+### 6.1 For developers
+- normal work should stop at `develop`.
+- no one should think of `develop` as a release branch.
+- promotion to `master` becomes an explicit release step.
+
+### 6.2 For reviewers/operators
+- review confidence is accumulated before `master`, not after.
+- if evidence is incomplete, the correct action is to block promotion to `master`.
+- post-merge runtime failures from `master` are treated as release failures, not ordinary integration noise.
+
+### 6.3 For workflow maintenance
+- workflow files may stay separate for staging and production.
+- but their branch trigger semantics, summary text, and surrounding docs must not imply alternative release paths.
+- if a workflow can be triggered manually, it still must not undermine the rule that `master` is the only legitimate deploy source branch.
+
+## 7. Risks and Trade-offs
+
+### Benefits
+- simpler operator mental model
+- stronger release discipline
+- better alignment between docs, policy, and runtime evidence
+- fewer accidental “is staging from develop or master?” questions
+
+### Costs
+- slower promotion to `master` because evidence must be ready first
+- less flexibility for ad-hoc branch-based deployment experiments
+- any remaining workflow ambiguity becomes more visible and must be cleaned up
+
+### Main risk
+If workflow files, repo docs, and human habits are not aligned after this design is adopted, the team may continue following mixed release behavior despite the documented rule.
+
+## 8. Acceptance Criteria
+
+This design is considered successfully implemented when all of the following are true:
+
+1. backend repo guidance consistently states:
+   - `develop` = integration/review
+   - `master` = release/deploy source
+2. no active backend deploy workflow implies another branch as an equal deploy source.
+3. canonical backend runtime documentation clearly points to droplet + DOCR + managed DB.
+4. the compose/runtime contract does not silently encourage non-canonical release behavior.
+5. promotion to `master` is described as evidence-gated.
+6. staging and production deployment behavior both clearly derive from `master`.
+
+## 9. Recommended Implementation Scope
+
+The implementation plan for this design should focus on:
+- workflow trigger and wording alignment
+- release-policy doc alignment
+- runtime-path doc alignment
+- contract test alignment where deploy behavior is asserted
+- avoiding broad unrelated infra refactors
+
+The implementation plan should **not** automatically expand into:
+- secret rotation work
+- infra redesign
+- database migration redesign
+- application behavior changes outside deploy/runtime contract surfaces
+
+## 10. Open Questions Resolved in This Design
+
+Resolved choices:
+- official release path = `develop -> review -> master -> deploy`
+- `master` deploys to staging automatically
+- `master` deploys to production automatically
+- all evidence must be green before merge into `master`
+- “single deploy path” means one branch/release truth, not necessarily one workflow file
+
+## 11. Recommendation
+
+Proceed with a contract-first implementation.
+
+That means the next planning phase should make the smallest set of changes necessary to ensure:
+- branch policy,
+- workflow semantics,
+- runtime contract,
+- and deploy documentation
+
+all say the same thing without introducing broader system redesign.

--- a/tests/configContract.test.js
+++ b/tests/configContract.test.js
@@ -468,6 +468,33 @@ describe('backend runtime config contract', () => {
     expect(dropletRuntime).not.toContain('docker compose up -d app');
   });
 
+  test('treats master as the only deploy source branch for both staging and production workflows', () => {
+    const stagingWorkflow = readWorkflow('.github/workflows/deploy-staging.yml');
+    const productionWorkflow = readWorkflow('.github/workflows/deploy-production.yml');
+
+    expect(stagingWorkflow).toContain('push:');
+    expect(stagingWorkflow).toContain('branches:');
+    expect(stagingWorkflow).toContain('- master');
+    expect(stagingWorkflow).not.toContain('branches:\n      - develop');
+
+    expect(productionWorkflow).toContain('push:');
+    expect(productionWorkflow).toContain('branches:');
+    expect(productionWorkflow).toContain('- master');
+    expect(productionWorkflow).not.toContain('workflow_dispatch:');
+    expect(productionWorkflow).not.toContain('deploy-to-production');
+  });
+
+  test('documents the official backend release path as develop to master to deploy', () => {
+    const readme = readRootReadme();
+    const productionGuide = readScript('docs/PRODUCTION_DEPLOYMENT.md');
+
+    expect(readme).toContain('develop -> review -> master -> deploy');
+    expect(productionGuide).toContain('develop -> review -> master -> deploy');
+    expect(productionGuide).toContain('staging deploy is automatic from `master`');
+    expect(productionGuide).toContain('production deploy is automatic from `master`');
+    expect(productionGuide).toContain('all required evidence is green before merge into `master`');
+  });
+
   test('locks staging and production workflows to droplet rollout with blocking verification', () => {
     const stagingWorkflow = readWorkflow('.github/workflows/deploy-staging.yml');
     const productionWorkflow = readWorkflow('.github/workflows/deploy-production.yml');

--- a/tests/configContract.test.js
+++ b/tests/configContract.test.js
@@ -279,12 +279,14 @@ describe('backend runtime config contract', () => {
     expect(config.autoCheckout).toBeUndefined();
   });
 
-  test('declares droplet runtime contract with host networking and env-file driven config', () => {
+  test('declares droplet runtime contract with immutable DOCR image selection and env-file driven config', () => {
     const compose = readDockerCompose();
 
-    expect(compose).toContain('image: ${BACKEND_IMAGE:-infinit-track-backend}:${BACKEND_IMAGE_TAG:-latest}');
-    expect(compose).toContain('build:');
-    expect(compose).toContain('network: host');
+    expect(compose).toContain(
+      'image: ${BACKEND_IMAGE:-registry.digitalocean.com/infinit-track/infinit-track-backend}:${BACKEND_IMAGE_TAG:?BACKEND_IMAGE_TAG is required}'
+    );
+    expect(compose).not.toContain('build:');
+    expect(compose).not.toContain('network: host');
     expect(compose).toContain('network_mode: host');
     expect(compose).toContain('env_file:');
     expect(compose).toContain('${BACKEND_ENV_FILE:-./deploy/env/backend.production.env}');
@@ -512,6 +514,9 @@ describe('backend runtime config contract', () => {
     expect(stagingWorkflow).toContain('STAGING_EXPECTED_IP');
     expect(stagingWorkflow).toContain('Missing required staging runtime variable');
     expect(stagingWorkflow).toContain('authenticated Admin/Management only');
+    expect(stagingWorkflow).toContain('push:');
+    expect(stagingWorkflow).toContain('pull_request:');
+    expect(stagingWorkflow).not.toContain('workflow_dispatch:');
     expect(stagingWorkflow).not.toContain('https://api.infinite-track.tech');
     expect(stagingWorkflow).not.toContain('continue-on-error: true');
     expect(stagingWorkflow).not.toContain('doctl apps create-deployment');
@@ -524,7 +529,7 @@ describe('backend runtime config contract', () => {
     expect(productionWorkflow).toContain('docker compose exec -T app npm run migrate');
     expect(productionWorkflow).toContain('./deploy/scripts/verify-droplet-api.sh');
     expect(productionWorkflow).toContain('npm run smoke-test "$PRODUCTION_PUBLIC_BASE_URL"');
-    expect(productionWorkflow).toContain('Type "deploy-to-production" to confirm');
+    expect(productionWorkflow).toContain("if: github.event_name != 'pull_request'");
     expect(productionWorkflow).toContain('PRODUCTION_PUBLIC_BASE_URL');
     expect(productionWorkflow).toContain('authenticated Admin/Management only');
     expect(productionWorkflow).not.toContain('doctl apps create-deployment');


### PR DESCRIPTION
## Summary
- align backend release path contract to `develop -> review -> master -> deploy`
- make staging and production workflows derive from `master`
- tighten canonical droplet + DOCR runtime contract and related docs/tests
- add the approved design spec for the master release path

## Changes
- update `deploy-production.yml` and `deploy-staging.yml` to remove non-`master` deploy entry points and keep PR runs validation-only
- lock release-path semantics in `tests/configContract.test.js`
- align `README.md` and `docs/PRODUCTION_DEPLOYMENT.md` to the official release path
- lock DOCR image/runtime expectations in `docker-compose.yml`, `deploy/env/backend.production.example`, `docs/droplet-docr-runtime.md`, and `docs/infra-config-truth-audit.md`
- add `docs/superpowers/specs/2026-06-30-backend-master-release-path-design.md`

## Verification
- `npm run lint`
- `npm test`
- `npm run smoke-test https://api.infinite-track.tech`

## Caveat
Production is now auto-triggered from `master`, so GitHub-side protection/governance for `master` must be confirmed as the replacement control for the removed manual confirmation step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated deployment flows so staging and production now follow a clearer branch-based release path from `master`.
  * Added guidance for an official release process and runtime image selection rules.

* **Bug Fixes**
  * Prevented production deployment steps from running on pull request events.
  * Tightened runtime configuration expectations to avoid falling back to mutable images.

* **Documentation**
  * Refreshed deployment docs to match the new release and rollout behavior.
  * Clarified local environment file handling and ignored files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->