### PR TITLE
fix: preserve local attendance history period dates

### DIFF
--- a/src/controllers/attendance.controller.js
+++ b/src/controllers/attendance.controller.js
@@ -159,6 +159,13 @@ const parsePositiveInteger = (value, fallback) => {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 };
 
+const formatLocalDateOnly = (date) => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
 const buildDateLabel = (dateOnly) => {
   const [year, month, day] = String(dateOnly).split('-').map(Number);
   if (!year || !month || !day) return String(dateOnly || '');
@@ -307,8 +314,8 @@ export const getAttendanceHistory = async (req, res) => {
 
     if (period !== 'all') {
       if (period !== 'custom') {
-        startDateOnly = startDate.toISOString().split('T')[0];
-        endDateOnly = endDate.toISOString().split('T')[0];
+        startDateOnly = formatLocalDateOnly(startDate);
+        endDateOnly = formatLocalDateOnly(endDate);
       }
 
       whereClause.attendance_date = {

--- a/tests/attendanceHistoryTimelineContract.test.js
+++ b/tests/attendanceHistoryTimelineContract.test.js
@@ -118,6 +118,10 @@ describe('getAttendanceHistory timeline contract', () => {
     jest.clearAllMocks();
   });
 
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it('rejects invalid custom date input with 400 before querying attendance', async () => {
     const { Attendance } = mockControllerDependencies();
     const { getAttendanceHistory } = await import('../src/controllers/attendance.controller.js');
@@ -232,6 +236,33 @@ describe('getAttendanceHistory timeline contract', () => {
         offset: 0
       })
     );
+  });
+
+  it('uses local business dates for monthly period boundaries without UTC off-by-one drift', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-07-07T00:00:00+07:00'));
+
+    const { Attendance } = mockControllerDependencies({
+      findAllResults: [[], [], [{ total_work_hours: null }]],
+      findAndCountAllResult: { count: 0, rows: [] }
+    });
+    const { getAttendanceHistory } = await import('../src/controllers/attendance.controller.js');
+
+    const req = { user: { id: 42 }, query: { period: 'monthly', page: '1', limit: '5' } };
+    const res = buildRes();
+
+    await getAttendanceHistory(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    const body = res.json.mock.calls[0][0];
+    expect(body.data.period).toEqual({
+      type: 'monthly',
+      label: 'This Month',
+      start_date: '2026-07-01',
+      end_date: '2026-07-31'
+    });
+    const attendanceDateFilter = Attendance.findAndCountAll.mock.calls[0][0].where.attendance_date;
+    const betweenSymbol = Object.getOwnPropertySymbols(attendanceDateFilter)[0];
+    expect(attendanceDateFilter[betweenSymbol]).toEqual(['2026-07-01', '2026-07-31']);
   });
 
   it('keeps alpha rows from displaying misleading work hours and uses final status badge', async () => {


### PR DESCRIPTION
## Summary
- Fix `GET /api/attendance/history` daily/weekly/monthly period date boundaries to use local business date components instead of UTC `toISOString()` conversion.
- Prevent Asia/Jakarta runtime from returning monthly July metadata like `start_date=2026-06-30` instead of `2026-07-01`.
- Add regression coverage for monthly period boundary metadata and query filter.

## Why
Runtime evidence after INF-217 showed the new monthly period metadata returned `start_date=2026-06-30` for a July monthly window. The query/metadata used `toISOString().split('T')[0]`, which can drift to the previous UTC date for local midnight in WIB.

## Scope control
- Existing `GET /api/attendance/history` only.
- No response shape change.
- No DB migration.
- No attendance final-state mutation.
- No scheduler/job changes.
- No Android UI changes.

## Verification
- `npm test -- --runTestsByPath tests/attendanceHistoryTimelineContract.test.js` ✅ — 5 tests
- `npm run lint` ✅
- `npm test` ✅ — 84 suites / 548 tests
- `git diff --check` ✅

## Runtime follow-up
After merge/deploy, verify:
`GET /api/attendance/history?period=monthly&page=1&limit=3`

Expected monthly period metadata in July:
- `period.start_date = 2026-07-01`
- `period.end_date = 2026-07-31`

Docs/ADR: no docs/ADR update required because response shape is unchanged; this is a date-boundary correctness fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)