### PR TITLE
fix: rebalance FAHP discipline matrix

### DIFF
--- a/docs/fahp-discipline-matrix-rebalance.md
+++ b/docs/fahp-discipline-matrix-rebalance.md
@@ -1,0 +1,94 @@
+# FAHP Discipline Matrix Rebalance — INF-234
+
+## Context
+
+The Discipline FAHP matrix previously produced runtime weights:
+
+```json
+{
+  "alpha_rate": 1,
+  "lateness_severity": 0,
+  "lateness_frequency": 0,
+  "work_focus": 0,
+  "consistency_ratio": 0.07889627296412856
+}
+```
+
+This happened even when research attendance data contained late, early, and alpha rows. The data was present, but the zero weights prevented lateness and work-hour consistency from affecting the Discipline ranking.
+
+## Root Cause
+
+The previous `DISC_PAIRWISE_TFN` made `alpha_rate` too dominant for Chang's Extent Analysis. Its synthetic extent did not overlap with the other criteria:
+
+```text
+alpha_rate extent          [0.3729, 0.5585, 0.8160]
+lateness_severity extent   [0.1412, 0.2074, 0.3000]
+lateness_frequency extent  [0.0819, 0.1011, 0.1320]
+work_focus extent          [0.1102, 0.1330, 0.1680]
+```
+
+The resulting possibility vector was:
+
+```text
+d = [1, 0, 0, 0]
+weights = [1, 0, 0, 0]
+```
+
+The matrix was consistent (`CR = 0.079`), but consistency did not guarantee useful non-zero weights.
+
+## Rebalanced Matrix Target
+
+INF-234 target:
+
+```text
+alpha_rate          0.50–0.70
+lateness_severity   > 0
+lateness_frequency  > 0
+work_focus          > 0
+CR                  < 0.10
+```
+
+The rebalanced Discipline matrix keeps absence as the dominant signal while preserving non-zero influence for lateness severity, lateness frequency, and work-hour consistency.
+
+## Result
+
+Runtime weights after rebalance:
+
+```json
+{
+  "alpha_rate": 0.5128812499692939,
+  "lateness_severity": 0.2477192702838649,
+  "lateness_frequency": 0.11486769150110643,
+  "work_focus": 0.1245317882457348,
+  "consistency_ratio": 0.07732121780209075
+}
+```
+
+All criteria now have non-zero weights, alpha remains dominant, and CR remains below `0.10`.
+
+## Verification
+
+Focused test:
+
+```bash
+npm test -- --runInBand tests/fahpDisciplineWeights.test.js
+```
+
+Expected assertions:
+
+- alpha remains between `0.50` and `0.70`
+- all criteria weights are greater than zero
+- weights sum to approximately `1`
+- CR remains below `0.10`
+- lateness metrics affect Discipline score when alpha is equal
+- work-hour consistency affects Discipline score when alpha/lateness are equal
+
+## Governance Note
+
+This is a FAHP theory/matrix change.
+
+```text
+DOCS/ADR UPDATE REQUIRED
+```
+
+The change is intentionally scoped to `DISC_PAIRWISE_TFN`; WFA and Smart Auto Checkout matrices are not changed.

--- a/docs/superpowers/plans/2026-07-08-inf234-fahp-discipline-rebalance-implementation.md
+++ b/docs/superpowers/plans/2026-07-08-inf234-fahp-discipline-rebalance-implementation.md
@@ -1,0 +1,330 @@
+# Implementation Plan — INF-234 FAHP Discipline Matrix Rebalance
+
+## Issue
+
+Linear: INF-234 — Rebalance FAHP Discipline matrix so lateness and work-focus criteria do not collapse to zero
+
+Design spec:
+
+```text
+docs/superpowers/specs/2026-07-08-inf234-fahp-discipline-rebalance-design.md
+```
+
+## Worktree / Branch
+
+Isolated worktree:
+
+```text
+C:\Users\Febriyadi\.claude\worktrees\Infinit_Track_BE-inf234-fahp-discipline-rebalance
+```
+
+Branch:
+
+```text
+feature/inf-234-fahp-discipline-rebalance
+```
+
+Base:
+
+```text
+develop @ a462663
+```
+
+## Scope
+
+Rebalance only the FAHP Discipline pairwise matrix so discipline criteria do not collapse to zero.
+
+In scope:
+
+- `src/analytics/config.fahp.js`
+- tests for discipline FAHP weights and scoring behavior
+- optional small docs/ADR note
+
+Out of scope:
+
+- research trigger endpoints
+- attendance generated data
+- scheduler/jobs
+- auth/session
+- WFA matrix
+- Smart Auto Checkout matrix
+- CR threshold
+- generic FAHP algorithm unless matrix-only fix cannot satisfy acceptance criteria
+
+## Task 0 — Preflight
+
+1. Confirm isolated worktree branch:
+   ```bash
+   git status --branch --short
+   ```
+2. Read:
+   - `CLAUDE.md`
+   - `.claude/rules/10-high-risk-areas.md`
+   - `src/analytics/config.fahp.js`
+   - `src/analytics/fahp.extent.js`
+   - `src/utils/fuzzyAhpEngine.js`
+3. Confirm no writes occur in main `develop` tree.
+
+Expected output:
+
+```text
+branch = feature/inf-234-fahp-discipline-rebalance
+```
+
+## Task 1 — Add Baseline Failing Test
+
+Goal: lock the current failure before changing the matrix.
+
+Find an existing FAHP/discipline test file. If none is suitable, create a focused test file such as:
+
+```text
+tests/fahpDisciplineWeights.test.js
+```
+
+Test current expected acceptance criteria:
+
+```js
+const weights = fuzzyEngine.getDisciplineAhpWeights();
+
+expect(weights.alpha_rate).toBeGreaterThanOrEqual(0.5);
+expect(weights.alpha_rate).toBeLessThanOrEqual(0.7);
+expect(weights.lateness_severity).toBeGreaterThan(0);
+expect(weights.lateness_frequency).toBeGreaterThan(0);
+expect(weights.work_focus).toBeGreaterThan(0);
+expect(weights.consistency_ratio).toBeLessThan(0.1);
+```
+
+Also assert approximate sum:
+
+```js
+const sum = weights.alpha_rate + weights.lateness_severity + weights.lateness_frequency + weights.work_focus;
+expect(sum).toBeCloseTo(1, 5);
+```
+
+Run focused test and confirm it fails on current matrix with collapse `[1,0,0,0]`.
+
+Verification:
+
+```bash
+npm test -- --runInBand --testPathPattern=fahpDisciplineWeights
+```
+
+## Task 2 — Create Weight Exploration Script (Temporary / Non-committed Preferred)
+
+Use a temporary node command or scratch script to try candidate matrices.
+
+Purpose:
+
+- compute Chang extent weights
+- compute CR from defuzzified matrix
+- inspect all weights > 0
+- keep alpha 0.50–0.70
+
+Do not commit scratch scripts unless useful as a documented test fixture.
+
+Recommended exploration command shape:
+
+```bash
+node --input-type=module -e "
+import { TFN } from './src/analytics/config.fahp.js';
+import { invTFN, defuzzifyMatrixTFN, computeCR } from './src/analytics/fahp.js';
+import { extentWeightsTFN } from './src/analytics/fahp.extent.js';
+const matrix = [ /* candidate */ ];
+console.log(extentWeightsTFN(matrix));
+console.log(computeCR(defuzzifyMatrixTFN(matrix)));
+"
+```
+
+Candidate directions:
+
+1. Start by reducing alpha dominance:
+   - alpha vs lateness severity: `MODERATE` or `MODERATE_PLUS`
+   - alpha vs lateness frequency: `MODERATE` or `MODERATE_PLUS`
+   - alpha vs work focus: `WEAK` or `MODERATE`
+
+2. Keep lateness severity slightly above lateness frequency.
+3. Keep work focus lower but not zero.
+
+Stop when:
+
+```text
+alpha_rate 0.50–0.70
+all other weights > 0
+CR < 0.10
+```
+
+## Task 3 — Update Discipline Matrix and Rationale
+
+Edit:
+
+```text
+src/analytics/config.fahp.js
+```
+
+Update only:
+
+```js
+DISC_PAIRWISE_TFN
+```
+
+and its rationale comments.
+
+Do not change:
+
+- `WFA_PAIRWISE_TFN`
+- `SMART_AC_PAIRWISE_TFN`
+- `TFN` constants
+- FAHP algorithm
+- CR threshold
+
+Rationale comments must explain:
+
+- alpha remains dominant because absence is the strongest discipline signal
+- lateness severity and frequency remain meaningful
+- work focus remains lower but non-zero
+- matrix is rebalanced to avoid Chang extent collapse
+
+## Task 4 — Add Score Behavior Tests
+
+Add tests proving non-alpha criteria affect score.
+
+Suggested tests:
+
+### Lateness affects score when alpha is equal
+
+```js
+const clean = await fuzzyEngine.calculateDisciplineIndex({
+  alpha_rate: 0,
+  avg_lateness_minutes: 0,
+  lateness_frequency: 0,
+  work_hour_consistency: 100
+});
+
+const late = await fuzzyEngine.calculateDisciplineIndex({
+  alpha_rate: 0,
+  avg_lateness_minutes: 30,
+  lateness_frequency: 50,
+  work_hour_consistency: 100
+});
+
+expect(late.score).not.toBe(clean.score);
+```
+
+Use the correct score direction based on current normalization/label semantics after inspecting existing behavior.
+
+### Work focus affects score when alpha/lateness are equal
+
+```js
+const consistent = await fuzzyEngine.calculateDisciplineIndex({
+  alpha_rate: 0,
+  avg_lateness_minutes: 0,
+  lateness_frequency: 0,
+  work_hour_consistency: 100
+});
+
+const inconsistent = await fuzzyEngine.calculateDisciplineIndex({
+  alpha_rate: 0,
+  avg_lateness_minutes: 0,
+  lateness_frequency: 0,
+  work_hour_consistency: 50
+});
+
+expect(inconsistent.score).not.toBe(consistent.score);
+```
+
+Important: current scoring semantics may label higher score as better or worse depending normalization and label mapping. Test for meaningful difference first; if asserting direction, verify with existing conventions.
+
+## Task 5 — Optional Docs / ADR Note
+
+Because this changes FAHP theory/matrix, add a short note if the repo has an appropriate docs location.
+
+Possible location:
+
+```text
+docs/fahp-discipline-matrix-rebalance.md
+```
+
+or update an existing FAHP docs file if one exists.
+
+Minimum content:
+
+- previous collapse `[1,0,0,0]`
+- root cause: synthetic extents did not overlap
+- new measured weights
+- CR value
+- rationale for alpha target 50–70%
+- verification commands
+
+If docs are ignored by `.gitignore`, decide whether to force-add or document in PR body. Follow repository convention.
+
+## Task 6 — Verification
+
+Run focused tests:
+
+```bash
+npm test -- --runInBand --testPathPattern=fahp
+npm test -- --runInBand --testPathPattern=discipline
+```
+
+Run full verification:
+
+```bash
+npm run lint
+npm test
+```
+
+Runtime check:
+
+```bash
+node --input-type=module -e "
+import fuzzyEngine from './src/utils/fuzzyAhpEngine.js';
+console.log(JSON.stringify(fuzzyEngine.getDisciplineAhpWeights(), null, 2));
+"
+```
+
+Expected:
+
+```text
+alpha_rate between 0.50 and 0.70
+all other weights > 0
+CR < 0.10
+```
+
+## Task 7 — PR Package
+
+Prepare final PR notes using backend required format:
+
+1. Fact
+2. Assumption
+3. Mismatch / Needs Verification
+4. Risk
+5. Files/area terdampak
+6. Verification evidence
+7. Docs/ADR update note
+8. PR/review note
+
+Include:
+
+- final weights
+- final CR
+- tests run
+- explicit note that WFA/Smart AC matrices were not changed
+- `DOCS/ADR UPDATE REQUIRED`
+
+## Acceptance Criteria
+
+- Discipline weights no longer collapse to `[1,0,0,0]`.
+- `alpha_rate` remains dominant and within `0.50–0.70`.
+- `lateness_severity`, `lateness_frequency`, and `work_focus` are all > 0.
+- `consistency_ratio < 0.10`.
+- Tests cover non-collapse and scoring impact.
+- Full lint/test evidence exists or failures are reported as `Needs Verification`.
+
+## Stop Conditions
+
+Stop and ask if:
+
+- no candidate matrix can satisfy alpha 0.50–0.70 and CR < 0.10
+- fixing this appears to require changing generic Chang extent algorithm
+- score direction conflicts with existing dashboard semantics
+- tests reveal broader FAHP engine behavior changes outside discipline

--- a/docs/superpowers/specs/2026-07-08-inf234-fahp-discipline-rebalance-design.md
+++ b/docs/superpowers/specs/2026-07-08-inf234-fahp-discipline-rebalance-design.md
@@ -1,0 +1,251 @@
+# Design Spec — INF-234 FAHP Discipline Matrix Rebalance
+
+## Issue
+
+Linear: INF-234 — Rebalance FAHP Discipline matrix so lateness and work-focus criteria do not collapse to zero
+
+URL: https://linear.app/infinite-track-palu/issue/INF-234/rebalance-fahp-discipline-matrix-so-lateness-and-work-focus-criteria
+
+## Background
+
+Research attendance trigger data now contains discipline variation:
+
+- `ontime`
+- `late`
+- `early`
+- `alpha`
+
+The FAHP Discipline UI still shows criteria weights:
+
+```text
+Disiplin Kehadiran      1.000
+Tingkat Keterlambatan   0.000
+Frekuensi Keterlambatan 0.000
+Fokus Kerja             0.000
+```
+
+Runtime evidence from Docker:
+
+```json
+{
+  "alpha_rate": 1,
+  "lateness_severity": 0,
+  "lateness_frequency": 0,
+  "work_focus": 0,
+  "consistency_ratio": 0.07889627296412856
+}
+```
+
+This means late/frequency/work-focus data exists, but has no impact on ranking because the FAHP Discipline weights collapse to `[1, 0, 0, 0]`.
+
+## Current Technical Cause
+
+The current `DISC_PAIRWISE_TFN` in `src/analytics/config.fahp.js` is too dominant toward `alpha_rate` for Chang's Extent Analysis:
+
+```js
+export const DISC_PAIRWISE_TFN = [
+  [TFN.EQUAL, TFN.STRONG, TFN.STRONG, TFN.MODERATE],
+  [invTFN(TFN.STRONG), TFN.EQUAL, TFN.MODERATE, TFN.EQUAL],
+  [invTFN(TFN.STRONG), invTFN(TFN.MODERATE), TFN.EQUAL, TFN.EQUAL],
+  [invTFN(TFN.MODERATE), invTFN(TFN.EQUAL), invTFN(TFN.EQUAL), TFN.EQUAL]
+];
+```
+
+Computed synthetic extents:
+
+```text
+alpha_rate extent          [0.3729, 0.5585, 0.8160]
+lateness_severity extent   [0.1412, 0.2074, 0.3000]
+lateness_frequency extent  [0.0819, 0.1011, 0.1320]
+work_focus extent          [0.1102, 0.1330, 0.1680]
+```
+
+Because `alpha_rate` lower bound is greater than the upper bound of every other criterion, the degree of possibility for the other criteria against alpha becomes `0`. The resulting vector is:
+
+```text
+d = [1, 0, 0, 0]
+weights = [1, 0, 0, 0]
+```
+
+CR remains acceptable:
+
+```text
+CR = 0.079 < 0.10
+```
+
+But CR consistency does not guarantee healthy non-zero weights for all criteria under Chang's Extent Analysis.
+
+## Goal
+
+Rebalance only the FAHP Discipline pairwise matrix so that:
+
+1. `alpha_rate` remains the dominant criterion.
+2. `alpha_rate` target weight is between `0.50` and `0.70`.
+3. `lateness_severity`, `lateness_frequency`, and `work_focus` all have non-zero weights.
+4. CR remains below `0.10`.
+5. Discipline ranking can be affected by lateness severity, lateness frequency, and work-hour consistency.
+
+Target weight envelope:
+
+```text
+alpha_rate          0.50–0.70
+lateness_severity   0.10–0.25
+lateness_frequency  0.10–0.20
+work_focus          0.05–0.15
+```
+
+## Non-Goals
+
+Do not change:
+
+- research attendance trigger endpoints
+- generated attendance data semantics
+- scheduler/cron behavior
+- auth/session/API unrelated behavior
+- WFA matrix
+- Smart Auto Checkout matrix
+- FAHP threshold (`CR_THRESHOLD`)
+- generic Chang's Extent implementation unless matrix-only fix cannot satisfy acceptance criteria
+
+## Proposed Design
+
+### Approach A — Matrix-only rebalance (recommended)
+
+Update `DISC_PAIRWISE_TFN` so alpha is still strongest, but not so dominant that other extents lose all overlap.
+
+Recommended direction:
+
+- `alpha_rate > lateness_severity`: reduce from `STRONG` to `MODERATE` or `MODERATE_PLUS`.
+- `alpha_rate > lateness_frequency`: reduce from `STRONG` to `MODERATE` or `MODERATE_PLUS`.
+- `alpha_rate > work_focus`: keep moderate but validate overlap.
+- `lateness_severity > lateness_frequency`: keep mild/moderate because lateness minutes and frequency both matter.
+- `lateness_severity > work_focus`: slight or moderate preference.
+- `lateness_frequency > work_focus`: slight preference or equal depending on CR/weights.
+
+The final matrix must be chosen empirically by computing:
+
+- Chang extent weights
+- CR on defuzzified crisp matrix
+- all weights > 0
+- alpha in target range
+
+### Approach B — Add fallback/minimum weight guard (not recommended initially)
+
+If matrix-only rebalance cannot produce healthy weights, add a discipline-specific fallback or minimum epsilon guard. This is not first choice because it changes weighting behavior beyond pairwise judgment and may be less academically clean.
+
+## Acceptance Criteria
+
+1. `fuzzyEngine.getDisciplineAhpWeights()` returns all non-zero weights:
+
+```text
+alpha_rate > 0
+lateness_severity > 0
+lateness_frequency > 0
+work_focus > 0
+```
+
+2. `alpha_rate` is dominant and between `0.50` and `0.70`.
+3. CR is `< 0.10`.
+4. Existing WFA and Smart Auto Checkout weights are not changed.
+5. Tests prove the discipline matrix does not collapse to `[1, 0, 0, 0]`.
+6. Tests prove alpha remains dominant.
+7. Tests prove lateness/work-focus metrics can affect score when alpha is equal.
+8. Rationale comments in `config.fahp.js` match the new matrix.
+
+## Test Design
+
+Add focused tests around FAHP Discipline weights, preferably in an existing FAHP/discipline test file or a new focused test file.
+
+Minimum test cases:
+
+1. `getDisciplineAhpWeights()` returns:
+   - all four weights finite
+   - all four weights > 0
+   - sum approximately 1
+   - alpha in `[0.50, 0.70]`
+   - CR < 0.10
+
+2. Lateness affects score when alpha is equal:
+   - user A metrics: alpha 0, lateness 0, frequency 0, consistency 100
+   - user B metrics: alpha 0, lateness > 0, frequency > 0, consistency 100
+   - scores differ in the expected direction
+
+3. Work-hour consistency affects score when alpha/lateness are equal:
+   - user A consistency 100
+   - user B consistency lower
+   - scores differ in the expected direction
+
+## Risk
+
+This touches FAHP matrix/theory, which is a high-risk area in repo governance.
+
+Risks:
+
+- A matrix may pass CR but still generate poor weights.
+- Changing matrix changes dashboard/research ranking semantics.
+- Too much rebalance can underweight alpha, which conflicts with product/research intent.
+
+Mitigations:
+
+- Keep alpha dominant.
+- Bound alpha target to 0.50–0.70.
+- Preserve CR < 0.10.
+- Add tests that fail on zero-weight collapse.
+- Document the rationale.
+
+## Docs / ADR Note
+
+`DOCS/ADR UPDATE REQUIRED`
+
+Reason:
+
+- FAHP Discipline matrix is a theory/algorithm artifact.
+- Changing it affects ranking semantics and dashboard output.
+
+Documentation can be a short ADR/doc note explaining:
+
+- prior collapse `[1,0,0,0]`
+- why the matrix was rebalanced
+- target weight envelope
+- final measured weights and CR
+
+## Verification Plan
+
+Required:
+
+```bash
+npm run lint
+npm test
+```
+
+Focused:
+
+```bash
+npm test -- --runInBand --testPathPattern=fahp
+npm test -- --runInBand --testPathPattern=discipline
+```
+
+Runtime check:
+
+```bash
+node --input-type=module -e "
+import fuzzyEngine from './src/utils/fuzzyAhpEngine.js';
+console.log(fuzzyEngine.getDisciplineAhpWeights());
+"
+```
+
+Expected runtime shape:
+
+```json
+{
+  "alpha_rate": 0.5xx,
+  "lateness_severity": 0.xxx,
+  "lateness_frequency": 0.xxx,
+  "work_focus": 0.xxx,
+  "consistency_ratio": "< 0.10"
+}
+```
+
+## Open Questions
+
+None for initial plan. User decision already made: use matrix rebalance with alpha target `50%–70%`.

--- a/src/analytics/config.fahp.js
+++ b/src/analytics/config.fahp.js
@@ -43,18 +43,21 @@ export const WFA_PAIRWISE_TFN = [
  * Criteria: [alpha_rate, lateness_severity, lateness_frequency, work_focus]
  *
  * Judgment rationale:
- * - alpha_rate > lateness_severity: STRONG (5) - Being absent is worse than being late
- * - alpha_rate > lateness_frequency: STRONG (5) - Absence frequency is critical
- * - alpha_rate > work_focus: MODERATE (3) - Absence matters more than work consistency
- * - lateness_severity > work_focus: EQUAL (1) - Both equally important
- * - lateness_frequency > work_focus: EQUAL (1) - Both equally important
- * - lateness_severity > lateness_frequency: MODERATE (3) - How late matters more than how often
+ * - alpha_rate > lateness_severity: MODERATE (3) - Absence remains the strongest signal, but lateness severity must still influence the score
+ * - alpha_rate > lateness_frequency: WEAK (2) - Absence is worse than repeated lateness, but frequency must not collapse to zero
+ * - alpha_rate > work_focus: WEAK (2) - Absence is worse than work-hour inconsistency, while work focus remains a measurable discipline dimension
+ * - lateness_severity > lateness_frequency: WEAK (2) - How late someone is matters slightly more than how often they are late
+ * - lateness_severity = work_focus: EQUAL (1) - Lateness severity and work-hour consistency both affect discipline quality
+ * - lateness_frequency = work_focus: EQUAL (1) - Repeated lateness and work-hour consistency are both secondary discipline indicators
+ *
+ * Target behavior: alpha_rate remains dominant (~50-70%) while lateness_severity,
+ * lateness_frequency, and work_focus keep non-zero weights under Chang's Extent Analysis.
  */
 export const DISC_PAIRWISE_TFN = [
-  [TFN.EQUAL, TFN.STRONG, TFN.STRONG, TFN.MODERATE], // alpha_rate (was M, VH, VH, H)
-  [invTFN(TFN.STRONG), TFN.EQUAL, TFN.MODERATE, TFN.EQUAL], // lateness_severity (was 1/VH, M, H, M)
-  [invTFN(TFN.STRONG), invTFN(TFN.MODERATE), TFN.EQUAL, TFN.EQUAL], // lateness_frequency (was 1/VH, 1/H, M, M)
-  [invTFN(TFN.MODERATE), invTFN(TFN.EQUAL), invTFN(TFN.EQUAL), TFN.EQUAL] // work_focus (was 1/H, 1/M, 1/M, M)
+  [TFN.EQUAL, TFN.MODERATE, TFN.WEAK, TFN.WEAK],
+  [invTFN(TFN.MODERATE), TFN.EQUAL, TFN.WEAK, TFN.EQUAL],
+  [invTFN(TFN.WEAK), invTFN(TFN.WEAK), TFN.EQUAL, TFN.EQUAL],
+  [invTFN(TFN.WEAK), invTFN(TFN.EQUAL), invTFN(TFN.EQUAL), TFN.EQUAL]
 ];
 
 /**

--- a/tests/fahpDisciplineWeights.test.js
+++ b/tests/fahpDisciplineWeights.test.js
@@ -1,0 +1,55 @@
+import fuzzyEngine from '../src/utils/fuzzyAhpEngine.js';
+
+const sumDisciplineWeights = (weights) =>
+  weights.alpha_rate + weights.lateness_severity + weights.lateness_frequency + weights.work_focus;
+
+describe('FAHP Discipline weights', () => {
+  it('keeps alpha dominant while preserving non-zero lateness and work-focus criteria', () => {
+    const weights = fuzzyEngine.getDisciplineAhpWeights();
+
+    expect(weights.alpha_rate).toBeGreaterThanOrEqual(0.5);
+    expect(weights.alpha_rate).toBeLessThanOrEqual(0.7);
+    expect(weights.lateness_severity).toBeGreaterThan(0);
+    expect(weights.lateness_frequency).toBeGreaterThan(0);
+    expect(weights.work_focus).toBeGreaterThan(0);
+    expect(weights.alpha_rate).toBeGreaterThan(weights.lateness_severity);
+    expect(weights.alpha_rate).toBeGreaterThan(weights.lateness_frequency);
+    expect(weights.alpha_rate).toBeGreaterThan(weights.work_focus);
+    expect(weights.consistency_ratio).toBeLessThan(0.1);
+    expect(sumDisciplineWeights(weights)).toBeCloseTo(1, 5);
+  });
+
+  it('allows lateness metrics to affect discipline score when alpha is equal', async () => {
+    const clean = await fuzzyEngine.calculateDisciplineIndex({
+      alpha_rate: 0,
+      avg_lateness_minutes: 0,
+      lateness_frequency: 0,
+      work_hour_consistency: 100
+    });
+    const late = await fuzzyEngine.calculateDisciplineIndex({
+      alpha_rate: 0,
+      avg_lateness_minutes: 30,
+      lateness_frequency: 50,
+      work_hour_consistency: 100
+    });
+
+    expect(late.score).not.toBe(clean.score);
+  });
+
+  it('allows work-hour consistency to affect discipline score when absence and lateness are equal', async () => {
+    const consistent = await fuzzyEngine.calculateDisciplineIndex({
+      alpha_rate: 0,
+      avg_lateness_minutes: 0,
+      lateness_frequency: 0,
+      work_hour_consistency: 100
+    });
+    const inconsistent = await fuzzyEngine.calculateDisciplineIndex({
+      alpha_rate: 0,
+      avg_lateness_minutes: 0,
+      lateness_frequency: 0,
+      work_hour_consistency: 50
+    });
+
+    expect(inconsistent.score).not.toBe(consistent.score);
+  });
+});


### PR DESCRIPTION
## Summary
- rebalance `DISC_PAIRWISE_TFN` so FAHP Discipline weights no longer collapse to `[1, 0, 0, 0]`
- keep `alpha_rate` dominant while preserving non-zero weights for lateness severity, lateness frequency, and work focus
- add focused regression tests proving non-collapse and score sensitivity across discipline criteria
- document the matrix rebalance rationale and implementation plan

## Impact
- FAHP Discipline ranking is no longer driven only by alpha
- late minutes, late frequency, and work-hour consistency can now affect score when alpha is equal
- WFA and Smart Auto Checkout matrices remain unchanged

## Risk
- touches FAHP theory/matrix semantics
- discipline ranking output will change because the criteria weights are now meaningful instead of collapsing to alpha-only
- docs are force-added because `docs/*` is ignored in this repo

## Verification
- `npm run lint` ✅
- `npm test -- --runInBand tests/fahpDisciplineWeights.test.js` ✅
- `npm test -- --runInBand --testPathPattern=fahp` ✅
- `npm test` ✅
- runtime weights check ✅

Runtime weights after rebalance:

```json
{
  "alpha_rate": 0.5128812499692939,
  "lateness_severity": 0.2477192702838649,
  "lateness_frequency": 0.11486769150110643,
  "work_focus": 0.1245317882457348,
  "consistency_ratio": 0.07732121780209075
}
```

## Docs/ADR
- DOCS/ADR UPDATE REQUIRED because this changes the FAHP Discipline theory/matrix semantics and downstream dashboard ranking behavior

🤖 Generated with [Claude Code](https://claude.ai/code)