### PR TITLE
fix: harden booking status today active mode

### DIFF
--- a/src/controllers/attendance.controller.js
+++ b/src/controllers/attendance.controller.js
@@ -1170,14 +1170,17 @@ export const getAttendanceStatus = async (req, res, next) => {
         category: currentAttendance.location.attendance_category.category_name
       };
     } else if (todayBooking) {
-      active_mode = 'Work From Anywhere';
+      const bookingCategoryName =
+        todayBooking.location?.attendance_category?.category_name || 'Work From Anywhere';
+
+      active_mode = bookingCategoryName;
       active_location = {
         location_id: todayBooking.location.location_id,
         latitude: parseFloat(todayBooking.location.latitude),
         longitude: parseFloat(todayBooking.location.longitude),
         radius: todayBooking.location.radius,
         description: todayBooking.location.description,
-        category: todayBooking.location.attendance_category.category_name
+        category: bookingCategoryName
       };
     } else {
       // Get WFO location from database
@@ -1225,7 +1228,7 @@ export const getAttendanceStatus = async (req, res, next) => {
 
     // Tentukan can_check_in
     // For WFA mode (booking approved today), ignore holiday/weekend gating; use time window only
-    const isWfaMode = active_mode === 'Work From Anywhere';
+    const isWfaMode = Boolean(todayBooking);
     const can_check_in =
       !currentAttendance &&
       currentTimeMinutes >= checkinStartMinutes &&

--- a/tests/attendanceStatusCurrentAttendance.test.js
+++ b/tests/attendanceStatusCurrentAttendance.test.js
@@ -175,6 +175,90 @@ describe('getAttendanceStatus current attendance mode', () => {
     expect(next).not.toHaveBeenCalled();
   });
 
+  it('uses booked location attendance category for booking branch active_mode and category', async () => {
+    const models = buildModelsMock({
+      booking: {
+        location: {
+          location_id: 31,
+          latitude: '-0.9000',
+          longitude: '119.8800',
+          radius: 120,
+          description: 'Coworking Space',
+          attendance_category: {
+            category_name: 'Work From Home'
+          }
+        }
+      }
+    });
+    mockControllerDependencies({ models, holidayInfo: [{ name: 'Booking Holiday Override Proof' }] });
+
+    const { getAttendanceStatus } = await import('../src/controllers/attendance.controller.js');
+
+    const req = {
+      user: { id: 9 },
+      query: { now: '2026-04-14T10:00:00+07:00' },
+      headers: {}
+    };
+    const res = buildRes();
+    const next = jest.fn();
+
+    await getAttendanceStatus(req, res, next);
+
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          can_check_in: true,
+          active_mode: 'Work From Home',
+          active_location: expect.objectContaining({
+            location_id: 31,
+            category: 'Work From Home'
+          })
+        })
+      })
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('falls back booking branch active_mode to Work From Anywhere when category relation is missing', async () => {
+    const models = buildModelsMock({
+      booking: {
+        location: {
+          location_id: 44,
+          latitude: '-0.9100',
+          longitude: '119.8700',
+          radius: 130,
+          description: 'Fallback Booking Spot'
+        }
+      }
+    });
+    mockControllerDependencies({ models });
+
+    const { getAttendanceStatus } = await import('../src/controllers/attendance.controller.js');
+
+    const req = {
+      user: { id: 9 },
+      query: { now: '2026-04-14T10:00:00+07:00' },
+      headers: {}
+    };
+    const res = buildRes();
+    const next = jest.fn();
+
+    await getAttendanceStatus(req, res, next);
+
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          active_mode: 'Work From Anywhere',
+          active_location: expect.objectContaining({
+            location_id: 44,
+            category: 'Work From Anywhere'
+          })
+        })
+      })
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+
   it('coerces holiday library truthy payload into boolean is_holiday in status response', async () => {
     const holidayPayload = [{ name: 'Hari Buruh Internasional' }];
     const models = buildModelsMock();


### PR DESCRIPTION
## Summary

Small backend contract hardening for:

```http
GET /api/attendance/status-today
```

This change removes the potential contradiction in the approved-booking branch where:

- `active_mode` was hardcoded to `Work From Anywhere`
- `active_location.category` was derived from `todayBooking.location.attendance_category.category_name`

Now the booking branch derives both values from the same source:

- `active_mode = todayBooking.location?.attendance_category?.category_name || 'Work From Anywhere'`
- `active_location.category = same bookingCategoryName`

To preserve the current MVP business rule that approved bookings remain WFA-only, the WFA check-in gating now relies on `Boolean(todayBooking)` rather than the `active_mode` string.

## Scope / non-goals

No change to:

- check-in logic
- checkout logic
- booking workflow
- WFH source of truth
- WFA validation requirement (`booking_id` still required)
- database
- Android
- response shape (`active_mode` remains a string)

## Risk

Low risk:

- response shape is unchanged
- fallback remains `Work From Anywhere`
- booking remains WFA-only for MVP
- this only prevents a future contract contradiction between `active_mode` and `active_location.category`

## Verification

PASS:

```bash
npm test -- --runTestsByPath tests/attendanceStatusCurrentAttendance.test.js tests/attendanceOperationalSettingsContract.test.js
npm run lint
npm test
```

Latest full test result:

```text
Test Suites: 89 passed, 89 total
Tests: 571 passed, 571 total
```

Needs Verification:

- runtime `/api/attendance/status-today` for a user with an approved booking today

## Docs / ADR

DOCS/ADR UPDATE REQUIRED: Not required for this small backward-compatible hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
