### PR TITLE
Clarify master GitHub gate semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,17 @@ Infinit Track Backend menggunakan **GitOps-style deployment** berbasis **Digital
 Official backend release path: `develop -> review -> master -> deploy`.
 Staging and production both derive from `master`; `master` should only receive reviewed, verified release candidates.
 
+GitHub enforces PR review + `build` on `master`.
+
+In this repository, `build` means install + lint + test:
+
+- install dependencies (`npm ci`)
+- lint (`npm run lint`)
+- test (`npm test`)
+
+runtime/smoke verification is still an operational verification concern.
+It is not part of the enforced GitHub merge gate for `master` today.
+
 ```
 Development → Image Build → Staging Droplet → Production Droplet
      ↓             ↓              ↓                    ↓
@@ -467,7 +478,7 @@ Development → Image Build → Staging Droplet → Production Droplet
 - ✅ Image release dipin oleh `BACKEND_IMAGE_TAG`
 - ✅ Manual/CI deploy harus diverifikasi lewat `/livez` dan `/health`
 - ✅ Managed MySQL tetap terpisah per environment
-- ✅ Smoke/readiness verification adalah release gate, bukan best-effort check
+- ✅ Smoke/readiness verification adalah release gate operasional, bukan enforced GitHub merge gate untuk `master` today
 - ✅ Rollback dilakukan dengan mengembalikan tag image terakhir yang sehat
 
 ### **📋 8.2 Quick Start - First Deployment**
@@ -505,12 +516,13 @@ PRODUCTION_EXPECTED_IP=<production-public-ip>
 git add .
 git commit -m "Deploy-ready change"
 git push origin master
-# → push ke master memicu workflow staging:
-#   lint + test + DOCR publish + droplet rollout + migrate + blocking smoke gate
+# → GitHub merge gate for master requires PR review + build
+# → build means npm ci + npm run lint + npm test
+# → runtime rollout and smoke verification remain operational release evidence
 
 # Production / approved release flow
 # → merge/push reviewed, verified release candidate to master
-# → workflow menjalankan lint + test + DOCR publish + production droplet rollout + migrate + blocking smoke gate.
+# → GitHub merge gate remains PR review + build; runtime/smoke verification is operational evidence.
 ```
 
 ### **🎯 8.3 Deployment Workflows**
@@ -605,7 +617,7 @@ Automated tests after each deployment:
 # Run locally against the current staging host
 npm run smoke-test "$STAGING_PUBLIC_BASE_URL"
 
-# Included in GitHub Actions automatically
+# Operational verification; not part of the enforced GitHub merge gate for master today
 # Tests: Liveness, Readiness, Docs, CORS, Security, Auth, Performance
 ```
 

--- a/README.md
+++ b/README.md
@@ -515,13 +515,14 @@ PRODUCTION_EXPECTED_IP=<production-public-ip>
 # Staging / release-candidate flow
 git add .
 git commit -m "Deploy-ready change"
-git push origin master
+git push origin <review-branch>
+# → open PR to master
 # → GitHub merge gate for master requires PR review + build
 # → build means npm ci + npm run lint + npm test
 # → runtime rollout and smoke verification remain operational release evidence
 
 # Production / approved release flow
-# → merge/push reviewed, verified release candidate to master
+# → merge reviewed, verified PR into master
 # → GitHub merge gate remains PR review + build; runtime/smoke verification is operational evidence.
 ```
 

--- a/docs/PRODUCTION_DEPLOYMENT.md
+++ b/docs/PRODUCTION_DEPLOYMENT.md
@@ -27,6 +27,13 @@ The backend uses a single official release path:
 - production deploy is automatic from `master`.
 - all required evidence is green before merge into `master`.
 
+## Master GitHub Gate
+
+GitHub enforces PR review + `build` for `master`.
+In this repository, `build` means install + lint + test.
+
+runtime/smoke verification is still an operational verification concern, not an enforced GitHub merge gate today.
+
 ## Current Deployment Model
 
 ### Phase 1: Publish image to DOCR

--- a/docs/superpowers/specs/2026-06-30-master-github-gate-hardening-design.md
+++ b/docs/superpowers/specs/2026-06-30-master-github-gate-hardening-design.md
@@ -1,0 +1,159 @@
+# Master GitHub Gate Hardening Design
+
+**Date:** 2026-06-30  
+**Repo:** `Infinit_Track_BE`  
+**Status:** Draft for user review  
+**Scope:** GitHub-only hardening for the `master` release gate
+
+## 1. Purpose
+
+Define the minimum GitHub governance required for `master` now that the backend release path has been normalized to:
+
+```text
+develop -> review -> master -> deploy
+```
+
+This design intentionally hardens only the GitHub merge gate. It does not redesign runtime workflows, environment approvals, or broader release process layers.
+
+## 2. Problem Statement
+
+We verified that:
+- `master` had disappeared from GitHub and was recreated from current `develop`.
+- active repository rulesets exist for `master`.
+- the effective rules for `master` currently require pull-request review and a required check named `build`.
+- the `build` check is meaningful because the CI workflow job named `build` runs `npm ci`, `npm run lint`, and `npm test`.
+
+The remaining issue is not absence of governance, but ambiguity about what that governance does and does not guarantee.
+
+Without an explicit design, future operators may incorrectly assume that:
+- smoke/runtime verification is already enforced by GitHub merge policy, or
+- release safety is stronger than the actual configured gate.
+
+## 3. Design Goal
+
+Lock an explicit and honest GitHub-only merge gate for `master`:
+
+- `master` exists as the release branch.
+- merge to `master` requires PR-based review.
+- merge to `master` requires the `build` check to pass.
+- `build` is explicitly defined as the CI job that performs install + lint + test.
+- no stronger guarantee is implied.
+
+## 4. Non-Goals
+
+This design does not attempt to:
+- add smoke/runtime verification as a required GitHub check.
+- add environment approval gates.
+- redesign staging/production workflow topology.
+- add new deployment workflows.
+- replace operational verification with GitHub policy.
+- change backend runtime behavior.
+
+## 5. Chosen Design
+
+### 5.1 Branch existence rule
+
+`master` must continue to exist as a first-class remote branch because release governance and auto-deploy semantics now depend on it.
+
+### 5.2 Merge policy rule
+
+The minimum acceptable GitHub gate for `master` is:
+- pull request review required
+- required status check `build`
+
+That is the only merge gate this design intends to enforce.
+
+### 5.3 Meaning of `build`
+
+`build` is not a generic label.
+In this repository it maps to the CI workflow job that runs:
+- `npm ci`
+- `npm run lint`
+- `npm test`
+
+This mapping must remain true if the repository continues to rely on `build` as the only required check for `master`.
+
+### 5.4 Honesty rule
+
+Documentation and operator guidance must not imply that `master` merge is protected by smoke/runtime verification if GitHub does not actually enforce that.
+
+The correct interpretation is:
+- GitHub enforces review + `build`
+- operational/runtime verification may still exist as process evidence, but not as a required GitHub merge check
+
+### 5.5 Release-surface rule
+
+Because staging and production now derive from `master`, weakening `master` governance would directly weaken release safety.
+
+Therefore:
+- `master` merge gate must stay explicit
+- branch/ruleset drift must be treated as a release risk
+- repo docs should reflect the real GitHub gate, not an imagined one
+
+## 6. Operational Consequences
+
+### 6.1 What this gate guarantees
+- code entering `master` has passed PR review
+- code entering `master` has passed install + lint + test through `build`
+
+### 6.2 What this gate does not guarantee
+- successful smoke test against a live runtime
+- successful droplet rollout
+- environment approval or human release signoff beyond PR review
+- protection from all accidental release risk if GitHub admin settings are later weakened
+
+### 6.3 Why this is still acceptable
+
+This is acceptable because the chosen scope is intentionally minimal.
+The goal is not to solve all release governance at once.
+The goal is to ensure GitHub’s actual merge gate is explicit, meaningful, and not overstated.
+
+## 7. Risks and Trade-offs
+
+### Benefits
+- smallest possible hardening step
+- no workflow redesign required
+- keeps release gate understandable
+- makes `build` enforcement explicit and auditable
+
+### Costs
+- smoke/runtime verification is still outside the required GitHub gate
+- operational discipline is still needed after merge to `master`
+- if CI job naming changes, the meaning of `build` can drift unless tests/docs are kept aligned
+
+### Main risk
+If the repo continues to say or imply that `master` is fully release-safe just because GitHub enforces `build`, operators may overtrust the merge gate and skip runtime verification.
+
+## 8. Acceptance Criteria
+
+This design is considered implemented when all of the following are true:
+
+1. `master` exists remotely.
+2. GitHub ruleset for `master` remains active.
+3. `master` requires PR review.
+4. `master` requires the `build` check.
+5. repository docs/specs describe `build` honestly as install + lint + test, not as a smoke/runtime gate.
+6. no repository guidance falsely claims that smoke/runtime verification is GitHub-enforced if it is not.
+
+## 9. Recommended Implementation Scope
+
+Implementation should stay bounded to:
+- GitHub-side verification/audit of `master` rules
+- repo docs/spec wording where merge-gate meaning is described
+- contract tests if needed to lock the `build` check meaning or branch gate assumptions
+
+Implementation should not automatically expand into:
+- smoke check enforcement redesign
+- deploy workflow redesign
+- infra approval layers
+- broader release orchestration changes
+
+## 10. Recommendation
+
+Proceed with minimal GitHub-only hardening.
+
+The repository should explicitly state that:
+- `master` is the release branch
+- GitHub enforces PR review + `build`
+- `build` means install + lint + test
+- runtime/smoke safety is still an operational verification concern, not part of the enforced GitHub merge gate today

--- a/tests/configContract.test.js
+++ b/tests/configContract.test.js
@@ -497,6 +497,36 @@ describe('backend runtime config contract', () => {
     expect(productionGuide).toContain('all required evidence is green before merge into `master`');
   });
 
+  test('describes master github gate honestly as pr review plus build where build means install lint and test', () => {
+    const readme = readRootReadme();
+    const productionGuide = readScript('docs/PRODUCTION_DEPLOYMENT.md');
+    const ciWorkflow = readWorkflow('.github/workflows/ci.yml');
+
+    expect(readme).toContain('GitHub enforces PR review + `build`');
+    expect(readme).toContain('`build` means install + lint + test');
+    expect(productionGuide).toContain('GitHub enforces PR review + `build`');
+    expect(productionGuide).toContain('`build` means install + lint + test');
+
+    expect(ciWorkflow).toContain('name: CI');
+    expect(ciWorkflow).toContain('build:');
+    expect(ciWorkflow).toContain('npm ci');
+    expect(ciWorkflow).toContain('npm run lint');
+    expect(ciWorkflow).toContain('npm test');
+  });
+
+  test('does not claim github-enforced smoke or runtime verification on master', () => {
+    const readme = readRootReadme();
+    const productionGuide = readScript('docs/PRODUCTION_DEPLOYMENT.md');
+
+    expect(readme).toContain('runtime/smoke verification is still an operational verification concern');
+    expect(productionGuide).toContain('runtime/smoke verification is still an operational verification concern');
+
+    expect(readme).not.toContain('GitHub enforces smoke');
+    expect(readme).not.toContain('GitHub enforces runtime verification');
+    expect(productionGuide).not.toContain('GitHub-enforced smoke gate');
+    expect(productionGuide).not.toContain('GitHub-enforced runtime verification');
+  });
+
   test('locks staging and production workflows to droplet rollout with blocking verification', () => {
     const stagingWorkflow = readWorkflow('.github/workflows/deploy-staging.yml');
     const productionWorkflow = readWorkflow('.github/workflows/deploy-production.yml');

--- a/tests/configContract.test.js
+++ b/tests/configContract.test.js
@@ -446,7 +446,7 @@ describe('backend runtime config contract', () => {
     expect(claude).toContain('Treat `.do/app*.yaml` and `k8s/` as legacy or historical backend paths');
     expect(readme).toContain('DigitalOcean Container Registry (DOCR) + droplet-hosted Docker Compose runtime + host Nginx');
     expect(readme).toContain('registry.digitalocean.com/infinit-track/infinit-track-backend');
-    expect(readme).toContain('Smoke/readiness verification adalah release gate');
+    expect(readme).toContain('Smoke/readiness verification adalah release gate operasional');
     expect(readme).toContain('Staging host is environment-specific');
     expect(readme).toContain('Docker Compose');
     expect(readme).toContain('bash ./test-production.sh --local-base-url http://127.0.0.1:3005 --public-base-url http://127.0.0.1:3005');


### PR DESCRIPTION
## Summary
- harden the GitHub-only `master` gate contract
- document that GitHub enforces PR review + `build` on `master`
- define `build` honestly as install + lint + test
- make docs explicit that smoke/runtime verification is still operational, not GitHub-enforced

## Changes
- add RED/green contract coverage in `tests/configContract.test.js`
- align `README.md` and `docs/PRODUCTION_DEPLOYMENT.md` with the approved GitHub-only gate semantics
- add the approved design spec for master GitHub gate hardening
- audit and verify that remote `master` exists and effective rules still require PR review plus `build`

## Verification
- `npm test`
- Task 2 targeted config contract test: 26/26 green
- GitHub evidence audit confirmed:
  - remote `master` exists
  - effective `master` rules include PR review and required check `build`
  - CI job `build` runs `npm ci`, `npm run lint`, and `npm test`
- local `npm run lint` passed
- local `npm test` passed

## Scope note
This branch is GitHub-only gate hardening. It does **not** redesign deploy workflows or claim that smoke/runtime verification is enforced by GitHub merge policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the `master` deployment gate: PR review plus a successful `build` check are required.
  * Updated deployment guidance to distinguish GitHub merge requirements from operational smoke/readiness verification.
  * Added a new design note describing the intended `master` release protections and rollout expectations.

* **Tests**
  * Updated contract checks to match the revised deployment wording and gate definitions.
  * Added coverage to ensure the docs no longer imply GitHub-enforced smoke/runtime checks on `master`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->