### PR TITLE
feat: extend attendance history timeline contract

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1790,26 +1790,43 @@ paths:
       tags:
         - Attendance
       summary: Get user attendance history
-      description: Retrieve attendance history for the current user
+      description: Retrieve authenticated user's attendance history for Recent Attendance and Attendance Timeline UI. Active Session is a computed display badge only and is not stored in attendance_statuses.
       parameters:
         - in: query
-          name: month
+          name: period
+          schema:
+            type: string
+            enum: [daily, weekly, monthly, all, custom]
+            default: daily
+          description: Date window to retrieve. Use custom with start_date and end_date.
+        - in: query
+          name: start_date
+          schema:
+            type: string
+            format: date
+            example: '2026-05-01'
+          description: Required when period=custom. Must use YYYY-MM-DD.
+        - in: query
+          name: end_date
+          schema:
+            type: string
+            format: date
+            example: '2026-05-31'
+          description: Required when period=custom. Must use YYYY-MM-DD and be greater than or equal to start_date.
+        - in: query
+          name: page
           schema:
             type: integer
             minimum: 1
-            maximum: 12
-          description: Filter by month (1-12)
-        - in: query
-          name: year
-          schema:
-            type: integer
-          description: Filter by year
+            default: 1
+          description: Page number for paginated attendance rows.
         - in: query
           name: limit
           schema:
             type: integer
-            default: 50
-          description: Number of records to return
+            minimum: 1
+            default: 5
+          description: Number of records to return.
       responses:
         '200':
           description: Attendance history retrieved successfully
@@ -1822,9 +1839,184 @@ paths:
                     type: boolean
                     example: true
                   data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Attendance'
+                    type: object
+                    properties:
+                      period:
+                        type: object
+                        properties:
+                          type:
+                            type: string
+                            example: custom
+                          label:
+                            type: string
+                            example: Custom Range
+                          start_date:
+                            type: string
+                            nullable: true
+                            example: '2026-05-01'
+                          end_date:
+                            type: string
+                            nullable: true
+                            example: '2026-05-31'
+                      summary:
+                        type: object
+                        properties:
+                          total_ontime:
+                            type: integer
+                            example: 8
+                          total_late:
+                            type: integer
+                            example: 2
+                          total_early:
+                            type: integer
+                            example: 1
+                          total_alpha:
+                            type: integer
+                            example: 0
+                          total_wfo:
+                            type: integer
+                            example: 6
+                          total_wfa:
+                            type: integer
+                            example: 3
+                          total_wfh:
+                            type: integer
+                            example: 2
+                          total_work_hours:
+                            type: number
+                            format: float
+                            example: 88.5
+                      attendances:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            id_attendance:
+                              type: integer
+                              example: 123
+                            attendance_date:
+                              type: string
+                              format: date
+                              example: '2026-05-03'
+                            date:
+                              type: string
+                              description: Legacy day-of-month display field retained for backward compatibility.
+                              example: '03'
+                            monthYear:
+                              type: string
+                              description: Legacy month-year display field retained for backward compatibility.
+                              example: May 2026
+                            date_label:
+                              type: string
+                              example: 03 May 2026
+                            mode_key:
+                              type: string
+                              nullable: true
+                              enum: [wfo, wfh, wfa]
+                              example: wfo
+                            mode_label:
+                              type: string
+                              nullable: true
+                              example: WFO
+                            time_in:
+                              type: string
+                              nullable: true
+                              example: '08:04'
+                            time_out:
+                              type: string
+                              nullable: true
+                              example: '17:06'
+                            time_range:
+                              type: string
+                              example: '08:04 - 17:06'
+                            work_hour:
+                              type: string
+                              nullable: true
+                              description: Formatted work hour display. Null for alpha/absent rows to avoid misleading duration display.
+                              example: '09:02'
+                            work_hour_raw:
+                              type: number
+                              nullable: true
+                              format: float
+                              example: 9.03
+                            status_key:
+                              type: string
+                              nullable: true
+                              enum: [ontime, late, early, alpha]
+                              example: ontime
+                            status_label:
+                              type: string
+                              nullable: true
+                              example: On Time
+                            display_badge_key:
+                              type: string
+                              nullable: true
+                              enum: [active, ontime, late, early, alpha]
+                              example: active
+                            display_badge_label:
+                              type: string
+                              nullable: true
+                              example: Active Session
+                            location_label:
+                              type: string
+                              nullable: true
+                              example: Kantor Utama
+                            category:
+                              type: string
+                              nullable: true
+                              description: Legacy category label retained for backward compatibility.
+                              example: Work From Office
+                            status:
+                              type: string
+                              nullable: true
+                              description: Legacy final status label retained for backward compatibility.
+                              example: ontime
+                            location:
+                              type: string
+                              nullable: true
+                              description: Legacy location label retained for backward compatibility.
+                              example: Kantor Utama
+                            notes:
+                              type: string
+                              nullable: true
+                              example: Manual attendance
+                      pagination:
+                        type: object
+                        properties:
+                          current_page:
+                            type: integer
+                            example: 1
+                          total_pages:
+                            type: integer
+                            example: 4
+                          total_items:
+                            type: integer
+                            example: 20
+                          items_per_page:
+                            type: integer
+                            example: 5
+                          has_next_page:
+                            type: boolean
+                            example: true
+                          has_prev_page:
+                            type: boolean
+                            example: false
+                  message:
+                    type: string
+                    example: Riwayat absensi berhasil diambil
+        '400':
+          description: Invalid period or custom date input
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: Parameter start_date dan end_date wajib valid dengan format YYYY-MM-DD untuk period custom
         '401':
           $ref: '#/components/responses/Unauthorized'
 

--- a/src/controllers/attendance.controller.js
+++ b/src/controllers/attendance.controller.js
@@ -146,25 +146,106 @@ export const testWeightedPrediction = async (req, res) => {
   }
 };
 
+const MONTH_LABELS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+const isStrictDateOnly = (value) => {
+  if (typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const parsed = new Date(`${value}T00:00:00Z`);
+  return !isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value;
+};
+
+const parsePositiveInteger = (value, fallback) => {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+const buildDateLabel = (dateOnly) => {
+  const [year, month, day] = String(dateOnly).split('-').map(Number);
+  if (!year || !month || !day) return String(dateOnly || '');
+  return `${String(day).padStart(2, '0')} ${MONTH_LABELS[month - 1]} ${year}`;
+};
+
+const normalizeHistoryValue = (value) => String(value || '').trim().toLowerCase();
+
+const deriveModeContract = (attendance) => {
+  const categoryName = attendance.attendance_category?.category_name || null;
+  const normalized = normalizeHistoryValue(categoryName);
+
+  if (attendance.category_id === 1 || ['wfo', 'work from office'].includes(normalized)) {
+    return { mode_key: 'wfo', mode_label: 'WFO' };
+  }
+
+  if (attendance.category_id === 2 || ['wfh', 'work from home'].includes(normalized)) {
+    return { mode_key: 'wfh', mode_label: 'WFH' };
+  }
+
+  if (attendance.category_id === 3 || ['wfa', 'work from anywhere'].includes(normalized)) {
+    return { mode_key: 'wfa', mode_label: 'WFA' };
+  }
+
+  return { mode_key: normalized || null, mode_label: categoryName || null };
+};
+
+const deriveStatusContract = (attendance) => {
+  const statusName = attendance.status?.attendance_status_name || null;
+  const normalized = normalizeHistoryValue(statusName);
+
+  if (attendance.status_id === 1 || ['ontime', 'on time', 'tepat waktu'].includes(normalized)) {
+    return { status_key: 'ontime', status_label: 'On Time' };
+  }
+
+  if (attendance.status_id === 2 || ['late', 'terlambat'].includes(normalized)) {
+    return { status_key: 'late', status_label: 'Late' };
+  }
+
+  if (attendance.status_id === 3 || ['alpha', 'alpa', 'absent'].includes(normalized)) {
+    return { status_key: 'alpha', status_label: 'Alpha' };
+  }
+
+  if (attendance.status_id === 4 || ['early', 'lebih awal'].includes(normalized)) {
+    return { status_key: 'early', status_label: 'Early' };
+  }
+
+  return { status_key: normalized || null, status_label: statusName || null };
+};
+
+const buildPeriodLabel = (period) => {
+  switch (period) {
+    case 'daily':
+      return 'Today';
+    case 'weekly':
+      return 'This Week';
+    case 'monthly':
+      return 'This Month';
+    case 'custom':
+      return 'Custom Range';
+    case 'all':
+      return 'All Time';
+    default:
+      return period;
+  }
+};
+
 export const getAttendanceHistory = async (req, res) => {
   try {
     const userId = req.user.id;
-    const { period = 'daily', page = 1, limit = 5 } = req.query;
+    const { period = 'daily', start_date: customStartDate, end_date: customEndDate } = req.query;
+    const pageNum = parsePositiveInteger(req.query.page, 1);
+    const limitNum = parsePositiveInteger(req.query.limit, 5);
+    const offset = (pageNum - 1) * limitNum;
 
-    // Calculate offset for pagination
-    const offset = (parseInt(page) - 1) * parseInt(limit);
-
-    // Get current Jakarta time
     const now = new Date();
-    const jakartaOffset = 7 * 60; // UTC+7 in minutes
+    const jakartaOffset = 7 * 60;
     const jakartaTime = new Date(now.getTime() + jakartaOffset * 60000);
 
-    // Determine date range based on period
-    let startDate, endDate;
-    let whereClause = { user_id: userId };
+    let startDate;
+    let endDate;
+    let startDateOnly = null;
+    let endDateOnly = null;
+    const whereClause = { user_id: userId };
+
     switch (period) {
       case 'daily': {
-        // Start and end of today
         startDate = new Date(jakartaTime);
         startDate.setHours(0, 0, 0, 0);
         endDate = new Date(jakartaTime);
@@ -173,9 +254,8 @@ export const getAttendanceHistory = async (req, res) => {
       }
 
       case 'weekly': {
-        // Start of this week (Monday) to end of this week (Sunday)
         const dayOfWeek = jakartaTime.getDay();
-        const diffToMonday = dayOfWeek === 0 ? -6 : 1 - dayOfWeek; // Handle Sunday as 0
+        const diffToMonday = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
 
         startDate = new Date(jakartaTime);
         startDate.setDate(jakartaTime.getDate() + diffToMonday);
@@ -188,32 +268,59 @@ export const getAttendanceHistory = async (req, res) => {
       }
 
       case 'monthly': {
-        // Start and end of current month
         startDate = new Date(jakartaTime.getFullYear(), jakartaTime.getMonth(), 1);
         endDate = new Date(jakartaTime.getFullYear(), jakartaTime.getMonth() + 1, 0);
         endDate.setHours(23, 59, 59, 999);
         break;
       }
 
+      case 'custom': {
+        if (!isStrictDateOnly(customStartDate) || !isStrictDateOnly(customEndDate)) {
+          return res.status(400).json({
+            success: false,
+            message: 'Parameter start_date dan end_date wajib valid dengan format YYYY-MM-DD untuk period custom'
+          });
+        }
+
+        if (customStartDate > customEndDate) {
+          return res.status(400).json({
+            success: false,
+            message: 'Parameter start_date tidak boleh lebih besar dari end_date'
+          });
+        }
+
+        startDateOnly = customStartDate;
+        endDateOnly = customEndDate;
+        break;
+      }
+
       case 'all':
-        // No date filter
         break;
 
       default:
         return res.status(400).json({
           success: false,
-          message: 'Period parameter tidak valid. Gunakan: daily, weekly, monthly, atau all'
+          message: 'Period parameter tidak valid. Gunakan: daily, weekly, monthly, custom, atau all'
         });
-    } // Add date filter if not 'all'
+    }
+
     if (period !== 'all') {
+      if (period !== 'custom') {
+        startDateOnly = startDate.toISOString().split('T')[0];
+        endDateOnly = endDate.toISOString().split('T')[0];
+      }
+
       whereClause.attendance_date = {
-        [Op.between]: [startDate.toISOString().split('T')[0], endDate.toISOString().split('T')[0]]
+        [Op.between]: [startDateOnly, endDateOnly]
       };
     }
 
-    // Run queries in parallel for efficiency
-    const [summaryByStatus, summaryByCategory, attendanceData] = await Promise.all([
-      // Query 1: Summary by status
+    const nonAlphaWhereClause = {
+      ...whereClause,
+      status_id: { [Op.ne]: 3 }
+    };
+
+    const [summaryByStatus, summaryByCategory, workHourSummary, attendanceData] = await Promise.all([
       Attendance.findAll({
         where: whereClause,
         attributes: ['status_id', [sequelize.fn('COUNT', sequelize.col('status_id')), 'count']],
@@ -221,7 +328,6 @@ export const getAttendanceHistory = async (req, res) => {
         raw: true
       }),
 
-      // Query 2: Summary by category
       Attendance.findAll({
         where: whereClause,
         attributes: ['category_id', [sequelize.fn('COUNT', sequelize.col('category_id')), 'count']],
@@ -229,7 +335,12 @@ export const getAttendanceHistory = async (req, res) => {
         raw: true
       }),
 
-      // Query 3: Detailed attendance list with pagination
+      Attendance.findAll({
+        where: nonAlphaWhereClause,
+        attributes: [[sequelize.fn('SUM', sequelize.col('work_hour')), 'total_work_hours']],
+        raw: true
+      }),
+
       Attendance.findAndCountAll({
         where: whereClause,
         include: [
@@ -251,18 +362,22 @@ export const getAttendanceHistory = async (req, res) => {
           }
         ],
         order: [['attendance_date', 'DESC']],
-        limit: parseInt(limit),
-        offset: offset
+        limit: limitNum,
+        offset
       })
-    ]); // Process summary data with updated status mapping
+    ]);
+
     const summary = {
       total_ontime: 0,
       total_late: 0,
       total_early: 0,
       total_alpha: 0,
       total_wfo: 0,
-      total_wfa: 0
-    }; // Map status counts with dynamic status logic: 1=ontime, 2=late, 4=early, 3=alpha
+      total_wfa: 0,
+      total_wfh: 0,
+      total_work_hours: 0
+    };
+
     summaryByStatus.forEach((item) => {
       const count = parseInt(item.count);
 
@@ -282,7 +397,6 @@ export const getAttendanceHistory = async (req, res) => {
       }
     });
 
-    // Map category counts (assuming: 1=WFO, 3=WFA)
     summaryByCategory.forEach((item) => {
       const count = parseInt(item.count);
 
@@ -290,47 +404,41 @@ export const getAttendanceHistory = async (req, res) => {
         case 1:
           summary.total_wfo = count;
           break;
+        case 2:
+          summary.total_wfh = count;
+          break;
         case 3:
           summary.total_wfa = count;
           break;
       }
-    }); // Transform attendance data
+    });
+
+    const totalWorkHours = Number.parseFloat(workHourSummary?.[0]?.total_work_hours);
+    summary.total_work_hours = Number.isFinite(totalWorkHours) ? Number(totalWorkHours.toFixed(2)) : 0;
+
+    const todayDate = getJakartaDateString();
     const transformedData = attendanceData.rows.map((att) => {
-      // Parse attendance date
-      const attendanceDate = new Date(att.attendance_date);
+      const [dateYear, dateMonth, dateDay] = String(att.attendance_date).split('-').map(Number);
+      const day = String(dateDay).padStart(2, '0');
+      const month = MONTH_LABELS[dateMonth - 1];
+      const monthYear = `${month} ${dateYear}`;
+      const modeContract = deriveModeContract(att);
+      const statusContract = deriveStatusContract(att);
+      const isAlpha = statusContract.status_key === 'alpha';
+      const isActiveSession = Boolean(att.time_in && !att.time_out && att.attendance_date === todayDate);
+      const timeIn = att.time_in ? formatTimeOnly(att.time_in) : null;
+      const timeOut = att.time_out ? formatTimeOnly(att.time_out) : null;
 
-      // Format date components
-      const day = attendanceDate.getDate().toString().padStart(2, '0');
-      const months = [
-        'Jan',
-        'Feb',
-        'Mar',
-        'Apr',
-        'May',
-        'Jun',
-        'Jul',
-        'Aug',
-        'Sep',
-        'Oct',
-        'Nov',
-        'Dec'
-      ];
-      const month = months[attendanceDate.getMonth()];
-      const year = attendanceDate.getFullYear();
-      const monthYear = `${month} ${year}`;
-
-      // Extract PredOut from notes if present for history display
       const notesStr = att.notes || '';
       const smartMatch = notesStr.match(/\[Smart AC\]\s*pred=([^,]+),\s*used=([^,]+),/);
       const fallbackMatch = notesStr.match(/\[Fallback AC\]\s*used=([^,]+),/);
       const predOutStr = smartMatch ? smartMatch[1] : fallbackMatch ? fallbackMatch[1] : null;
-      // Derive work hour display when DB value is 0 or invalid
       let workHourDisplay = att.work_hour;
       try {
         const rawIn = att.time_in ? new Date(att.time_in) : null;
         const rawOut = att.time_out ? new Date(att.time_out) : null;
         const outBeforeIn = rawIn && rawOut ? rawOut.getTime() < rawIn.getTime() : false;
-        if (workHourDisplay == null || workHourDisplay <= 0 || outBeforeIn) {
+        if (!isAlpha && (workHourDisplay == null || workHourDisplay <= 0 || outBeforeIn)) {
           if (predOutStr && rawIn) {
             const usedDate = new Date(`${att.attendance_date}T${predOutStr}:00+07:00`);
             workHourDisplay = calculateWorkHour(rawIn, usedDate);
@@ -342,15 +450,31 @@ export const getAttendanceHistory = async (req, res) => {
         // keep original workHourDisplay
       }
 
+      const displayBadge = isActiveSession
+        ? { display_badge_key: 'active', display_badge_label: 'Active Session' }
+        : {
+            display_badge_key: statusContract.status_key,
+            display_badge_label: statusContract.status_label
+          };
+
       return {
         id_attendance: att.id_attendance,
         attendance_date: att.attendance_date,
         date: day,
-        monthYear: monthYear,
-        time_in: formatTimeOnly(att.time_in),
-        time_out: formatTimeOnly(att.time_out),
-        work_hour: formatWorkHour(workHourDisplay),
+        monthYear,
+        date_label: buildDateLabel(att.attendance_date),
+        mode_key: modeContract.mode_key,
+        mode_label: modeContract.mode_label,
+        time_in: timeIn,
+        time_out: timeOut,
+        time_range: `${timeIn || '--:--'} - ${timeOut || '--:--'}`,
+        work_hour: isAlpha ? null : formatWorkHour(workHourDisplay),
         work_hour_raw: workHourDisplay,
+        status_key: statusContract.status_key,
+        status_label: statusContract.status_label,
+        display_badge_key: displayBadge.display_badge_key,
+        display_badge_label: displayBadge.display_badge_label,
+        location_label: att.location ? att.location.description : null,
         category: att.attendance_category ? att.attendance_category.category_name : null,
         status: att.status ? att.status.attendance_status_name : null,
         location: att.location ? att.location.description : null,
@@ -358,21 +482,26 @@ export const getAttendanceHistory = async (req, res) => {
       };
     });
 
-    // Calculate pagination info
-    const totalPages = Math.ceil(attendanceData.count / parseInt(limit));
+    const totalPages = Math.ceil(attendanceData.count / limitNum);
 
     res.status(200).json({
       success: true,
       data: {
+        period: {
+          type: period,
+          label: buildPeriodLabel(period),
+          start_date: startDateOnly,
+          end_date: endDateOnly
+        },
         summary,
         attendances: transformedData,
         pagination: {
-          current_page: parseInt(page),
+          current_page: pageNum,
           total_pages: totalPages,
           total_items: attendanceData.count,
-          items_per_page: parseInt(limit),
-          has_next_page: parseInt(page) < totalPages,
-          has_prev_page: parseInt(page) > 1
+          items_per_page: limitNum,
+          has_next_page: pageNum < totalPages,
+          has_prev_page: pageNum > 1
         }
       },
       message: 'Riwayat absensi berhasil diambil'

--- a/tests/attendanceHistoryTimelineContract.test.js
+++ b/tests/attendanceHistoryTimelineContract.test.js
@@ -1,0 +1,271 @@
+import { jest } from '@jest/globals';
+
+const buildRes = () => {
+  const res = {};
+  res.status = jest.fn(() => res);
+  res.json = jest.fn(() => res);
+  return res;
+};
+
+const formatJakartaClock = (value) => {
+  if (!value) return null;
+  const shifted = new Date(new Date(value).getTime() + 7 * 60 * 60 * 1000);
+  return `${String(shifted.getUTCHours()).padStart(2, '0')}:${String(shifted.getUTCMinutes()).padStart(2, '0')}`;
+};
+
+const mockControllerDependencies = ({ findAllResults = [], findAndCountAllResult } = {}) => {
+  const mockFindAll = jest.fn();
+  for (const result of findAllResults) {
+    mockFindAll.mockResolvedValueOnce(result);
+  }
+  mockFindAll.mockResolvedValue([]);
+
+  const Attendance = {
+    findAll: mockFindAll,
+    findAndCountAll: jest.fn().mockResolvedValue(findAndCountAllResult || { count: 0, rows: [] })
+  };
+
+  jest.unstable_mockModule('../src/config/database.js', () => ({
+    default: {
+      fn: jest.fn((name, column) => ({ fn: name, column })),
+      col: jest.fn((name) => ({ col: name })),
+      transaction: jest.fn()
+    }
+  }));
+
+  jest.unstable_mockModule('../src/models/index.js', () => ({
+    Attendance,
+    Booking: {},
+    Location: {},
+    Settings: {},
+    AttendanceCategory: {},
+    AttendanceStatus: {},
+    BookingStatus: {},
+    User: {},
+    Role: {},
+    LocationEvent: {},
+    Photo: {}
+  }));
+
+  jest.unstable_mockModule('date-holidays', () => ({
+    default: jest.fn().mockImplementation(() => ({ isHoliday: jest.fn(() => false) }))
+  }));
+
+  jest.unstable_mockModule('../src/utils/geofence.js', () => ({
+    calculateDistance: jest.fn(),
+    getJakartaTime: jest.fn(),
+    getJakartaDateString: jest.fn(() => '2026-05-03'),
+    getCurrentTimeForDB: jest.fn(),
+    formatUTCToJakartaTime: jest.fn(formatJakartaClock)
+  }));
+
+  jest.unstable_mockModule('../src/utils/workHourFormatter.js', () => ({
+    formatWorkHour: jest.fn((value) => {
+      if (value == null || value <= 0) return '00:00';
+      const hours = Math.floor(value);
+      const minutes = Math.round((value - hours) * 60);
+      return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
+    }),
+    calculateWorkHour: jest.fn((start, end) => {
+      if (!start || !end) return 0;
+      return Math.round(((new Date(end) - new Date(start)) / 36e5) * 100) / 100;
+    }),
+    formatTimeOnly: jest.fn(formatJakartaClock)
+  }));
+
+  jest.unstable_mockModule('../src/utils/searchHelper.js', () => ({
+    applySearch: jest.fn()
+  }));
+
+  jest.unstable_mockModule('../src/utils/settings.js', () => ({
+    getOperationalSettings: jest.fn()
+  }));
+
+  jest.unstable_mockModule('../src/jobs/autoCheckout.job.js', () => ({
+    triggerAutoCheckout: jest.fn(),
+    runSmartAutoCheckoutForDate: jest.fn()
+  }));
+
+  jest.unstable_mockModule('../src/jobs/resolveWfaBookings.job.js', () => ({
+    triggerResolveWfaBookings: jest.fn(),
+    resolveWfaBookingsForDate: jest.fn()
+  }));
+
+  jest.unstable_mockModule('../src/jobs/createGeneralAlpha.job.js', () => ({
+    runGeneralAlphaForDate: jest.fn()
+  }));
+
+  jest.unstable_mockModule('../src/utils/logger.js', () => ({
+    default: { info: jest.fn(), error: jest.fn(), debug: jest.fn() }
+  }));
+
+  jest.unstable_mockModule('../src/utils/fuzzyAhpEngine.js', () => ({
+    default: {}
+  }));
+
+  return { Attendance };
+};
+
+describe('getAttendanceHistory timeline contract', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it('rejects invalid custom date input with 400 before querying attendance', async () => {
+    const { Attendance } = mockControllerDependencies();
+    const { getAttendanceHistory } = await import('../src/controllers/attendance.controller.js');
+
+    const req = {
+      user: { id: 42 },
+      query: { period: 'custom', start_date: 'bad-date', end_date: '2026-05-31' }
+    };
+    const res = buildRes();
+
+    await getAttendanceHistory(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        message: expect.stringContaining('start_date')
+      })
+    );
+    expect(Attendance.findAll).not.toHaveBeenCalled();
+    expect(Attendance.findAndCountAll).not.toHaveBeenCalled();
+  });
+
+  it('returns additive timeline fields, custom period metadata, WFH summary, and active badge override', async () => {
+    const activeAttendance = {
+      id_attendance: 123,
+      user_id: 42,
+      category_id: 1,
+      status_id: 1,
+      attendance_date: '2026-05-03',
+      time_in: new Date('2026-05-03T08:04:00+07:00'),
+      time_out: null,
+      work_hour: 5.53,
+      notes: 'Manual attendance',
+      attendance_category: { category_name: 'Work From Office' },
+      status: { attendance_status_name: 'ontime' },
+      location: { description: 'Kantor Utama' }
+    };
+
+    const { Attendance } = mockControllerDependencies({
+      findAllResults: [
+        [{ status_id: 1, count: '1' }],
+        [
+          { category_id: 1, count: '1' },
+          { category_id: 2, count: '2' },
+          { category_id: 3, count: '3' }
+        ],
+        [{ total_work_hours: '12.75' }]
+      ],
+      findAndCountAllResult: { count: 1, rows: [activeAttendance] }
+    });
+    const { getAttendanceHistory } = await import('../src/controllers/attendance.controller.js');
+
+    const req = {
+      user: { id: 42 },
+      query: {
+        period: 'custom',
+        start_date: '2026-05-01',
+        end_date: '2026-05-31',
+        page: '1',
+        limit: '20'
+      }
+    };
+    const res = buildRes();
+
+    await getAttendanceHistory(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    const body = res.json.mock.calls[0][0];
+    expect(body.data.period).toEqual({
+      type: 'custom',
+      label: 'Custom Range',
+      start_date: '2026-05-01',
+      end_date: '2026-05-31'
+    });
+    expect(body.data.summary).toEqual(
+      expect.objectContaining({
+        total_ontime: 1,
+        total_wfo: 1,
+        total_wfh: 2,
+        total_wfa: 3,
+        total_work_hours: 12.75
+      })
+    );
+    expect(body.data.attendances[0]).toEqual(
+      expect.objectContaining({
+        id_attendance: 123,
+        attendance_date: '2026-05-03',
+        date_label: '03 May 2026',
+        mode_key: 'wfo',
+        mode_label: 'WFO',
+        time_in: '08:04',
+        time_out: null,
+        time_range: '08:04 - --:--',
+        status_key: 'ontime',
+        status_label: 'On Time',
+        display_badge_key: 'active',
+        display_badge_label: 'Active Session',
+        location_label: 'Kantor Utama',
+        category: 'Work From Office',
+        status: 'ontime',
+        location: 'Kantor Utama'
+      })
+    );
+    expect(Attendance.findAndCountAll).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          user_id: 42,
+          attendance_date: expect.any(Object)
+        }),
+        limit: 20,
+        offset: 0
+      })
+    );
+  });
+
+  it('keeps alpha rows from displaying misleading work hours and uses final status badge', async () => {
+    const alphaAttendance = {
+      id_attendance: 321,
+      user_id: 42,
+      category_id: 1,
+      status_id: 3,
+      attendance_date: '2026-05-02',
+      time_in: new Date('2026-05-02T00:00:00+07:00'),
+      time_out: new Date('2026-05-03T07:00:00+07:00'),
+      work_hour: 32,
+      notes: 'Absent',
+      attendance_category: { category_name: 'Work From Office' },
+      status: { attendance_status_name: 'alpha' },
+      location: null
+    };
+
+    mockControllerDependencies({
+      findAllResults: [[{ status_id: 3, count: '1' }], [{ category_id: 1, count: '1' }], [{ total_work_hours: null }]],
+      findAndCountAllResult: { count: 1, rows: [alphaAttendance] }
+    });
+    const { getAttendanceHistory } = await import('../src/controllers/attendance.controller.js');
+
+    const req = { user: { id: 42 }, query: { period: 'monthly', page: '1', limit: '5' } };
+    const res = buildRes();
+
+    await getAttendanceHistory(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    const row = res.json.mock.calls[0][0].data.attendances[0];
+    expect(row).toEqual(
+      expect.objectContaining({
+        status_key: 'alpha',
+        status_label: 'Alpha',
+        display_badge_key: 'alpha',
+        display_badge_label: 'Alpha',
+        work_hour: null,
+        work_hour_raw: 32
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Extend `GET /api/attendance/history` with additive Android timeline fields for Recent Attendance and Attendance Timeline consumers.
- Add `period=custom` with strict `start_date` / `end_date` validation and 400 responses for invalid custom input.
- Add computed display badge fields, including Active Session override, without changing final attendance status or inserting `Active Session` into `attendance_statuses`.
- Add `total_wfh` and `total_work_hours` summary fields, preserve existing legacy row fields, and avoid misleading alpha/absent work-hour display.
- Update OpenAPI for the actual attendance history contract.

## Scope control
- No PDF export.
- No Android UI changes.
- No new personal report endpoint.
- No Attendance Rate formula.
- No WFA Requests changes.
- No DB migration, seed, or attendance_statuses mutation.

## Verification
- `npm test -- --runTestsByPath tests/attendanceHistoryTimelineContract.test.js` ✅
- `npm run lint` ✅
- `npm test` ✅ — 84 suites / 546 tests
- `git diff --check` ✅
- `git diff -- src/models src/models/seeders v1_infinite_track.sql` ✅ — no output / no model-seed-SQL mutation

## Needs Verification
Live/Postman evidence remains pending for:
- weekly recent attendance: `period=weekly&page=1&limit=3`
- monthly timeline
- custom range
- empty range
- invalid custom date 400
- active session badge override
- alpha/absent safe `work_hour` display
- user-scoped response
- live DB proof that `attendance_statuses` has no `Active Session`
- runtime WFH history evidence, to coordinate with INF-164 if needed

## Docs / ADR
DOCS/ADR UPDATE REQUIRED: OpenAPI updated in `docs/openapi.yaml` for the changed API contract. Full ADR not added because this is an additive endpoint contract extension with no DB/final-state mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)