### PR TITLE
fix: clamp attendance history pagination overflow

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1985,7 +1985,16 @@ paths:
                         properties:
                           current_page:
                             type: integer
+                            description: Effective page returned. If the requested page exceeds total_pages and records exist, this is clamped to the last available page.
                             example: 1
+                          requested_page:
+                            type: integer
+                            description: Original requested page after positive-integer normalization.
+                            example: 120
+                          page_was_clamped:
+                            type: boolean
+                            description: True when the requested page exceeded total_pages and the response was served from the last available page.
+                            example: true
                           total_pages:
                             type: integer
                             example: 4

--- a/src/controllers/attendance.controller.js
+++ b/src/controllers/attendance.controller.js
@@ -230,9 +230,10 @@ export const getAttendanceHistory = async (req, res) => {
   try {
     const userId = req.user.id;
     const { period = 'daily', start_date: customStartDate, end_date: customEndDate } = req.query;
-    const pageNum = parsePositiveInteger(req.query.page, 1);
+    const requestedPageNum = parsePositiveInteger(req.query.page, 1);
+    let pageNum = requestedPageNum;
     const limitNum = parsePositiveInteger(req.query.limit, 5);
-    const offset = (pageNum - 1) * limitNum;
+    let offset = (pageNum - 1) * limitNum;
 
     const now = new Date();
     const jakartaOffset = 7 * 60;
@@ -320,7 +321,32 @@ export const getAttendanceHistory = async (req, res) => {
       status_id: { [Op.ne]: 3 }
     };
 
-    const [summaryByStatus, summaryByCategory, workHourSummary, attendanceData] = await Promise.all([
+    const buildAttendanceListQuery = () => ({
+      where: whereClause,
+      include: [
+        {
+          model: AttendanceCategory,
+          as: 'attendance_category',
+          attributes: ['category_name']
+        },
+        {
+          model: AttendanceStatus,
+          as: 'status',
+          attributes: ['attendance_status_name']
+        },
+        {
+          model: Location,
+          as: 'location',
+          attributes: ['description'],
+          required: false
+        }
+      ],
+      order: [['attendance_date', 'DESC']],
+      limit: limitNum,
+      offset
+    });
+
+    const [summaryByStatus, summaryByCategory, workHourSummary, firstAttendancePage] = await Promise.all([
       Attendance.findAll({
         where: whereClause,
         attributes: ['status_id', [sequelize.fn('COUNT', sequelize.col('status_id')), 'count']],
@@ -341,31 +367,17 @@ export const getAttendanceHistory = async (req, res) => {
         raw: true
       }),
 
-      Attendance.findAndCountAll({
-        where: whereClause,
-        include: [
-          {
-            model: AttendanceCategory,
-            as: 'attendance_category',
-            attributes: ['category_name']
-          },
-          {
-            model: AttendanceStatus,
-            as: 'status',
-            attributes: ['attendance_status_name']
-          },
-          {
-            model: Location,
-            as: 'location',
-            attributes: ['description'],
-            required: false
-          }
-        ],
-        order: [['attendance_date', 'DESC']],
-        limit: limitNum,
-        offset
-      })
+      Attendance.findAndCountAll(buildAttendanceListQuery())
     ]);
+
+    const totalPages = Math.ceil(firstAttendancePage.count / limitNum);
+    let attendanceData = firstAttendancePage;
+
+    if (firstAttendancePage.count > 0 && firstAttendancePage.rows.length === 0 && pageNum > totalPages) {
+      pageNum = totalPages;
+      offset = (pageNum - 1) * limitNum;
+      attendanceData = await Attendance.findAndCountAll(buildAttendanceListQuery());
+    }
 
     const summary = {
       total_ontime: 0,
@@ -482,7 +494,7 @@ export const getAttendanceHistory = async (req, res) => {
       };
     });
 
-    const totalPages = Math.ceil(attendanceData.count / limitNum);
+    const pageWasClamped = requestedPageNum !== pageNum;
 
     res.status(200).json({
       success: true,
@@ -497,6 +509,8 @@ export const getAttendanceHistory = async (req, res) => {
         attendances: transformedData,
         pagination: {
           current_page: pageNum,
+          requested_page: requestedPageNum,
+          page_was_clamped: pageWasClamped,
           total_pages: totalPages,
           total_items: attendanceData.count,
           items_per_page: limitNum,

--- a/tests/attendanceHistoryTimelineContract.test.js
+++ b/tests/attendanceHistoryTimelineContract.test.js
@@ -13,16 +13,22 @@ const formatJakartaClock = (value) => {
   return `${String(shifted.getUTCHours()).padStart(2, '0')}:${String(shifted.getUTCMinutes()).padStart(2, '0')}`;
 };
 
-const mockControllerDependencies = ({ findAllResults = [], findAndCountAllResult } = {}) => {
+const mockControllerDependencies = ({ findAllResults = [], findAndCountAllResult, findAndCountAllResults } = {}) => {
   const mockFindAll = jest.fn();
   for (const result of findAllResults) {
     mockFindAll.mockResolvedValueOnce(result);
   }
   mockFindAll.mockResolvedValue([]);
 
+  const mockFindAndCountAll = jest.fn();
+  for (const result of findAndCountAllResults || []) {
+    mockFindAndCountAll.mockResolvedValueOnce(result);
+  }
+  mockFindAndCountAll.mockResolvedValue(findAndCountAllResult || { count: 0, rows: [] });
+
   const Attendance = {
     findAll: mockFindAll,
-    findAndCountAll: jest.fn().mockResolvedValue(findAndCountAllResult || { count: 0, rows: [] })
+    findAndCountAll: mockFindAndCountAll
   };
 
   jest.unstable_mockModule('../src/config/database.js', () => ({
@@ -267,5 +273,56 @@ describe('getAttendanceHistory timeline contract', () => {
         work_hour_raw: 32
       })
     );
+  });
+
+  it('clamps out-of-range pages to the last available page instead of returning an empty page', async () => {
+    const lastPageAttendance = {
+      id_attendance: 999,
+      user_id: 42,
+      category_id: 1,
+      status_id: 1,
+      attendance_date: '2026-05-01',
+      time_in: new Date('2026-05-01T08:00:00+07:00'),
+      time_out: new Date('2026-05-01T17:00:00+07:00'),
+      work_hour: 9,
+      notes: 'Manual attendance',
+      attendance_category: { category_name: 'Work From Office' },
+      status: { attendance_status_name: 'ontime' },
+      location: { description: 'Kantor Utama' }
+    };
+
+    const { Attendance } = mockControllerDependencies({
+      findAllResults: [[{ status_id: 1, count: '3' }], [{ category_id: 1, count: '3' }], [{ total_work_hours: '27' }]],
+      findAndCountAllResults: [
+        { count: 3, rows: [] },
+        { count: 3, rows: [lastPageAttendance] }
+      ]
+    });
+    const { getAttendanceHistory } = await import('../src/controllers/attendance.controller.js');
+
+    const req = { user: { id: 42 }, query: { period: 'all', page: '120', limit: '100' } };
+    const res = buildRes();
+
+    await getAttendanceHistory(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    const body = res.json.mock.calls[0][0];
+    expect(body.data.attendances).toHaveLength(1);
+    expect(body.data.attendances[0].id_attendance).toBe(999);
+    expect(body.data.pagination).toEqual(
+      expect.objectContaining({
+        current_page: 1,
+        requested_page: 120,
+        page_was_clamped: true,
+        total_pages: 1,
+        total_items: 3,
+        items_per_page: 100,
+        has_next_page: false,
+        has_prev_page: false
+      })
+    );
+    expect(Attendance.findAndCountAll).toHaveBeenCalledTimes(2);
+    expect(Attendance.findAndCountAll.mock.calls[0][0]).toEqual(expect.objectContaining({ limit: 100, offset: 11900 }));
+    expect(Attendance.findAndCountAll.mock.calls[1][0]).toEqual(expect.objectContaining({ limit: 100, offset: 0 }));
   });
 });


### PR DESCRIPTION
## Summary
- Clamp `GET /api/attendance/history` out-of-range page requests to the last available page when records exist.
- Add additive pagination metadata: `requested_page` and `page_was_clamped`.
- Preserve valid empty response behavior when `total_items=0`.
- Update OpenAPI and focused contract tests.

## Why
Runtime evidence showed a request like `page=120&limit=100` could return `attendances: []` even though `total_items=3` and `total_pages=1`. This is a stale-pagination/client-state edge case, not missing attendance data.

## Scope control
- Existing `GET /api/attendance/history` only.
- No DB migration.
- No attendance final-state mutation.
- No scheduler/job changes.
- No Android UI changes.

## Verification
- `npm test -- --runTestsByPath tests/attendanceHistoryTimelineContract.test.js` ✅ — 4 tests
- `npm run lint` ✅
- `npm test` ✅ — 84 suites / 547 tests
- `git diff --check` ✅

## Runtime follow-up
After merge/deploy, verify:
`GET /api/attendance/history?period=all&page=120&limit=100`

Expected when records exist:
- `attendances` is served from last available page
- `pagination.current_page = total_pages`
- `pagination.requested_page = 120`
- `pagination.page_was_clamped = true`

DOCS/ADR UPDATE REQUIRED: OpenAPI updated for additive pagination metadata. Full ADR not required for this small pagination hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Attendance history now returns clearer pagination details, including the originally requested page and whether the page was adjusted to the last available page.

* **Bug Fixes**
  * Out-of-range attendance history requests now return the last available page instead of an empty result.
  * Pagination metadata now reflects when clamping occurs, helping users understand the page shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->