### PR TITLE
fix: correct research trigger replace date scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Sistem ini memiliki empat pilar fungsionalitas utama yang membuatnya lebih dari 
 - **Missed Checkout Flag:** Menandai sesi yang melewati jam pulang + toleransi tanpa checkout (tanpa prediksi fuzzy).
 - **WFA Resolution:** Memproses booking WFA yang disetujui.
 - **Manual Trigger API:** Admin dapat memicu jobs secara manual.
-- **Research Attendance Trigger API:** Admin/Management dapat membangun atau menerapkan research attendance plan operator-only melalui `/api/attendance/research-trigger/daily` dan `/api/attendance/research-trigger/full-day`, dengan default `dry_run=true` dan feature flag `RESEARCH_ATTENDANCE_TRIGGER_ENABLED=false`.
+- **Research Attendance Trigger API:** Admin/Management dapat membangun atau menerapkan research attendance plan operator-only melalui `/api/attendance/research-trigger/daily` dan `/api/attendance/research-trigger/full-day`, dengan default `dry_run=true`, optional policy `seed_suffix`, `existing_strategy`, `discipline_mix`, serta feature flag `RESEARCH_ATTENDANCE_TRIGGER_ENABLED=false`.
 
 ### **📊 4. Dashboard Analitik dengan Indeks Kedisiplinan**
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1964,6 +1964,33 @@ paths:
                 confirm:
                   type: string
                   example: 'I_UNDERSTAND_THIS_WRITES_ATTENDANCE'
+                seed_suffix:
+                  type: string
+                  maxLength: 80
+                  example: 'research-batch-001'
+                existing_strategy:
+                  type: string
+                  enum:
+                    - skip
+                    - replace
+                  default: skip
+                  example: skip
+                discipline_mix:
+                  type: object
+                  description: Optional deterministic discipline distribution for generated rows.
+                  properties:
+                    ontime:
+                      type: number
+                      example: 75
+                    late:
+                      type: number
+                      example: 12
+                    early:
+                      type: number
+                      example: 8
+                    alpha:
+                      type: number
+                      example: 5
       responses:
         '200':
           description: Research attendance daily trigger processed successfully
@@ -1987,7 +2014,10 @@ paths:
                     example: '2026-07-01'
                   seed:
                     type: string
-                    example: '2026-07-01:daily'
+                    example: '2026-07-01:daily:research-batch-001'
+                  existing_strategy:
+                    type: string
+                    example: skip
                   policy:
                     type: object
                   population:
@@ -1997,6 +2027,9 @@ paths:
                     type: object
                     nullable: true
                   mode_summary:
+                    type: object
+                    nullable: true
+                  discipline_summary:
                     type: object
                     nullable: true
                   warnings:
@@ -2010,7 +2043,13 @@ paths:
                   planned_writes:
                     type: object
                     nullable: true
+                  would_replace:
+                    type: object
+                    nullable: true
                   applied_writes:
+                    type: object
+                    nullable: true
+                  replaced:
                     type: object
                     nullable: true
                   skipped_existing:
@@ -2019,16 +2058,53 @@ paths:
                   skipped_conflict:
                     type: integer
                     example: 0
+              examples:
+                dryRun:
+                  value:
+                    success: true
+                    endpoint_type: daily
+                    mode: dry-run
+                    target_date: '2026-07-01'
+                    seed: '2026-07-01:daily:research-batch-001'
+                    existing_strategy: skip
+                    discipline_summary:
+                      ontime: 12
+                      late: 2
+                      early: 1
+                      alpha: 1
+                    planned_writes:
+                      attendance: 16
+                      bookings: 1
+                      location_events: 30
+                    would_replace:
+                      attendance: 0
+                      location_events: 0
         '400':
-          description: Invalid trigger request payload or confirmation guard failure
+          description: Invalid trigger request payload, discipline mix, seed suffix, or confirmation guard failure
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
         '409':
-          description: Feature disabled, non-working day blocked, or no eligible users
+          description: Feature disabled, non-working day blocked, no eligible users, or invalid reference conflict
+          content:
+            application/json:
+              examples:
+                invalidReference:
+                  value:
+                    success: false
+                    code: E_INVALID_REFERENCE_STATE
+                    message: Research attendance trigger memiliki conflict reference.
+                    target_date: '2026-07-02'
+                    endpoint_type: daily
+                    conflicts:
+                      - type: invalid_reference
+                        user_id: 62
+                        target_date: '2026-07-02'
+                        mode: WFA
+                    hint: Jalankan dry_run=true atau siapkan approved WFA booking/lokasi untuk user conflict.
         '500':
-          description: Invalid reference state or trigger execution failure
+          description: Unexpected trigger execution failure
 
   /api/attendance/research-trigger/full-day:
     post:
@@ -2063,6 +2139,33 @@ paths:
                 confirm:
                   type: string
                   example: 'I_UNDERSTAND_THIS_WRITES_ATTENDANCE'
+                seed_suffix:
+                  type: string
+                  maxLength: 80
+                  example: 'research-batch-001'
+                existing_strategy:
+                  type: string
+                  enum:
+                    - skip
+                    - replace
+                  default: skip
+                  example: skip
+                discipline_mix:
+                  type: object
+                  description: Optional deterministic discipline distribution for generated rows.
+                  properties:
+                    ontime:
+                      type: number
+                      example: 75
+                    late:
+                      type: number
+                      example: 12
+                    early:
+                      type: number
+                      example: 8
+                    alpha:
+                      type: number
+                      example: 5
       responses:
         '200':
           description: Research attendance full-day trigger processed successfully
@@ -2086,7 +2189,10 @@ paths:
                     example: '2026-07-01'
                   seed:
                     type: string
-                    example: '2026-07-01:full-day'
+                    example: '2026-07-01:full-day:research-batch-001'
+                  existing_strategy:
+                    type: string
+                    example: replace
                   policy:
                     type: object
                   population:
@@ -2096,6 +2202,9 @@ paths:
                     type: object
                     nullable: true
                   mode_summary:
+                    type: object
+                    nullable: true
+                  discipline_summary:
                     type: object
                     nullable: true
                   warnings:
@@ -2109,7 +2218,13 @@ paths:
                   planned_writes:
                     type: object
                     nullable: true
+                  would_replace:
+                    type: object
+                    nullable: true
                   applied_writes:
+                    type: object
+                    nullable: true
+                  replaced:
                     type: object
                     nullable: true
                   skipped_existing:
@@ -2118,16 +2233,53 @@ paths:
                   skipped_conflict:
                     type: integer
                     example: 0
+              examples:
+                apply:
+                  value:
+                    success: true
+                    endpoint_type: full-day
+                    mode: apply
+                    target_date: '2026-07-01'
+                    seed: '2026-07-01:full-day:research-batch-001'
+                    existing_strategy: replace
+                    discipline_summary:
+                      ontime: 39
+                      late: 6
+                      early: 4
+                      alpha: 3
+                    applied_writes:
+                      attendance: 52
+                      bookings: 2
+                      location_events: 98
+                    replaced:
+                      attendance: 12
+                      location_events: 24
         '400':
-          description: Invalid trigger request payload or confirmation guard failure
+          description: Invalid trigger request payload, discipline mix, seed suffix, or confirmation guard failure
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
         '409':
-          description: Feature disabled, non-working day blocked, or no eligible users
+          description: Feature disabled, non-working day blocked, no eligible users, or invalid reference conflict
+          content:
+            application/json:
+              examples:
+                invalidReference:
+                  value:
+                    success: false
+                    code: E_INVALID_REFERENCE_STATE
+                    message: Research attendance trigger memiliki conflict reference.
+                    target_date: '2026-07-02'
+                    endpoint_type: full-day
+                    conflicts:
+                      - type: invalid_reference
+                        user_id: 62
+                        target_date: '2026-07-02'
+                        mode: WFA
+                    hint: Jalankan dry_run=true atau siapkan approved WFA booking/lokasi untuk user conflict.
         '500':
-          description: Invalid reference state or trigger execution failure
+          description: Unexpected trigger execution failure
 
   /api/attendance/{id}:
     delete:

--- a/scripts/research/generate-attendance-dataset.js
+++ b/scripts/research/generate-attendance-dataset.js
@@ -356,7 +356,9 @@ export async function applyResearchAttendancePlan({
     await models.LocationEvent.bulkCreate(
       plan.plannedLocationEventRows.map((row) => ({
         ...row,
-        event_timestamp: `${row.event_date} ${row.event_type === 'ENTER' ? '08:00:00' : '17:00:00'}`
+        event_timestamp:
+          row.event_timestamp ||
+          `${row.event_date} ${row.event_type === 'ENTER' ? '08:00:00' : '17:00:00'}`
       })),
       { transaction }
     );

--- a/src/middlewares/errorHandler.js
+++ b/src/middlewares/errorHandler.js
@@ -1,7 +1,10 @@
 import logger from '../utils/logger.js';
 import config from '../config/index.js';
 
-const PUBLIC_ERROR_CODES = new Set(['E_OPERATIONAL_SETTINGS_INVALID']);
+const PUBLIC_ERROR_CODES = new Set([
+  'E_OPERATIONAL_SETTINGS_INVALID',
+  'E_INVALID_REFERENCE_STATE'
+]);
 
 export const errorHandler = (err, req, res, _next) => {
   const logPayload = {
@@ -15,6 +18,10 @@ export const errorHandler = (err, req, res, _next) => {
 
   if (err.code === 'E_OPERATIONAL_SETTINGS_INVALID' && Array.isArray(err.details)) {
     logPayload.details = err.details;
+  }
+
+  if (err.code === 'E_INVALID_REFERENCE_STATE' && Array.isArray(err.conflicts)) {
+    logPayload.conflicts = err.conflicts;
   }
 
   logger.error(logPayload);
@@ -62,12 +69,30 @@ export const errorHandler = (err, req, res, _next) => {
         : err.message || 'Internal server error'
   };
 
-  if (PUBLIC_ERROR_CODES.has(err.code)) {
+  if (err.code && (statusCode < 500 || PUBLIC_ERROR_CODES.has(err.code))) {
     response.code = err.code;
   }
 
   if (err.code === 'E_OPERATIONAL_SETTINGS_INVALID' && Array.isArray(err.details)) {
     response.details = err.details;
+  }
+
+  if (err.code === 'E_INVALID_REFERENCE_STATE') {
+    if (err.target_date) {
+      response.target_date = err.target_date;
+    }
+
+    if (err.endpoint_type) {
+      response.endpoint_type = err.endpoint_type;
+    }
+
+    if (Array.isArray(err.conflicts)) {
+      response.conflicts = err.conflicts;
+    }
+
+    if (err.hint) {
+      response.hint = err.hint;
+    }
   }
 
   // Only include stack trace in development

--- a/src/services/researchAttendanceTrigger.service.js
+++ b/src/services/researchAttendanceTrigger.service.js
@@ -207,6 +207,12 @@ function buildTimestamp(dateString, hour, minute = 0) {
   return `${dateString} ${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}:00`;
 }
 
+function buildNextDateOnly(dateString) {
+  const date = new Date(`${dateString}T00:00:00+07:00`);
+  date.setUTCDate(date.getUTCDate() + 1);
+  return date.toISOString().slice(0, 10);
+}
+
 function buildTimestampFromMinutes(dateString, totalMinutes) {
   const hour = Math.floor(totalMinutes / 60);
   const minute = totalMinutes % 60;
@@ -461,10 +467,9 @@ function extractDateOnlyFromTimestamp(value) {
   return String(value).slice(0, 10);
 }
 
-function buildReplacementPlan({ selectedUsers, targetDate, snapshot }) {
-  const selectedUserIds = new Set(selectedUsers.map((user) => user.userId));
+function buildReplacementPlan({ targetDate, snapshot }) {
   const targetDateAttendanceRows = (snapshot.existingAttendanceRows || []).filter(
-    (row) => row.attendance_date === targetDate && selectedUserIds.has(row.user_id)
+    (row) => row.attendance_date === targetDate
   );
   const replaceableAttendanceRows = targetDateAttendanceRows.filter(isResearchOwnedAttendanceRow);
   const unsafeAttendanceRows = targetDateAttendanceRows.filter(
@@ -616,7 +621,7 @@ export async function buildResearchAttendanceTriggerPlan({
   const disciplineAssignments = assignDisciplineStatuses(selectedUsers, seed, request.disciplineMix);
   const replacement =
     request.existingStrategy === 'replace'
-      ? buildReplacementPlan({ selectedUsers, targetDate, snapshot })
+      ? buildReplacementPlan({ targetDate, snapshot })
       : {
           attendanceRows: [],
           unsafeAttendanceRows: [],
@@ -646,7 +651,7 @@ export async function buildResearchAttendanceTriggerPlan({
 
   if (request.existingStrategy === 'replace' && replacement.unsafeAttendanceRows.length > 0) {
     warnings.push(
-      `existing_strategy=replace hanya mengganti attendance research-owned. ${replacement.unsafeAttendanceRows.length} row existing non-research tetap di-skip.`
+      `existing_strategy=replace mengganti semua attendance research-owned pada tanggal target. ${replacement.unsafeAttendanceRows.length} row existing non-research tetap dipertahankan dan tidak ikut direplace.`
     );
   }
 
@@ -843,7 +848,7 @@ export async function applyResearchAttendancePlanInTransaction(plan) {
             },
             event_timestamp: {
               [sequelize.Sequelize.Op.gte]: `${plan.targetDate} 00:00:00`,
-              [sequelize.Sequelize.Op.lt]: `${plan.targetDate} 23:59:59`
+              [sequelize.Sequelize.Op.lt]: `${buildNextDateOnly(plan.targetDate)} 00:00:00`
             }
           },
           transaction
@@ -952,7 +957,13 @@ export async function executeResearchAttendanceTrigger({
   const seed = buildTriggerSeed(request, endpointType);
   const collectSnapshot = dependencies.collectSnapshot || (() => collectTriggerSnapshotForDate(request.targetDate));
   const buildPlan = dependencies.buildPlan || defaultBuildPlan;
-  const applyPlan = dependencies.applyPlan || ((payload) => applyResearchAttendancePlanInTransaction(payload.plan));
+  const applyPlan =
+    dependencies.applyPlan ||
+    ((payload) =>
+      applyResearchAttendancePlanInTransaction({
+        ...payload.plan,
+        targetDate: payload.targetDate
+      }));
 
   const snapshot = await collectSnapshot();
   const plan = await buildPlan({ endpointType, targetDate: request.targetDate, seed, request, snapshot, user });

--- a/src/services/researchAttendanceTrigger.service.js
+++ b/src/services/researchAttendanceTrigger.service.js
@@ -3,27 +3,113 @@ import Holidays from 'date-holidays';
 import config from '../config/index.js';
 
 const TARGET_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const SEED_SUFFIX_PATTERN = /^[A-Za-z0-9._-]+$/;
 const APPLY_CONFIRMATION = 'I_UNDERSTAND_THIS_WRITES_ATTENDANCE';
 const DAILY_SUBSET_PERCENT = 0.3;
+const DEFAULT_DISCIPLINE_MIX = Object.freeze({ ontime: 75, late: 12, early: 8, alpha: 5 });
+const DISCIPLINE_SEQUENCE = ['ontime', 'late', 'early', 'alpha'];
+const VALID_EXISTING_STRATEGIES = new Set(['skip', 'replace']);
+const RESEARCH_TRIGGER_ATTENDANCE_NOTE =
+  'Kehadiran tercatat melalui research attendance trigger operator.';
+const RESEARCH_TRIGGER_BOOKING_NOTE = 'Kehadiran WFA tercatat sesuai lokasi yang disetujui.';
+const REPLACE_LOCATION_EVENT_WARNING =
+  'existing_strategy=replace akan menghapus location events existing pada level user+tanggal untuk attendance research-owned karena location_events tidak memiliki marker research-owned.';
+const LATE_BUCKETS = Object.freeze([
+  { key: 'light', minMinutes: 8 * 60 + 10, maxMinutes: 8 * 60 + 30 },
+  { key: 'medium', minMinutes: 8 * 60 + 31, maxMinutes: 8 * 60 + 55 },
+  { key: 'heavy', minMinutes: 8 * 60 + 56, maxMinutes: 9 * 60 + 30 }
+]);
+const EARLY_CHECKOUT_RANGE = Object.freeze({ minMinutes: 15 * 60 + 30, maxMinutes: 16 * 60 + 30 });
+const STANDARD_WORK_START_MINUTES = 8 * 60;
+const STANDARD_WORK_END_MINUTES = 17 * 60;
 
 const ATTENDANCE_CATEGORY_IDS = Object.freeze({ WFO: 1, WFH: 2, WFA: 3 });
 const ATTENDANCE_STATUS_IDS = Object.freeze({ ONTIME: 1, LATE: 2, ALPHA: 3, EARLY: 4 });
 const BOOKING_STATUS_IDS = Object.freeze({ APPROVED: 1 });
 
-function createHttpError(status, code, message) {
+function createHttpError(status, code, message, extra = {}) {
   const error = new Error(message);
   error.status = status;
   error.code = code;
+  Object.assign(error, extra);
   return error;
 }
 
 function normalizeTriggerRequest(body = {}) {
+  const disciplineMixRaw =
+    body.discipline_mix && typeof body.discipline_mix === 'object' && !Array.isArray(body.discipline_mix)
+      ? body.discipline_mix
+      : null;
+
   return {
     targetDate: typeof body.target_date === 'string' ? body.target_date.trim() : '',
     dryRun: body.dry_run !== false,
     allowNonWorkingDay: body.allow_non_working_day === true,
-    confirm: typeof body.confirm === 'string' ? body.confirm.trim() : ''
+    confirm: typeof body.confirm === 'string' ? body.confirm.trim() : '',
+    seedSuffix: typeof body.seed_suffix === 'string' ? body.seed_suffix.trim() : '',
+    existingStrategy:
+      typeof body.existing_strategy === 'string' && body.existing_strategy.trim()
+        ? body.existing_strategy.trim().toLowerCase()
+        : 'skip',
+    disciplineMix: normalizeDisciplineMix(disciplineMixRaw)
   };
+}
+
+function normalizeDisciplineMix(disciplineMixRaw) {
+  if (!disciplineMixRaw) {
+    return { ...DEFAULT_DISCIPLINE_MIX };
+  }
+
+  return {
+    ontime: Number(disciplineMixRaw.ontime ?? 0),
+    late: Number(disciplineMixRaw.late ?? 0),
+    early: Number(disciplineMixRaw.early ?? 0),
+    alpha: Number(disciplineMixRaw.alpha ?? 0)
+  };
+}
+
+function validateSeedSuffix(seedSuffix) {
+  if (!seedSuffix) {
+    return;
+  }
+
+  if (seedSuffix.length > 80) {
+    throw createHttpError(
+      400,
+      'E_INVALID_SEED_SUFFIX',
+      'seed_suffix maksimal 80 karakter.'
+    );
+  }
+
+  if (!SEED_SUFFIX_PATTERN.test(seedSuffix)) {
+    throw createHttpError(
+      400,
+      'E_INVALID_SEED_SUFFIX',
+      'seed_suffix hanya boleh berisi huruf, angka, titik, dash, atau underscore.'
+    );
+  }
+}
+
+function validateDisciplineMix(disciplineMix) {
+  const values = Object.entries(disciplineMix);
+  for (const [key, value] of values) {
+    if (!Number.isFinite(value) || value < 0) {
+      throw createHttpError(
+        400,
+        'E_INVALID_DISCIPLINE_MIX',
+        `discipline_mix.${key} harus berupa angka non-negatif.`
+      );
+    }
+  }
+
+  const total = values.reduce((sum, [, value]) => sum + value, 0);
+  if (Math.abs(total - 100) > 0.001) {
+    throw createHttpError(
+      400,
+      'E_INVALID_DISCIPLINE_MIX',
+      'discipline_mix harus berjumlah total 100.'
+    );
+  }
 }
 
 function validateTriggerRequest(request) {
@@ -42,6 +128,17 @@ function validateTriggerRequest(request) {
   if (!TARGET_DATE_PATTERN.test(request.targetDate)) {
     throw createHttpError(400, 'E_INVALID_TARGET_DATE', 'target_date harus berformat YYYY-MM-DD.');
   }
+
+  if (!VALID_EXISTING_STRATEGIES.has(request.existingStrategy)) {
+    throw createHttpError(
+      400,
+      'E_INVALID_EXISTING_STRATEGY',
+      'existing_strategy hanya boleh bernilai skip atau replace.'
+    );
+  }
+
+  validateSeedSuffix(request.seedSuffix);
+  validateDisciplineMix(request.disciplineMix);
 
   if (!request.dryRun && !request.confirm) {
     throw createHttpError(
@@ -110,6 +207,17 @@ function buildTimestamp(dateString, hour, minute = 0) {
   return `${dateString} ${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}:00`;
 }
 
+function buildTimestampFromMinutes(dateString, totalMinutes) {
+  const hour = Math.floor(totalMinutes / 60);
+  const minute = totalMinutes % 60;
+  return buildTimestamp(dateString, hour, minute);
+}
+
+function calculateWorkHour(startMinutes, endMinutes) {
+  const workedMinutes = Math.max(0, endMinutes - startMinutes);
+  return Math.round((workedMinutes / 60) * 100) / 100;
+}
+
 function createSeededNumberStream(seed) {
   let state = 0;
 
@@ -123,7 +231,7 @@ function createSeededNumberStream(seed) {
   };
 }
 
-async function buildDeterministicOrder(items, seed, keySelector) {
+function buildDeterministicOrder(items, seed, keySelector) {
   const nextRandom = createSeededNumberStream(seed);
 
   return items
@@ -153,11 +261,7 @@ async function selectDailyUsers({ eligibleUsers, targetCount, seed }) {
   const selectedIds = new Set();
 
   for (const [groupName, users] of Object.entries(groupedUsers)) {
-    const orderedGroup = await buildDeterministicOrder(
-      users,
-      `${seed}:${groupName}`,
-      (user) => user.userId
-    );
+    const orderedGroup = buildDeterministicOrder(users, `${seed}:${groupName}`, (user) => user.userId);
     const takeCount = Math.min(orderedGroup.length, quotas[groupName]);
 
     for (const user of orderedGroup.slice(0, takeCount)) {
@@ -168,7 +272,7 @@ async function selectDailyUsers({ eligibleUsers, targetCount, seed }) {
 
   if (selectedUsers.length < targetCount) {
     const remainingUsers = eligibleUsers.filter((user) => !selectedIds.has(user.userId));
-    const orderedRemainingUsers = await buildDeterministicOrder(
+    const orderedRemainingUsers = buildDeterministicOrder(
       remainingUsers,
       `${seed}:remaining`,
       (user) => user.userId
@@ -186,8 +290,8 @@ async function selectDailyUsers({ eligibleUsers, targetCount, seed }) {
   return buildDeterministicOrder(selectedUsers, `${seed}:selected`, (user) => user.userId);
 }
 
-async function assignModes(selectedUsers, seed) {
-  const orderedUsers = await buildDeterministicOrder(selectedUsers, `${seed}:modes`, (user) => user.userId);
+function assignModes(selectedUsers, seed) {
+  const orderedUsers = buildDeterministicOrder(selectedUsers, `${seed}:modes`, (user) => user.userId);
   const modeCounts = allocateCounts(selectedUsers.length, { WFO: 80, WFA: 5, WFH: 15 });
   const userModes = new Map();
 
@@ -206,15 +310,116 @@ async function assignModes(selectedUsers, seed) {
   return userModes;
 }
 
+function assignDisciplineStatuses(selectedUsers, seed, disciplineMix) {
+  const orderedUsers = buildDeterministicOrder(
+    selectedUsers,
+    `${seed}:discipline`,
+    (user) => user.userId
+  );
+  const disciplineCounts = allocateCounts(selectedUsers.length, disciplineMix);
+  const assignments = new Map();
+
+  let cursor = 0;
+  for (const disciplineName of DISCIPLINE_SEQUENCE) {
+    for (const user of orderedUsers.slice(cursor, cursor + disciplineCounts[disciplineName])) {
+      assignments.set(user.userId, disciplineName);
+    }
+    cursor += disciplineCounts[disciplineName];
+  }
+
+  for (const user of orderedUsers.slice(cursor)) {
+    assignments.set(user.userId, 'ontime');
+  }
+
+  return {
+    assignments,
+    counts: disciplineCounts
+  };
+}
+
+function buildAttendanceTimingForDiscipline(statusName, targetDate, seed, userId) {
+  const nextRandom = createSeededNumberStream(`${seed}:${statusName}:${userId}`);
+
+  if (statusName === 'alpha') {
+    const alphaTimestamp = buildTimestamp(targetDate, 8, 0);
+    return {
+      statusId: ATTENDANCE_STATUS_IDS.ALPHA,
+      categoryId: ATTENDANCE_CATEGORY_IDS.WFO,
+      timeIn: alphaTimestamp,
+      timeOut: alphaTimestamp,
+      workHour: 0,
+      eventTimestamps: null,
+      isPresent: false
+    };
+  }
+
+  if (statusName === 'late') {
+    const bucket = LATE_BUCKETS[Math.floor(nextRandom() * LATE_BUCKETS.length)] || LATE_BUCKETS[0];
+    const bucketSpan = bucket.maxMinutes - bucket.minMinutes + 1;
+    const timeInMinutes = bucket.minMinutes + Math.floor(nextRandom() * bucketSpan);
+    const timeOutMinutes = STANDARD_WORK_END_MINUTES;
+
+    return {
+      statusId: ATTENDANCE_STATUS_IDS.LATE,
+      timeIn: buildTimestampFromMinutes(targetDate, timeInMinutes),
+      timeOut: buildTimestampFromMinutes(targetDate, timeOutMinutes),
+      workHour: calculateWorkHour(timeInMinutes, timeOutMinutes),
+      eventTimestamps: {
+        enter: buildTimestampFromMinutes(targetDate, timeInMinutes),
+        exit: buildTimestampFromMinutes(targetDate, timeOutMinutes)
+      },
+      isPresent: true
+    };
+  }
+
+  if (statusName === 'early') {
+    const checkoutSpan = EARLY_CHECKOUT_RANGE.maxMinutes - EARLY_CHECKOUT_RANGE.minMinutes + 1;
+    const timeOutMinutes =
+      EARLY_CHECKOUT_RANGE.minMinutes + Math.floor(nextRandom() * checkoutSpan);
+    const timeInMinutes = STANDARD_WORK_START_MINUTES;
+
+    return {
+      statusId: ATTENDANCE_STATUS_IDS.EARLY,
+      timeIn: buildTimestampFromMinutes(targetDate, timeInMinutes),
+      timeOut: buildTimestampFromMinutes(targetDate, timeOutMinutes),
+      workHour: calculateWorkHour(timeInMinutes, timeOutMinutes),
+      eventTimestamps: {
+        enter: buildTimestampFromMinutes(targetDate, timeInMinutes),
+        exit: buildTimestampFromMinutes(targetDate, timeOutMinutes)
+      },
+      isPresent: true
+    };
+  }
+
+  return {
+    statusId: ATTENDANCE_STATUS_IDS.ONTIME,
+    timeIn: buildTimestampFromMinutes(targetDate, STANDARD_WORK_START_MINUTES),
+    timeOut: buildTimestampFromMinutes(targetDate, STANDARD_WORK_END_MINUTES),
+    workHour: calculateWorkHour(STANDARD_WORK_START_MINUTES, STANDARD_WORK_END_MINUTES),
+    eventTimestamps: {
+      enter: buildTimestampFromMinutes(targetDate, STANDARD_WORK_START_MINUTES),
+      exit: buildTimestampFromMinutes(targetDate, STANDARD_WORK_END_MINUTES)
+    },
+    isPresent: true
+  };
+}
+
+function buildTriggerSeed(request, endpointType) {
+  const baseSeed = `${request.targetDate}:${endpointType === 'daily' ? 'daily' : 'full-day'}`;
+  return request.seedSuffix ? `${baseSeed}:${request.seedSuffix}` : baseSeed;
+}
+
 function selectApprovedBooking(existingBookingRows, userId, targetDate) {
-  return existingBookingRows
-    .filter(
-      (booking) =>
-        booking.user_id === userId &&
-        booking.schedule_date === targetDate &&
-        booking.status === BOOKING_STATUS_IDS.APPROVED
-    )
-    .sort((left, right) => left.booking_id - right.booking_id)[0] || null;
+  return (
+    existingBookingRows
+      .filter(
+        (booking) =>
+          booking.user_id === userId &&
+          booking.schedule_date === targetDate &&
+          booking.status === BOOKING_STATUS_IDS.APPROVED
+      )
+      .sort((left, right) => left.booking_id - right.booking_id)[0] || null
+  );
 }
 
 function mergeRows(existingRows, additionalRows, keySelector) {
@@ -230,6 +435,89 @@ function mergeRows(existingRows, additionalRows, keySelector) {
   }
 
   return mergedRows;
+}
+
+function buildAttendanceKey(userId, targetDate) {
+  return `${userId}:${targetDate}`;
+}
+
+function isResearchOwnedAttendanceRow(row) {
+  return String(row?.notes || '').trim() === RESEARCH_TRIGGER_ATTENDANCE_NOTE;
+}
+
+function extractDateOnlyFromTimestamp(value) {
+  if (!value) {
+    return '';
+  }
+
+  if (typeof value === 'string') {
+    return value.slice(0, 10);
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString().slice(0, 10);
+  }
+
+  return String(value).slice(0, 10);
+}
+
+function buildReplacementPlan({ selectedUsers, targetDate, snapshot }) {
+  const selectedUserIds = new Set(selectedUsers.map((user) => user.userId));
+  const targetDateAttendanceRows = (snapshot.existingAttendanceRows || []).filter(
+    (row) => row.attendance_date === targetDate && selectedUserIds.has(row.user_id)
+  );
+  const replaceableAttendanceRows = targetDateAttendanceRows.filter(isResearchOwnedAttendanceRow);
+  const unsafeAttendanceRows = targetDateAttendanceRows.filter(
+    (row) => !isResearchOwnedAttendanceRow(row)
+  );
+  const replaceableUserIds = new Set(replaceableAttendanceRows.map((row) => row.user_id));
+  const replaceableLocationEvents = (snapshot.existingLocationEvents || []).filter(
+    (row) =>
+      replaceableUserIds.has(row.user_id) &&
+      extractDateOnlyFromTimestamp(row.event_timestamp) === targetDate
+  );
+
+  return {
+    attendanceRows: replaceableAttendanceRows,
+    unsafeAttendanceRows,
+    replaceableUserIds: [...replaceableUserIds],
+    locationEventRows: replaceableLocationEvents,
+    attendance: replaceableAttendanceRows.length,
+    location_events: replaceableLocationEvents.length
+  };
+}
+
+function buildModeSummary(plannedAttendanceRows) {
+  return {
+    wfo: plannedAttendanceRows.filter((row) => row.category_id === ATTENDANCE_CATEGORY_IDS.WFO).length,
+    wfh: plannedAttendanceRows.filter((row) => row.category_id === ATTENDANCE_CATEGORY_IDS.WFH).length,
+    wfa: plannedAttendanceRows.filter((row) => row.category_id === ATTENDANCE_CATEGORY_IDS.WFA).length
+  };
+}
+
+function buildDisciplineSummary(plannedAttendanceRows) {
+  const summary = { ontime: 0, late: 0, early: 0, alpha: 0 };
+
+  for (const row of plannedAttendanceRows) {
+    if (Number(row.status_id) === ATTENDANCE_STATUS_IDS.LATE) {
+      summary.late += 1;
+      continue;
+    }
+
+    if (Number(row.status_id) === ATTENDANCE_STATUS_IDS.EARLY) {
+      summary.early += 1;
+      continue;
+    }
+
+    if (Number(row.status_id) === ATTENDANCE_STATUS_IDS.ALPHA) {
+      summary.alpha += 1;
+      continue;
+    }
+
+    summary.ontime += 1;
+  }
+
+  return summary;
 }
 
 export async function collectTriggerSnapshotForDate(targetDate) {
@@ -312,19 +600,39 @@ export async function buildResearchAttendanceTriggerPlan({
   const eligibleUsers = snapshot.baselineUsers.slice().sort((left, right) => left.userId - right.userId);
   const baselineUserCount = eligibleUsers.length;
   const eligibleUserCount = eligibleUsers.length;
-  const targetCount = endpointType === 'full-day'
-    ? eligibleUserCount
-    : eligibleUserCount === 0
-      ? 0
-      : Math.min(eligibleUserCount, Math.max(1, Math.round(eligibleUserCount * DAILY_SUBSET_PERCENT)));
+  const targetCount =
+    endpointType === 'full-day'
+      ? eligibleUserCount
+      : eligibleUserCount === 0
+        ? 0
+        : Math.min(eligibleUserCount, Math.max(1, Math.round(eligibleUserCount * DAILY_SUBSET_PERCENT)));
 
-  const selectedUsers = endpointType === 'full-day'
-    ? await buildDeterministicOrder(eligibleUsers, `${seed}:full-day`, (userEntry) => userEntry.userId)
-    : await selectDailyUsers({ eligibleUsers, targetCount, seed });
+  const selectedUsers =
+    endpointType === 'full-day'
+      ? buildDeterministicOrder(eligibleUsers, `${seed}:full-day`, (userEntry) => userEntry.userId)
+      : await selectDailyUsers({ eligibleUsers, targetCount, seed });
 
-  const modeAssignments = await assignModes(selectedUsers, seed);
+  const modeAssignments = assignModes(selectedUsers, seed);
+  const disciplineAssignments = assignDisciplineStatuses(selectedUsers, seed, request.disciplineMix);
+  const replacement =
+    request.existingStrategy === 'replace'
+      ? buildReplacementPlan({ selectedUsers, targetDate, snapshot })
+      : {
+          attendanceRows: [],
+          unsafeAttendanceRows: [],
+          replaceableUserIds: [],
+          locationEventRows: [],
+          attendance: 0,
+          location_events: 0
+        };
   const existingAttendanceKeys = new Set(
-    (snapshot.existingAttendanceRows || []).map((row) => `${row.user_id}:${row.attendance_date}`)
+    (snapshot.existingAttendanceRows || []).map((row) => buildAttendanceKey(row.user_id, row.attendance_date))
+  );
+  const replaceableAttendanceKeys = new Set(
+    replacement.attendanceRows.map((row) => buildAttendanceKey(row.user_id, row.attendance_date))
+  );
+  const unsafeAttendanceKeys = new Set(
+    replacement.unsafeAttendanceRows.map((row) => buildAttendanceKey(row.user_id, row.attendance_date))
   );
 
   const plannedAttendanceRows = [];
@@ -336,28 +644,62 @@ export async function buildResearchAttendanceTriggerPlan({
   let skippedConflict = 0;
   let invalidReferenceCount = 0;
 
+  if (request.existingStrategy === 'replace' && replacement.unsafeAttendanceRows.length > 0) {
+    warnings.push(
+      `existing_strategy=replace hanya mengganti attendance research-owned. ${replacement.unsafeAttendanceRows.length} row existing non-research tetap di-skip.`
+    );
+  }
+
+  if (request.existingStrategy === 'replace' && replacement.location_events > 0) {
+    warnings.push(REPLACE_LOCATION_EVENT_WARNING);
+  }
+
   for (const selectedUser of selectedUsers) {
-    const attendanceKey = `${selectedUser.userId}:${targetDate}`;
+    const attendanceKey = buildAttendanceKey(selectedUser.userId, targetDate);
     if (existingAttendanceKeys.has(attendanceKey)) {
-      skippedExisting += 1;
-      continue;
+      if (request.existingStrategy === 'skip') {
+        skippedExisting += 1;
+        continue;
+      }
+
+      if (unsafeAttendanceKeys.has(attendanceKey)) {
+        skippedExisting += 1;
+        continue;
+      }
+
+      if (!replaceableAttendanceKeys.has(attendanceKey)) {
+        skippedExisting += 1;
+        continue;
+      }
     }
 
     const modeName = modeAssignments.get(selectedUser.userId) || 'WFO';
+    const disciplineName = disciplineAssignments.assignments.get(selectedUser.userId) || 'ontime';
+    const timing = buildAttendanceTimingForDiscipline(
+      disciplineName,
+      targetDate,
+      seed,
+      selectedUser.userId
+    );
     const expectedLocations = snapshot.expectedLocationsByUser?.[selectedUser.userId] || {};
 
     const attendanceRow = {
       user_id: selectedUser.userId,
       attendance_date: targetDate,
-      category_id: ATTENDANCE_CATEGORY_IDS[modeName],
-      status_id: ATTENDANCE_STATUS_IDS.ONTIME,
+      category_id: timing.categoryId || ATTENDANCE_CATEGORY_IDS[modeName],
+      status_id: timing.statusId,
       booking_id: null,
       location_id: null,
-      time_in: buildTimestamp(targetDate, 8, 0),
-      time_out: buildTimestamp(targetDate, 17, 0),
-      work_hour: 8,
-      notes: 'Kehadiran tercatat melalui research attendance trigger operator.'
+      time_in: timing.timeIn,
+      time_out: timing.timeOut,
+      work_hour: timing.workHour,
+      notes: RESEARCH_TRIGGER_ATTENDANCE_NOTE
     };
+
+    if (!timing.isPresent) {
+      plannedAttendanceRows.push(attendanceRow);
+      continue;
+    }
 
     if (modeName === 'WFO') {
       attendanceRow.location_id = expectedLocations.wfoLocationId || null;
@@ -384,7 +726,7 @@ export async function buildResearchAttendanceTriggerPlan({
           schedule_date: targetDate,
           location_id: expectedLocations.fallbackWfaLocationId,
           status: BOOKING_STATUS_IDS.APPROVED,
-          notes: 'Kehadiran WFA tercatat sesuai lokasi yang disetujui.'
+          notes: RESEARCH_TRIGGER_BOOKING_NOTE
         });
       }
     }
@@ -407,13 +749,13 @@ export async function buildResearchAttendanceTriggerPlan({
         user_id: selectedUser.userId,
         location_id: attendanceRow.location_id,
         event_type: 'ENTER',
-        event_date: targetDate
+        event_timestamp: timing.eventTimestamps?.enter || attendanceRow.time_in
       },
       {
         user_id: selectedUser.userId,
         location_id: attendanceRow.location_id,
         event_type: 'EXIT',
-        event_date: targetDate
+        event_timestamp: timing.eventTimestamps?.exit || attendanceRow.time_out
       }
     );
   }
@@ -429,8 +771,11 @@ export async function buildResearchAttendanceTriggerPlan({
   return {
     policy: {
       allow_non_working_day: request.allowNonWorkingDay,
-      skip_existing: true,
-      daily_subset_percent: endpointType === 'daily' ? 30 : undefined
+      existing_strategy: request.existingStrategy,
+      skip_existing: request.existingStrategy === 'skip',
+      daily_subset_percent: endpointType === 'daily' ? 30 : undefined,
+      seed_suffix: request.seedSuffix || null,
+      discipline_mix: request.disciplineMix
     },
     population: {
       source: 'existing July 2025 attendance baseline',
@@ -438,26 +783,25 @@ export async function buildResearchAttendanceTriggerPlan({
       eligible_user_count: eligibleUserCount,
       selected_user_count: selectedUsers.length
     },
-    selection_summary: endpointType === 'daily'
-      ? {
-          strategy: 'fixed-percentage',
-          subset_percent: 30,
-          target_user_ids: selectedUsers.map((selectedUser) => selectedUser.userId)
-        }
-      : {
-          strategy: 'full-population',
-          target_user_ids: selectedUsers.map((selectedUser) => selectedUser.userId)
-        },
-    mode_summary: {
-      wfo: plannedAttendanceRows.filter((row) => row.category_id === ATTENDANCE_CATEGORY_IDS.WFO).length,
-      wfh: plannedAttendanceRows.filter((row) => row.category_id === ATTENDANCE_CATEGORY_IDS.WFH).length,
-      wfa: plannedAttendanceRows.filter((row) => row.category_id === ATTENDANCE_CATEGORY_IDS.WFA).length
-    },
+    selection_summary:
+      endpointType === 'daily'
+        ? {
+            strategy: 'fixed-percentage',
+            subset_percent: 30,
+            target_user_ids: selectedUsers.map((selectedUser) => selectedUser.userId)
+          }
+        : {
+            strategy: 'full-population',
+            target_user_ids: selectedUsers.map((selectedUser) => selectedUser.userId)
+          },
+    mode_summary: buildModeSummary(plannedAttendanceRows),
+    discipline_summary: buildDisciplineSummary(plannedAttendanceRows),
     warnings,
     conflicts,
     skipped_existing: skippedExisting,
     skipped_conflict: skippedConflict,
     invalid_reference_count: invalidReferenceCount,
+    replacement,
     plannedAttendanceRows,
     plannedBookingRows,
     plannedLocationEventRows
@@ -479,13 +823,57 @@ export async function applyResearchAttendancePlanInTransaction(plan) {
   const { applyResearchAttendancePlan } = await import(
     '../../scripts/research/generate-attendance-dataset.js'
   );
-  const { sequelize } = await import('../models/index.js');
+  const { Attendance, LocationEvent, sequelize } = await import('../models/index.js');
   const transaction = await sequelize.transaction();
 
   try {
-    const result = await applyResearchAttendancePlan({ plan, transaction });
+    const replacement = { attendance: 0, location_events: 0 };
+
+    if (plan.replacement?.replaceableUserIds?.length) {
+      const attendanceIdsToReplace = plan.replacement.attendanceRows
+        .map((row) => row.id_attendance)
+        .filter((value) => value !== undefined && value !== null);
+      const replaceableUserIds = plan.replacement.replaceableUserIds;
+
+      if (replaceableUserIds.length > 0) {
+        replacement.location_events = await LocationEvent.destroy({
+          where: {
+            user_id: {
+              [sequelize.Sequelize.Op.in]: replaceableUserIds
+            },
+            event_timestamp: {
+              [sequelize.Sequelize.Op.gte]: `${plan.targetDate} 00:00:00`,
+              [sequelize.Sequelize.Op.lt]: `${plan.targetDate} 23:59:59`
+            }
+          },
+          transaction
+        });
+      }
+
+      if (attendanceIdsToReplace.length > 0) {
+        replacement.attendance = await Attendance.destroy({
+          where: {
+            id_attendance: {
+              [sequelize.Sequelize.Op.in]: attendanceIdsToReplace
+            }
+          },
+          transaction
+        });
+      }
+    }
+
+    const rawAppliedWrites = await applyResearchAttendancePlan({ plan, transaction });
     await transaction.commit();
-    return result;
+
+    return {
+      applied_writes: {
+        attendance: rawAppliedWrites.attendance,
+        bookings: rawAppliedWrites.bookings,
+        location_events:
+          rawAppliedWrites.location_events ?? rawAppliedWrites.locationEvents ?? 0
+      },
+      replaced: replacement
+    };
   } catch (error) {
     await transaction.rollback();
     throw error;
@@ -499,9 +887,11 @@ function buildDryRunResponse({ endpointType, request, plan, seed }) {
     mode: 'dry-run',
     target_date: request.targetDate,
     seed,
+    existing_strategy: request.existingStrategy,
     policy: plan.policy,
     population: plan.population,
     mode_summary: plan.mode_summary,
+    discipline_summary: plan.discipline_summary,
     selection_summary: plan.selection_summary,
     warnings: plan.warnings,
     conflicts: plan.conflicts,
@@ -510,25 +900,32 @@ function buildDryRunResponse({ endpointType, request, plan, seed }) {
       bookings: plan.plannedBookingRows.length,
       location_events: plan.plannedLocationEventRows.length
     },
+    would_replace: {
+      attendance: plan.replacement?.attendance || 0,
+      location_events: plan.replacement?.location_events || 0
+    },
     skipped_existing: plan.skipped_existing,
     skipped_conflict: plan.skipped_conflict
   };
 }
 
-function buildApplyResponse({ endpointType, request, plan, seed, appliedWrites }) {
+function buildApplyResponse({ endpointType, request, plan, seed, appliedResult }) {
   return {
     success: true,
     endpoint_type: endpointType,
     mode: 'apply',
     target_date: request.targetDate,
     seed,
+    existing_strategy: request.existingStrategy,
     policy: plan.policy,
     population: plan.population,
     mode_summary: plan.mode_summary,
+    discipline_summary: plan.discipline_summary,
     selection_summary: plan.selection_summary,
     warnings: plan.warnings,
     conflicts: plan.conflicts,
-    applied_writes: appliedWrites,
+    applied_writes: appliedResult.applied_writes,
+    replaced: appliedResult.replaced,
     skipped_existing: plan.skipped_existing,
     skipped_conflict: plan.skipped_conflict
   };
@@ -552,7 +949,7 @@ export async function executeResearchAttendanceTrigger({
     );
   }
 
-  const seed = `${request.targetDate}:${endpointType === 'daily' ? 'daily' : 'full-day'}`;
+  const seed = buildTriggerSeed(request, endpointType);
   const collectSnapshot = dependencies.collectSnapshot || (() => collectTriggerSnapshotForDate(request.targetDate));
   const buildPlan = dependencies.buildPlan || defaultBuildPlan;
   const applyPlan = dependencies.applyPlan || ((payload) => applyResearchAttendancePlanInTransaction(payload.plan));
@@ -566,13 +963,19 @@ export async function executeResearchAttendanceTrigger({
 
   if (plan.invalid_reference_count > 0) {
     throw createHttpError(
-      500,
+      409,
       'E_INVALID_REFERENCE_STATE',
-      'Reference state tidak valid untuk apply research attendance trigger.'
+      'Research attendance trigger memiliki conflict reference.',
+      {
+        target_date: request.targetDate,
+        endpoint_type: endpointType,
+        conflicts: plan.conflicts,
+        hint: 'Jalankan dry_run=true atau siapkan approved WFA booking/lokasi untuk user conflict.'
+      }
     );
   }
 
-  const appliedWrites = await applyPlan({
+  const appliedResult = await applyPlan({
     endpointType,
     targetDate: request.targetDate,
     seed,
@@ -581,7 +984,7 @@ export async function executeResearchAttendanceTrigger({
     plan,
     user
   });
-  return buildApplyResponse({ endpointType, request, plan, seed, appliedWrites });
+  return buildApplyResponse({ endpointType, request, plan, seed, appliedResult });
 }
 
-export { APPLY_CONFIRMATION };
+export { APPLY_CONFIRMATION, DEFAULT_DISCIPLINE_MIX, RESEARCH_TRIGGER_ATTENDANCE_NOTE };

--- a/tests/errorHandler.test.js
+++ b/tests/errorHandler.test.js
@@ -95,4 +95,45 @@ describe('errorHandler middleware', () => {
       details
     });
   });
+
+  it('surfaces invalid research trigger reference conflicts to operators', () => {
+    const conflicts = [{ type: 'invalid_reference', user_id: 62, target_date: '2026-07-02', mode: 'WFA' }];
+    const err = Object.assign(new Error('Research attendance trigger memiliki conflict reference.'), {
+      status: 409,
+      code: 'E_INVALID_REFERENCE_STATE',
+      target_date: '2026-07-02',
+      endpoint_type: 'daily',
+      conflicts,
+      hint: 'Jalankan dry_run=true atau siapkan approved WFA booking/lokasi untuk user conflict.',
+      stack: 'stack-trace'
+    });
+    const req = {
+      path: '/api/attendance/research-trigger/daily',
+      method: 'POST',
+      ip: '127.0.0.1'
+    };
+    const res = createResponse();
+
+    errorHandler(err, req, res, jest.fn());
+
+    expect(mockLoggerError).toHaveBeenCalledWith({
+      message: 'Research attendance trigger memiliki conflict reference.',
+      code: 'E_INVALID_REFERENCE_STATE',
+      conflicts,
+      stack: 'stack-trace',
+      path: '/api/attendance/research-trigger/daily',
+      method: 'POST',
+      ip: '127.0.0.1'
+    });
+    expect(res.status).toHaveBeenCalledWith(409);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Research attendance trigger memiliki conflict reference.',
+      code: 'E_INVALID_REFERENCE_STATE',
+      target_date: '2026-07-02',
+      endpoint_type: 'daily',
+      conflicts,
+      hint: 'Jalankan dry_run=true atau siapkan approved WFA booking/lokasi untuk user conflict.'
+    });
+  });
 });

--- a/tests/researchAttendanceTriggerInfrastructure.test.js
+++ b/tests/researchAttendanceTriggerInfrastructure.test.js
@@ -6,6 +6,8 @@ const mockAttendanceFindAll = jest.fn();
 const mockBookingFindAll = jest.fn();
 const mockLocationEventFindAll = jest.fn();
 const mockUserFindAll = jest.fn();
+const mockAttendanceDestroy = jest.fn();
+const mockLocationEventDestroy = jest.fn();
 const mockCommit = jest.fn();
 const mockRollback = jest.fn();
 const mockTransaction = jest.fn(async () => ({
@@ -27,13 +29,15 @@ jest.unstable_mockModule('../scripts/research/generate-attendance-dataset.js', (
 
 jest.unstable_mockModule('../src/models/index.js', () => ({
   Attendance: {
-    findAll: mockAttendanceFindAll
+    findAll: mockAttendanceFindAll,
+    destroy: mockAttendanceDestroy
   },
   Booking: {
     findAll: mockBookingFindAll
   },
   LocationEvent: {
-    findAll: mockLocationEventFindAll
+    findAll: mockLocationEventFindAll,
+    destroy: mockLocationEventDestroy
   },
   User: {
     findAll: mockUserFindAll
@@ -44,7 +48,8 @@ jest.unstable_mockModule('../src/models/index.js', () => ({
     Sequelize: {
       Op: {
         gte: Symbol.for('gte'),
-        lt: Symbol.for('lt')
+        lt: Symbol.for('lt'),
+        in: Symbol.for('in')
       }
     }
   }
@@ -58,6 +63,8 @@ const {
 describe('research attendance trigger infrastructure helpers', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockAttendanceDestroy.mockResolvedValue(0);
+    mockLocationEventDestroy.mockResolvedValue(0);
     mockUserFindAll.mockResolvedValue([
       {
         id_users: 10,
@@ -106,13 +113,42 @@ describe('research attendance trigger infrastructure helpers', () => {
       locationEvents: 4
     });
 
+    mockLocationEventDestroy.mockResolvedValue(4);
+    mockAttendanceDestroy.mockResolvedValue(2);
+
     const result = await applyResearchAttendancePlanInTransaction({
+      targetDate: '2026-07-10',
+      replacement: {
+        attendanceRows: [
+          { id_attendance: 11, user_id: 1, attendance_date: '2026-07-10' },
+          { id_attendance: 12, user_id: 2, attendance_date: '2026-07-10' }
+        ],
+        replaceableUserIds: [1, 2],
+        location_events: 4
+      },
       plannedAttendanceRows: [{ id_attendance: 1 }],
       plannedBookingRows: [{ booking_id: 1 }],
       plannedLocationEventRows: [{ id: 1 }]
     });
 
     expect(mockTransaction).toHaveBeenCalled();
+    expect(mockLocationEventDestroy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          user_id: expect.any(Object),
+          event_timestamp: expect.any(Object)
+        }),
+        transaction: expect.objectContaining({ commit: mockCommit, rollback: mockRollback })
+      })
+    );
+    expect(mockAttendanceDestroy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id_attendance: expect.any(Object)
+        }),
+        transaction: expect.objectContaining({ commit: mockCommit, rollback: mockRollback })
+      })
+    );
     expect(mockApplyResearchAttendancePlan).toHaveBeenCalledWith(
       expect.objectContaining({
         transaction: expect.objectContaining({ commit: mockCommit, rollback: mockRollback })
@@ -127,8 +163,8 @@ describe('research attendance trigger infrastructure helpers', () => {
         location_events: 4
       },
       replaced: {
-        attendance: 0,
-        location_events: 0
+        attendance: 2,
+        location_events: 4
       }
     });
   });

--- a/tests/researchAttendanceTriggerInfrastructure.test.js
+++ b/tests/researchAttendanceTriggerInfrastructure.test.js
@@ -120,7 +120,17 @@ describe('research attendance trigger infrastructure helpers', () => {
     );
     expect(mockCommit).toHaveBeenCalled();
     expect(mockRollback).not.toHaveBeenCalled();
-    expect(result).toEqual({ attendance: 2, bookings: 1, locationEvents: 4 });
+    expect(result).toEqual({
+      applied_writes: {
+        attendance: 2,
+        bookings: 1,
+        location_events: 4
+      },
+      replaced: {
+        attendance: 0,
+        location_events: 0
+      }
+    });
   });
 
   it('rolls back transaction when apply write fails', async () => {

--- a/tests/researchAttendanceTriggerService.test.js
+++ b/tests/researchAttendanceTriggerService.test.js
@@ -474,6 +474,106 @@ describe('research attendance trigger service', () => {
     );
   });
 
+  it('replace on daily regenerates from all target-date research-owned rows instead of only the new batch selection', async () => {
+    const baselineSnapshot = createSnapshot();
+    const batchAPlan = await buildResearchAttendanceTriggerPlan({
+      endpointType: 'daily',
+      targetDate: '2026-07-10',
+      seed: '2026-07-10:daily:batch-a',
+      request: {
+        allowNonWorkingDay: false,
+        existingStrategy: 'replace',
+        disciplineMix: DEFAULT_DISCIPLINE_MIX,
+        seedSuffix: 'batch-a'
+      },
+      snapshot: baselineSnapshot,
+      user: { id: 99, role_name: 'Admin' }
+    });
+
+    const replaySnapshot = createSnapshot(52, {
+      existingAttendanceRows: batchAPlan.plannedAttendanceRows.map((row, index) => ({
+        id_attendance: index + 1,
+        ...row
+      })),
+      existingLocationEvents: batchAPlan.plannedLocationEventRows.map((row, index) => ({
+        id: index + 1,
+        ...row
+      }))
+    });
+
+    const batchBPlan = await buildResearchAttendanceTriggerPlan({
+      endpointType: 'daily',
+      targetDate: '2026-07-10',
+      seed: '2026-07-10:daily:batch-b',
+      request: {
+        allowNonWorkingDay: false,
+        existingStrategy: 'replace',
+        disciplineMix: DEFAULT_DISCIPLINE_MIX,
+        seedSuffix: 'batch-b'
+      },
+      snapshot: replaySnapshot,
+      user: { id: 99, role_name: 'Admin' }
+    });
+
+    expect(batchAPlan.selection_summary.target_user_ids).toHaveLength(16);
+    expect(batchBPlan.selection_summary.target_user_ids).toHaveLength(16);
+    expect(batchBPlan.selection_summary.target_user_ids).not.toEqual(
+      batchAPlan.selection_summary.target_user_ids
+    );
+    expect(batchBPlan.replacement).toMatchObject({
+      attendance: batchAPlan.plannedAttendanceRows.length,
+      location_events: batchAPlan.plannedLocationEventRows.length
+    });
+    expect(batchBPlan.plannedAttendanceRows).toHaveLength(16);
+    expect(batchBPlan.plannedLocationEventRows).toHaveLength(30);
+  });
+
+  it('replace keeps non-research target-date attendance untouched with warnings', async () => {
+    const snapshot = createSnapshot(52, {
+      existingAttendanceRows: [
+        {
+          id_attendance: 1,
+          user_id: 1,
+          attendance_date: '2026-07-10',
+          notes: RESEARCH_TRIGGER_ATTENDANCE_NOTE
+        },
+        {
+          id_attendance: 2,
+          user_id: 44,
+          attendance_date: '2026-07-10',
+          notes: 'Manual attendance'
+        }
+      ],
+      existingLocationEvents: [
+        { id: 1, user_id: 1, event_timestamp: '2026-07-10 08:00:00' },
+        { id: 2, user_id: 1, event_timestamp: '2026-07-10 17:00:00' },
+        { id: 3, user_id: 44, event_timestamp: '2026-07-10 08:00:00' }
+      ]
+    });
+
+    const plan = await buildResearchAttendanceTriggerPlan({
+      endpointType: 'daily',
+      targetDate: '2026-07-10',
+      seed: '2026-07-10:daily:batch-b',
+      request: {
+        allowNonWorkingDay: false,
+        existingStrategy: 'replace',
+        disciplineMix: DEFAULT_DISCIPLINE_MIX,
+        seedSuffix: 'batch-b'
+      },
+      snapshot,
+      user: { id: 99, role_name: 'Admin' }
+    });
+
+    expect(plan.replacement).toMatchObject({
+      attendance: 1,
+      location_events: 2
+    });
+    expect(plan.warnings).toContain(
+      'existing_strategy=replace mengganti semua attendance research-owned pada tanggal target. 1 row existing non-research tetap dipertahankan dan tidak ikut direplace.'
+    );
+  });
+
   it('returns an apply response when confirmation is valid and writes succeed', async () => {
     const applyPlan = jest.fn(async () => ({
       applied_writes: {

--- a/tests/researchAttendanceTriggerService.test.js
+++ b/tests/researchAttendanceTriggerService.test.js
@@ -11,9 +11,63 @@ jest.unstable_mockModule('../src/config/index.js', () => ({
   }
 }));
 
-const { executeResearchAttendanceTrigger, buildResearchAttendanceTriggerPlan } = await import(
-  '../src/services/researchAttendanceTrigger.service.js'
-);
+const {
+  executeResearchAttendanceTrigger,
+  buildResearchAttendanceTriggerPlan,
+  DEFAULT_DISCIPLINE_MIX,
+  RESEARCH_TRIGGER_ATTENDANCE_NOTE
+} = await import('../src/services/researchAttendanceTrigger.service.js');
+
+function buildBaselineUsers(totalUsers) {
+  return Array.from({ length: totalUsers }, (_, index) => {
+    const userId = index + 1;
+    let role_name = 'Internship';
+
+    if (userId > 40 && userId <= 50) {
+      role_name = 'Employee';
+    }
+
+    if (userId === 51) {
+      role_name = 'Admin';
+    }
+
+    if (userId === 52) {
+      role_name = 'Management';
+    }
+
+    return {
+      userId,
+      role_name
+    };
+  });
+}
+
+function buildExpectedLocations(totalUsers) {
+  return Object.fromEntries(
+    Array.from({ length: totalUsers }, (_, index) => {
+      const userId = index + 1;
+      return [
+        userId,
+        {
+          wfoLocationId: 1000 + userId,
+          wfhLocationId: 2000 + userId,
+          fallbackWfaLocationId: 3000 + userId
+        }
+      ];
+    })
+  );
+}
+
+function createSnapshot(totalUsers = 52, overrides = {}) {
+  return {
+    baselineUsers: buildBaselineUsers(totalUsers),
+    existingAttendanceRows: [],
+    existingBookingRows: [],
+    existingLocationEvents: [],
+    expectedLocationsByUser: buildExpectedLocations(totalUsers),
+    ...overrides
+  };
+}
 
 describe('research attendance trigger service', () => {
   beforeEach(() => {
@@ -24,30 +78,50 @@ describe('research attendance trigger service', () => {
     jest.clearAllMocks();
   });
 
-  it('returns a deterministic dry-run summary for the daily endpoint', async () => {
+  it('returns a deterministic dry-run summary for old request bodies and applies the default discipline mix', async () => {
     const collectSnapshot = jest.fn(async () => ({
       dbIdentity: { host: '127.0.0.1', port: 3306, database: 'v1_infinite_track' }
     }));
-    const buildPlan = jest.fn(async () => ({
-      policy: { allow_non_working_day: false, skip_existing: true },
+    const buildPlan = jest.fn(async ({ request }) => ({
+      policy: {
+        allow_non_working_day: false,
+        existing_strategy: request.existingStrategy,
+        skip_existing: true,
+        discipline_mix: request.disciplineMix
+      },
       population: {
         source: 'existing July 2025 attendance baseline',
         baseline_user_count: 10,
         eligible_user_count: 8,
         selected_user_count: 3
       },
+      selection_summary: {
+        strategy: 'fixed-percentage',
+        subset_percent: 30,
+        target_user_ids: [1, 2, 3]
+      },
       mode_summary: {
         wfo: 2,
         wfh: 1,
         wfa: 0
       },
+      discipline_summary: {
+        ontime: 2,
+        late: 1,
+        early: 0,
+        alpha: 0
+      },
       warnings: [],
       conflicts: [],
+      replacement: {
+        attendance: 0,
+        location_events: 0
+      },
       skipped_existing: 1,
       skipped_conflict: 0,
       plannedAttendanceRows: [{ id: 1 }, { id: 2 }, { id: 3 }],
       plannedBookingRows: [],
-      plannedLocationEventRows: [{ id: 1 }]
+      plannedLocationEventRows: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }, { id: 6 }]
     }));
 
     const result = await executeResearchAttendanceTrigger({
@@ -71,25 +145,27 @@ describe('research attendance trigger service', () => {
       mode: 'dry-run',
       target_date: '2026-07-01',
       seed: '2026-07-01:daily',
+      existing_strategy: 'skip',
       policy: {
         allow_non_working_day: false,
-        skip_existing: true
+        existing_strategy: 'skip',
+        skip_existing: true,
+        discipline_mix: DEFAULT_DISCIPLINE_MIX
       },
-      population: {
-        source: 'existing July 2025 attendance baseline',
-        baseline_user_count: 10,
-        eligible_user_count: 8,
-        selected_user_count: 3
-      },
-      mode_summary: {
-        wfo: 2,
-        wfh: 1,
-        wfa: 0
+      discipline_summary: {
+        ontime: 2,
+        late: 1,
+        early: 0,
+        alpha: 0
       },
       planned_writes: {
         attendance: 3,
         bookings: 0,
-        location_events: 1
+        location_events: 6
+      },
+      would_replace: {
+        attendance: 0,
+        location_events: 0
       },
       skipped_existing: 1,
       skipped_conflict: 0
@@ -99,7 +175,12 @@ describe('research attendance trigger service', () => {
       expect.objectContaining({
         endpointType: 'daily',
         targetDate: '2026-07-01',
-        seed: '2026-07-01:daily'
+        seed: '2026-07-01:daily',
+        request: expect.objectContaining({
+          disciplineMix: DEFAULT_DISCIPLINE_MIX,
+          existingStrategy: 'skip',
+          seedSuffix: ''
+        })
       })
     );
   });
@@ -127,101 +208,283 @@ describe('research attendance trigger service', () => {
     });
   });
 
-  it('builds a deterministic daily subset plan using 30 percent of eligible users', async () => {
-    const snapshot = {
-      baselineUsers: [
-        { userId: 1, role_name: 'Internship' },
-        { userId: 2, role_name: 'Internship' },
-        { userId: 3, role_name: 'Internship' },
-        { userId: 4, role_name: 'Internship' },
-        { userId: 5, role_name: 'Internship' },
-        { userId: 6, role_name: 'Internship' },
-        { userId: 7, role_name: 'Employee' },
-        { userId: 8, role_name: 'Employee' },
-        { userId: 9, role_name: 'Admin' },
-        { userId: 10, role_name: 'Management' }
-      ],
-      existingAttendanceRows: [],
-      existingBookingRows: [],
-      existingLocationEvents: [],
-      expectedLocationsByUser: {
-        1: { wfoLocationId: 101, wfhLocationId: 201, fallbackWfaLocationId: 301 },
-        2: { wfoLocationId: 102, wfhLocationId: 202, fallbackWfaLocationId: 302 },
-        3: { wfoLocationId: 103, wfhLocationId: 203, fallbackWfaLocationId: 303 },
-        4: { wfoLocationId: 104, wfhLocationId: 204, fallbackWfaLocationId: 304 },
-        5: { wfoLocationId: 105, wfhLocationId: 205, fallbackWfaLocationId: 305 },
-        6: { wfoLocationId: 106, wfhLocationId: 206, fallbackWfaLocationId: 306 },
-        7: { wfoLocationId: 107, wfhLocationId: 207, fallbackWfaLocationId: 307 },
-        8: { wfoLocationId: 108, wfhLocationId: 208, fallbackWfaLocationId: 308 },
-        9: { wfoLocationId: 109, wfhLocationId: 209, fallbackWfaLocationId: 309 },
-        10: { wfoLocationId: 110, wfhLocationId: 210, fallbackWfaLocationId: 310 }
-      }
-    };
-
-    const first = await buildResearchAttendanceTriggerPlan({
-      endpointType: 'daily',
-      targetDate: '2026-07-01',
-      seed: '2026-07-01:daily',
-      request: { allowNonWorkingDay: false },
-      snapshot,
-      user: { id: 99, role_name: 'Admin' }
+  it('rejects an invalid existing strategy', async () => {
+    await expect(
+      executeResearchAttendanceTrigger({
+        endpointType: 'daily',
+        body: {
+          target_date: '2026-07-01',
+          existing_strategy: 'overwrite'
+        },
+        dependencies: {
+          isNonWorkingDay: () => false,
+          collectSnapshot: jest.fn(),
+          buildPlan: jest.fn(),
+          applyPlan: jest.fn()
+        }
+      })
+    ).rejects.toMatchObject({
+      status: 400,
+      code: 'E_INVALID_EXISTING_STRATEGY'
     });
-    const second = await buildResearchAttendanceTriggerPlan({
-      endpointType: 'daily',
-      targetDate: '2026-07-01',
-      seed: '2026-07-01:daily',
-      request: { allowNonWorkingDay: false },
-      snapshot,
-      user: { id: 99, role_name: 'Admin' }
-    });
-
-    expect(first.population).toMatchObject({
-      baseline_user_count: 10,
-      eligible_user_count: 10,
-      selected_user_count: 3
-    });
-    expect(first.selection_summary.target_user_ids).toEqual(second.selection_summary.target_user_ids);
-    expect(first.plannedAttendanceRows).toHaveLength(3);
   });
 
-  it('targets the full eligible population for the full-day endpoint', async () => {
+  it('rejects an invalid discipline mix total', async () => {
+    await expect(
+      executeResearchAttendanceTrigger({
+        endpointType: 'daily',
+        body: {
+          target_date: '2026-07-01',
+          discipline_mix: {
+            ontime: 70,
+            late: 10,
+            early: 10,
+            alpha: 5
+          }
+        },
+        dependencies: {
+          isNonWorkingDay: () => false,
+          collectSnapshot: jest.fn(),
+          buildPlan: jest.fn(),
+          applyPlan: jest.fn()
+        }
+      })
+    ).rejects.toMatchObject({
+      status: 400,
+      code: 'E_INVALID_DISCIPLINE_MIX'
+    });
+  });
+
+  it('uses seed_suffix to vary deterministic daily selection while remaining reproducible', async () => {
+    const snapshot = createSnapshot();
+
+    const first = await executeResearchAttendanceTrigger({
+      endpointType: 'daily',
+      body: {
+        target_date: '2026-07-01',
+        dry_run: true,
+        seed_suffix: 'batch-a'
+      },
+      dependencies: {
+        isNonWorkingDay: () => false,
+        collectSnapshot: jest.fn(async () => snapshot)
+      }
+    });
+    const second = await executeResearchAttendanceTrigger({
+      endpointType: 'daily',
+      body: {
+        target_date: '2026-07-01',
+        dry_run: true,
+        seed_suffix: 'batch-a'
+      },
+      dependencies: {
+        isNonWorkingDay: () => false,
+        collectSnapshot: jest.fn(async () => snapshot)
+      }
+    });
+    const varied = await executeResearchAttendanceTrigger({
+      endpointType: 'daily',
+      body: {
+        target_date: '2026-07-01',
+        dry_run: true,
+        seed_suffix: 'batch-b'
+      },
+      dependencies: {
+        isNonWorkingDay: () => false,
+        collectSnapshot: jest.fn(async () => snapshot)
+      }
+    });
+
+    expect(first.seed).toBe('2026-07-01:daily:batch-a');
+    expect(second.selection_summary.target_user_ids).toEqual(first.selection_summary.target_user_ids);
+    expect(varied.selection_summary.target_user_ids).not.toEqual(first.selection_summary.target_user_ids);
+  });
+
+  it('builds a deterministic daily subset plan with meaningful discipline variation', async () => {
+    const snapshot = createSnapshot();
+
+    const plan = await buildResearchAttendanceTriggerPlan({
+      endpointType: 'daily',
+      targetDate: '2026-07-01',
+      seed: '2026-07-01:daily',
+      request: {
+        allowNonWorkingDay: false,
+        existingStrategy: 'skip',
+        disciplineMix: DEFAULT_DISCIPLINE_MIX,
+        seedSuffix: ''
+      },
+      snapshot,
+      user: { id: 99, role_name: 'Admin' }
+    });
+
+    const lateRows = plan.plannedAttendanceRows.filter((row) => row.status_id === 2);
+    const earlyRows = plan.plannedAttendanceRows.filter((row) => row.status_id === 4);
+    const alphaRows = plan.plannedAttendanceRows.filter((row) => row.status_id === 3);
+
+    expect(plan.population).toMatchObject({
+      baseline_user_count: 52,
+      eligible_user_count: 52,
+      selected_user_count: 16
+    });
+    expect(plan.discipline_summary).toEqual({
+      ontime: 12,
+      late: 2,
+      early: 1,
+      alpha: 1
+    });
+    expect(lateRows).toHaveLength(2);
+    expect(earlyRows).toHaveLength(1);
+    expect(alphaRows).toHaveLength(1);
+    expect(lateRows.every((row) => row.time_in > '2026-07-01 08:00:00')).toBe(true);
+    expect(earlyRows.every((row) => Number(row.work_hour) < 8)).toBe(true);
+    expect(alphaRows.every((row) => Number(row.work_hour) === 0)).toBe(true);
+    expect(plan.plannedLocationEventRows).toHaveLength(30);
+  });
+
+  it('builds a deterministic full-day plan with alpha rows excluded from location events', async () => {
+    const snapshot = createSnapshot();
+
     const plan = await buildResearchAttendanceTriggerPlan({
       endpointType: 'full-day',
       targetDate: '2026-07-01',
       seed: '2026-07-01:full-day',
-      request: { allowNonWorkingDay: false },
-      snapshot: {
-        baselineUsers: [
-          { userId: 1, role_name: 'Internship' },
-          { userId: 2, role_name: 'Employee' },
-          { userId: 3, role_name: 'Admin' }
-        ],
-        existingAttendanceRows: [],
-        existingBookingRows: [],
-        existingLocationEvents: [],
-        expectedLocationsByUser: {
-          1: { wfoLocationId: 101, wfhLocationId: 201, fallbackWfaLocationId: 301 },
-          2: { wfoLocationId: 102, wfhLocationId: 202, fallbackWfaLocationId: 302 },
-          3: { wfoLocationId: 103, wfhLocationId: 203, fallbackWfaLocationId: 303 }
-        }
+      request: {
+        allowNonWorkingDay: false,
+        existingStrategy: 'skip',
+        disciplineMix: DEFAULT_DISCIPLINE_MIX,
+        seedSuffix: ''
       },
+      snapshot,
       user: { id: 99, role_name: 'Admin' }
     });
 
+    const alphaUserIds = new Set(
+      plan.plannedAttendanceRows.filter((row) => row.status_id === 3).map((row) => row.user_id)
+    );
+
     expect(plan.population).toMatchObject({
-      baseline_user_count: 3,
-      eligible_user_count: 3,
-      selected_user_count: 3
+      baseline_user_count: 52,
+      eligible_user_count: 52,
+      selected_user_count: 52
     });
-    expect(plan.selection_summary.target_user_ids).toHaveLength(3);
+    expect(plan.discipline_summary).toEqual({
+      ontime: 39,
+      late: 6,
+      early: 4,
+      alpha: 3
+    });
+    expect(
+      plan.plannedAttendanceRows
+        .filter((row) => row.status_id === 3)
+        .every(
+          (row) =>
+            row.time_in === row.time_out &&
+            Number(row.work_hour) === 0 &&
+            row.notes === RESEARCH_TRIGGER_ATTENDANCE_NOTE
+        )
+    ).toBe(true);
+    expect(plan.plannedLocationEventRows).toHaveLength(98);
+    expect(plan.plannedLocationEventRows.every((row) => !alphaUserIds.has(row.user_id))).toBe(true);
+  });
+
+  it('keeps existing rows skipped by default', async () => {
+    const snapshot = createSnapshot(3, {
+      baselineUsers: [
+        { userId: 1, role_name: 'Employee' },
+        { userId: 2, role_name: 'Employee' },
+        { userId: 3, role_name: 'Employee' }
+      ],
+      expectedLocationsByUser: buildExpectedLocations(3),
+      existingAttendanceRows: [
+        {
+          id_attendance: 11,
+          user_id: 1,
+          attendance_date: '2026-07-01',
+          notes: 'Manual attendance'
+        }
+      ]
+    });
+
+    const plan = await buildResearchAttendanceTriggerPlan({
+      endpointType: 'full-day',
+      targetDate: '2026-07-01',
+      seed: '2026-07-01:full-day',
+      request: {
+        allowNonWorkingDay: false,
+        existingStrategy: 'skip',
+        disciplineMix: DEFAULT_DISCIPLINE_MIX,
+        seedSuffix: ''
+      },
+      snapshot,
+      user: { id: 99, role_name: 'Admin' }
+    });
+
+    expect(plan.skipped_existing).toBe(1);
+    expect(plan.plannedAttendanceRows).toHaveLength(2);
+    expect(plan.replacement).toMatchObject({
+      attendance: 0,
+      location_events: 0
+    });
+  });
+
+  it('reports replace counts and regenerates only research-owned rows when replace is requested', async () => {
+    const snapshot = createSnapshot(3, {
+      baselineUsers: [
+        { userId: 1, role_name: 'Employee' },
+        { userId: 2, role_name: 'Employee' },
+        { userId: 3, role_name: 'Employee' }
+      ],
+      expectedLocationsByUser: buildExpectedLocations(3),
+      existingAttendanceRows: [
+        {
+          id_attendance: 21,
+          user_id: 1,
+          attendance_date: '2026-07-01',
+          notes: RESEARCH_TRIGGER_ATTENDANCE_NOTE
+        }
+      ],
+      existingLocationEvents: [
+        { id: 31, user_id: 1, event_timestamp: '2026-07-01 08:00:00' },
+        { id: 32, user_id: 1, event_timestamp: '2026-07-01 17:00:00' }
+      ]
+    });
+
+    const plan = await buildResearchAttendanceTriggerPlan({
+      endpointType: 'full-day',
+      targetDate: '2026-07-01',
+      seed: '2026-07-01:full-day',
+      request: {
+        allowNonWorkingDay: false,
+        existingStrategy: 'replace',
+        disciplineMix: DEFAULT_DISCIPLINE_MIX,
+        seedSuffix: ''
+      },
+      snapshot,
+      user: { id: 99, role_name: 'Admin' }
+    });
+
     expect(plan.plannedAttendanceRows).toHaveLength(3);
+    expect(plan.replacement).toMatchObject({
+      attendance: 1,
+      location_events: 2,
+      replaceableUserIds: [1]
+    });
+    expect(plan.warnings).toContain(
+      'existing_strategy=replace akan menghapus location events existing pada level user+tanggal untuk attendance research-owned karena location_events tidak memiliki marker research-owned.'
+    );
   });
 
   it('returns an apply response when confirmation is valid and writes succeed', async () => {
     const applyPlan = jest.fn(async () => ({
-      attendance: 2,
-      bookings: 1,
-      locationEvents: 4
+      applied_writes: {
+        attendance: 2,
+        bookings: 1,
+        location_events: 4
+      },
+      replaced: {
+        attendance: 1,
+        location_events: 2
+      }
     }));
 
     const result = await executeResearchAttendanceTrigger({
@@ -236,7 +499,12 @@ describe('research attendance trigger service', () => {
         isNonWorkingDay: () => false,
         collectSnapshot: jest.fn(async () => ({ dbIdentity: {} })),
         buildPlan: jest.fn(async () => ({
-          policy: { allow_non_working_day: false, skip_existing: true },
+          policy: {
+            allow_non_working_day: false,
+            existing_strategy: 'skip',
+            skip_existing: true,
+            discipline_mix: DEFAULT_DISCIPLINE_MIX
+          },
           population: {
             source: 'existing July 2025 attendance baseline',
             baseline_user_count: 2,
@@ -248,8 +516,13 @@ describe('research attendance trigger service', () => {
             target_user_ids: [10, 11]
           },
           mode_summary: { wfo: 2, wfh: 0, wfa: 0 },
+          discipline_summary: { ontime: 2, late: 0, early: 0, alpha: 0 },
           warnings: [],
           conflicts: [],
+          replacement: {
+            attendance: 1,
+            location_events: 2
+          },
           skipped_existing: 0,
           skipped_conflict: 0,
           invalid_reference_count: 0,
@@ -270,13 +543,17 @@ describe('research attendance trigger service', () => {
       applied_writes: {
         attendance: 2,
         bookings: 1,
-        locationEvents: 4
+        location_events: 4
+      },
+      replaced: {
+        attendance: 1,
+        location_events: 2
       }
     });
     expect(applyPlan).toHaveBeenCalled();
   });
 
-  it('blocks apply when the plan reports invalid reference state', async () => {
+  it('blocks apply with an operator-friendly invalid reference error payload', async () => {
     const applyPlan = jest.fn();
 
     await expect(
@@ -292,7 +569,12 @@ describe('research attendance trigger service', () => {
           isNonWorkingDay: () => false,
           collectSnapshot: jest.fn(async () => ({ dbIdentity: {} })),
           buildPlan: jest.fn(async () => ({
-            policy: { allow_non_working_day: false, skip_existing: true },
+            policy: {
+              allow_non_working_day: false,
+              existing_strategy: 'skip',
+              skip_existing: true,
+              discipline_mix: DEFAULT_DISCIPLINE_MIX
+            },
             population: {
               source: 'existing July 2025 attendance baseline',
               baseline_user_count: 2,
@@ -305,8 +587,13 @@ describe('research attendance trigger service', () => {
               target_user_ids: [10]
             },
             mode_summary: { wfo: 0, wfh: 0, wfa: 0 },
+            discipline_summary: { ontime: 0, late: 0, early: 0, alpha: 0 },
             warnings: [],
-            conflicts: [{ type: 'invalid_reference', user_id: 10 }],
+            conflicts: [{ type: 'invalid_reference', user_id: 10, target_date: '2026-07-01', mode: 'WFA' }],
+            replacement: {
+              attendance: 0,
+              location_events: 0
+            },
             skipped_existing: 0,
             skipped_conflict: 1,
             invalid_reference_count: 1,
@@ -318,8 +605,12 @@ describe('research attendance trigger service', () => {
         }
       })
     ).rejects.toMatchObject({
-      status: 500,
-      code: 'E_INVALID_REFERENCE_STATE'
+      status: 409,
+      code: 'E_INVALID_REFERENCE_STATE',
+      target_date: '2026-07-01',
+      endpoint_type: 'daily',
+      conflicts: [{ type: 'invalid_reference', user_id: 10, target_date: '2026-07-01', mode: 'WFA' }],
+      hint: 'Jalankan dry_run=true atau siapkan approved WFA booking/lokasi untuk user conflict.'
     });
     expect(applyPlan).not.toHaveBeenCalled();
   });
@@ -336,7 +627,13 @@ describe('research attendance trigger service', () => {
         isNonWorkingDay: () => false,
         collectSnapshot: jest.fn(async () => ({ dbIdentity: {} })),
         buildPlan: jest.fn(async () => ({
-          policy: { allow_non_working_day: false, skip_existing: true, daily_subset_percent: 30 },
+          policy: {
+            allow_non_working_day: false,
+            existing_strategy: 'skip',
+            skip_existing: true,
+            daily_subset_percent: 30,
+            discipline_mix: DEFAULT_DISCIPLINE_MIX
+          },
           population: {
             source: 'existing July 2025 attendance baseline',
             baseline_user_count: 4,
@@ -349,8 +646,13 @@ describe('research attendance trigger service', () => {
             target_user_ids: [1, 2]
           },
           mode_summary: { wfo: 0, wfh: 0, wfa: 0 },
+          discipline_summary: { ontime: 0, late: 0, early: 0, alpha: 0 },
           warnings: ['Semua user target sudah memiliki attendance pada tanggal yang diminta.'],
           conflicts: [],
+          replacement: {
+            attendance: 0,
+            location_events: 0
+          },
           skipped_existing: 2,
           skipped_conflict: 0,
           invalid_reference_count: 0,
@@ -369,6 +671,10 @@ describe('research attendance trigger service', () => {
       planned_writes: {
         attendance: 0,
         bookings: 0,
+        location_events: 0
+      },
+      would_replace: {
+        attendance: 0,
         location_events: 0
       },
       skipped_existing: 2,


### PR DESCRIPTION
## Summary
- fix `existing_strategy=replace` so daily regeneration replaces all research-owned attendance on `target_date`
- clean up target-date location events for all replaced research-owned attendance rows
- keep non-research attendance rows untouched and surface them via warnings
- add regression tests for `batch-a` -> `batch-b` regeneration without silent accumulation

## Problem Addressed
The previous implementation only replaced attendance for users selected by the new batch. That behavior is unsafe for `/api/attendance/research-trigger/daily` because each run only targets around 30% of users, so research data from earlier seeds could accumulate on the same date.

## Impact
- `replace` now behaves like a real target-date regeneration for research-owned rows
- old research-owned location events no longer linger across daily seed changes
- manual/non-research attendance remains preserved

## Verification
- `npm run lint` ✅
- `npm test -- --runInBand tests/researchAttendanceTriggerService.test.js tests/researchAttendanceTriggerInfrastructure.test.js` ✅
- `npm test -- --runInBand --testPathPattern='research|alpha'` ✅
- `npm test` ✅

## Notes
- this is a follow-up PR after #73 to land the corrected replace semantics
- branch reused: `feature/research-discipline-trigger-policy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Attendance research trigger requests now support deterministic inputs, including seed suffixes, existing-record handling, and discipline mix settings.
  * Dry-run and success responses now include richer summaries, replacement counts, and discipline breakdowns.

* **Bug Fixes**
  * Improved handling of invalid reference conflicts with clearer error details and hints.
  * Attendance event timestamps now respect pre فراہمed timestamps when available, improving consistency in generated data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->