### PR TITLE
feat: align attendance history report summary contract

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2023,6 +2023,29 @@ paths:
                           total_alpha:
                             type: integer
                             example: 0
+                          total_present:
+                            type: integer
+                            example: 11
+                          total_absent:
+                            type: integer
+                            example: 1
+                          total_counted_days:
+                            type: integer
+                            example: 12
+                          total_working_days:
+                            type: integer
+                            nullable: true
+                            example: null
+                          attendance_rate:
+                            type: integer
+                            nullable: true
+                            example: 92
+                          attendance_rate_label:
+                            type: string
+                            example: 92%
+                          attendance_rate_denominator:
+                            type: string
+                            example: total_counted_days
                           total_wfo:
                             type: integer
                             example: 6
@@ -2036,6 +2059,60 @@ paths:
                             type: number
                             format: float
                             example: 88.5
+                          total_work_hours_label:
+                            type: string
+                            example: 88h 30m
+                          mode_distribution:
+                            type: object
+                            properties:
+                              total:
+                                type: integer
+                                example: 11
+                              wfo:
+                                type: object
+                                properties:
+                                  key:
+                                    type: string
+                                    example: wfo
+                                  label:
+                                    type: string
+                                    example: WFO
+                                  count:
+                                    type: integer
+                                    example: 6
+                                  percentage:
+                                    type: integer
+                                    example: 55
+                              wfa:
+                                type: object
+                                properties:
+                                  key:
+                                    type: string
+                                    example: wfa
+                                  label:
+                                    type: string
+                                    example: WFA
+                                  count:
+                                    type: integer
+                                    example: 3
+                                  percentage:
+                                    type: integer
+                                    example: 27
+                              wfh:
+                                type: object
+                                properties:
+                                  key:
+                                    type: string
+                                    example: wfh
+                                  label:
+                                    type: string
+                                    example: WFH
+                                  count:
+                                    type: integer
+                                    example: 2
+                                  percentage:
+                                    type: integer
+                                    example: 18
                       attendances:
                         type: array
                         items:
@@ -2071,13 +2148,30 @@ paths:
                             time_in:
                               type: string
                               nullable: true
+                              description: UI-facing check-in display. Null for alpha rows.
                               example: '08:04'
                             time_out:
                               type: string
                               nullable: true
+                              description: UI-facing check-out display. Null for alpha rows.
                               example: '17:06'
                             time_range:
                               type: string
+                              description: UI-facing time range. Alpha rows use '--:-- - --:--'.
+                              example: '08:04 - 17:06'
+                            raw_time_in:
+                              type: string
+                              nullable: true
+                              description: Raw backend/system-generated check-in time retained for audit/debug.
+                              example: '08:04'
+                            raw_time_out:
+                              type: string
+                              nullable: true
+                              description: Raw backend/system-generated check-out time retained for audit/debug.
+                              example: '17:06'
+                            raw_time_range:
+                              type: string
+                              description: Raw backend/system-generated time range retained for audit/debug.
                               example: '08:04 - 17:06'
                             work_hour:
                               type: string

--- a/docs/plans/2026-07-08-inf-233-attendance-history-report-summary-plan.md
+++ b/docs/plans/2026-07-08-inf-233-attendance-history-report-summary-plan.md
@@ -1,0 +1,384 @@
+# INF-233 — Attendance History Report Summary Implementation Plan
+
+## Worktree / Branch
+
+```text
+Worktree: C:/Users/Febriyadi/.claude/worktrees/Infinit_Track_BE-feature-inf-233-attendance-history-report-summary
+Branch: feature/inf-233-attendance-history-report-summary
+Base: develop @ a462663
+```
+
+## Scope
+
+Implement additive report summary fields and alpha UI-safe timeline display for:
+
+```http
+GET /api/attendance/history
+```
+
+No new endpoint and no DB migration.
+
+## Files to change
+
+Required:
+
+```text
+src/controllers/attendance.controller.js
+tests/attendanceHistoryTimelineContract.test.js
+docs/openapi.yaml
+```
+
+Optional after implementation:
+
+```text
+postman/inf-217-attendance-history-runtime.collection.json
+```
+
+Only update Postman if we decide to track INF-233 evidence in repo.
+
+## Design decisions locked
+
+### Attendance rate denominator
+
+Use MVP counted-days denominator:
+
+```text
+total_present = total_ontime + total_late + total_early
+total_absent = total_alpha
+total_counted_days = total_present + total_absent
+attendance_rate = round((total_present / total_counted_days) * 100)
+```
+
+When no counted days:
+
+```json
+{
+  "attendance_rate": null,
+  "attendance_rate_label": "N/A",
+  "attendance_rate_denominator": "total_counted_days"
+}
+```
+
+### Working days
+
+Return:
+
+```json
+"total_working_days": null
+```
+
+Reason: no reliable official working-day denominator in this issue.
+
+### Alpha display
+
+For `status_key === "alpha"`:
+
+```json
+{
+  "time_in": null,
+  "time_out": null,
+  "time_range": "--:-- - --:--",
+  "raw_time_in": "23:55",
+  "raw_time_out": "23:55",
+  "raw_time_range": "23:55 - 23:55",
+  "work_hour": null
+}
+```
+
+For non-alpha rows, raw time fields mirror display values.
+
+## Implementation steps
+
+### Step 1 — Add focused failing tests
+
+File:
+
+```text
+tests/attendanceHistoryTimelineContract.test.js
+```
+
+Add tests for:
+
+1. Summary report fields with example totals:
+
+```text
+total_ontime=2
+total_late=0
+total_early=0
+total_alpha=1
+total_wfo=3
+total_wfa=0
+total_wfh=0
+total_work_hours=16
+```
+
+Expect:
+
+```json
+{
+  "total_present": 2,
+  "total_absent": 1,
+  "total_counted_days": 3,
+  "total_working_days": null,
+  "attendance_rate": 67,
+  "attendance_rate_label": "67%",
+  "attendance_rate_denominator": "total_counted_days",
+  "total_work_hours_label": "16h"
+}
+```
+
+2. `mode_distribution`:
+
+```json
+{
+  "total": 3,
+  "wfo": { "count": 3, "percentage": 100 },
+  "wfa": { "count": 0, "percentage": 0 },
+  "wfh": { "count": 0, "percentage": 0 }
+}
+```
+
+3. Empty-count edge case:
+
+```text
+total_counted_days=0
+attendance_rate=null
+attendance_rate_label=N/A
+mode_distribution.total=0
+percentages=0
+```
+
+4. Alpha UI-safe row:
+
+Input row has system time values.
+
+Expect:
+
+```json
+{
+  "time_in": null,
+  "time_out": null,
+  "time_range": "--:-- - --:--",
+  "raw_time_in": "23:55",
+  "raw_time_out": "23:55",
+  "raw_time_range": "23:55 - 23:55",
+  "work_hour": null
+}
+```
+
+Run expected failing test:
+
+```bash
+npm test -- --runTestsByPath tests/attendanceHistoryTimelineContract.test.js
+```
+
+### Step 2 — Implement summary helpers
+
+File:
+
+```text
+src/controllers/attendance.controller.js
+```
+
+Add helper functions near existing attendance history helpers:
+
+```js
+const roundPercentage = (value) => Math.round(value);
+const formatWorkHoursLabel = (hours) => ...;
+const percentageOf = (count, total) => ...;
+const buildModeDistribution = (summary) => ...;
+const enrichHistorySummaryForReport = (summary) => ...;
+```
+
+Implementation details:
+
+- `total_present = total_ontime + total_late + total_early`
+- `total_absent = total_alpha`
+- `total_counted_days = total_present + total_absent`
+- `total_working_days = null`
+- `attendance_rate = null` if denominator 0, else rounded integer
+- `attendance_rate_label = "N/A"` if null, else `${attendance_rate}%`
+- `attendance_rate_denominator = "total_counted_days"`
+- `total_work_hours_label`: compact Android display helper:
+  - `0` → `0h`
+  - integer `16` → `16h`
+  - decimal `16.5` → `16h 30m`
+
+### Step 3 — Apply summary enrichment after existing counts
+
+In `getAttendanceHistory`, after current summary counts and `total_work_hours` assignment, apply helper:
+
+```js
+const reportSummary = enrichHistorySummaryForReport(summary);
+```
+
+Then return `summary: reportSummary`.
+
+Avoid mutating final attendance state or database.
+
+### Step 4 — Harden alpha row time display
+
+In timeline transformation:
+
+1. Compute raw formatted values first:
+
+```js
+const rawTimeIn = att.time_in ? formatTimeOnly(att.time_in) : null;
+const rawTimeOut = att.time_out ? formatTimeOnly(att.time_out) : null;
+const rawTimeRange = `${rawTimeIn || '--:--'} - ${rawTimeOut || '--:--'}`;
+```
+
+2. For alpha:
+
+```js
+const timeIn = isAlpha ? null : rawTimeIn;
+const timeOut = isAlpha ? null : rawTimeOut;
+const timeRange = isAlpha ? '--:-- - --:--' : rawTimeRange;
+```
+
+3. Return raw fields additively:
+
+```js
+raw_time_in: rawTimeIn,
+raw_time_out: rawTimeOut,
+raw_time_range: rawTimeRange
+```
+
+Keep `work_hour: null` for alpha as already implemented.
+
+### Step 5 — Update OpenAPI
+
+File:
+
+```text
+docs/openapi.yaml
+```
+
+Update `GET /api/attendance/history` response schema:
+
+Add summary properties:
+
+```text
+total_present
+total_absent
+total_counted_days
+total_working_days
+attendance_rate
+attendance_rate_label
+attendance_rate_denominator
+total_work_hours_label
+mode_distribution
+```
+
+Update row schema:
+
+```text
+raw_time_in
+raw_time_out
+raw_time_range
+```
+
+Clarify alpha behavior in descriptions:
+
+```text
+For alpha rows, UI-facing time_in/time_out are null and time_range is "--:-- - --:--". Raw system timestamps, when present, are available in raw_time_* fields.
+```
+
+### Step 6 — Verification
+
+Run focused test:
+
+```bash
+npm test -- --runTestsByPath tests/attendanceHistoryTimelineContract.test.js
+```
+
+Run lint:
+
+```bash
+npm run lint
+```
+
+Run full tests:
+
+```bash
+npm test
+```
+
+Diff hygiene:
+
+```bash
+git diff --check
+```
+
+### Step 7 — Runtime evidence after merge/deploy
+
+After PR merge and runtime rebuild/deploy:
+
+```http
+GET /api/attendance/history?period=monthly&page=1&limit=3
+Authorization: Bearer <token>
+```
+
+Capture evidence for:
+
+- `attendance_rate`
+- denominator fields
+- `total_work_hours_label`
+- `mode_distribution`
+- alpha row UI-safe `time_in/time_out/time_range`
+- alpha row raw fields
+
+## Risks and mitigations
+
+### Risk: Android already uses `time_in` for alpha
+
+Mitigation:
+
+- This change intentionally makes `time_in` UI-safe for alpha.
+- Raw values are preserved in `raw_time_*`.
+- Tests document the behavior.
+
+### Risk: `total_working_days=null` may surprise UI
+
+Mitigation:
+
+- Provide `total_counted_days` and `attendance_rate_denominator` explicitly.
+- Android should display counted-days rate for MVP.
+- Official working days can be separate future issue.
+
+### Risk: Mode distribution duplicates totals
+
+Mitigation:
+
+- It is additive and derived directly from existing totals.
+- Existing totals remain backward-compatible.
+
+## Definition of done
+
+- Spec and plan exist.
+- Controller implements additive summary fields and alpha display hardening.
+- OpenAPI updated.
+- Focused tests pass.
+- Lint and full tests pass.
+- PR body includes verification evidence and runtime follow-up.
+
+## PR notes draft
+
+```md
+## Summary
+- Extend GET /api/attendance/history summary with Android My Attendance report fields.
+- Add counted-days attendance_rate and denominator metadata.
+- Add total_present, total_absent, total_counted_days, total_working_days=null, total_work_hours_label, and mode_distribution.
+- Harden alpha timeline rows so UI-facing time fields do not show system-generated fake times.
+- Preserve raw alpha timestamps in raw_time_* fields.
+- Update OpenAPI and contract tests.
+
+## Verification
+- npm test -- --runTestsByPath tests/attendanceHistoryTimelineContract.test.js
+- npm run lint
+- npm test
+- git diff --check
+
+## Runtime follow-up
+- Postman evidence for GET /api/attendance/history?period=monthly&page=1&limit=3
+```

--- a/docs/specs/2026-07-08-inf-233-attendance-history-report-summary-spec.md
+++ b/docs/specs/2026-07-08-inf-233-attendance-history-report-summary-spec.md
@@ -1,0 +1,333 @@
+# INF-233 — Attendance History Report Summary Contract Design
+
+## Status
+
+Draft for implementation in isolated branch/worktree:
+
+```text
+feature/inf-233-attendance-history-report-summary
+```
+
+## Goal
+
+Align `GET /api/attendance/history` with Android **My Attendance Report** summary UI while preserving the INF-217 timeline contract and existing backend response fields.
+
+Primary Android UI needs:
+
+```text
+Attendance Rate
+Work Hours
+Late count
+Alpha count
+WFO/WFA/WFH distribution
+Timeline status display without misleading alpha times
+```
+
+## Endpoint
+
+```http
+GET /api/attendance/history?period=monthly&page=1&limit=3
+```
+
+No new endpoint.
+
+## Source facts from current code/runtime
+
+Current `data.summary` already includes:
+
+```text
+total_ontime
+total_late
+total_early
+total_alpha
+total_wfo
+total_wfa
+total_wfh
+total_work_hours
+```
+
+Current timeline rows already include INF-217 fields:
+
+```text
+id_attendance
+attendance_date
+date
+monthYear
+date_label
+mode_key
+mode_label
+time_in
+time_out
+time_range
+work_hour
+work_hour_raw
+status_key
+status_label
+display_badge_key
+display_badge_label
+location_label
+category
+status
+location
+notes
+```
+
+Current issue: alpha rows can expose system-generated timestamps in UI fields, for example:
+
+```json
+{
+  "status_key": "alpha",
+  "time_in": "23:55",
+  "time_out": "23:55",
+  "time_range": "23:55 - 23:55"
+}
+```
+
+This is misleading for Android UI because alpha is absence, not a valid work session.
+
+## Non-goals
+
+Do not:
+
+- Change endpoint path.
+- Remove existing fields.
+- Implement Android UI.
+- Add Personal Insight / recommendation text.
+- Add PDF export behavior.
+- Change attendance final-state semantics.
+- Add `Active Session` to `attendance_statuses`.
+- Introduce an official business-calendar denominator without reliable source.
+
+## Required additive summary fields
+
+Add these fields under `data.summary`:
+
+```json
+{
+  "total_present": 2,
+  "total_absent": 1,
+  "total_counted_days": 3,
+  "total_working_days": null,
+  "attendance_rate": 67,
+  "attendance_rate_label": "67%",
+  "attendance_rate_denominator": "total_counted_days",
+  "total_work_hours_label": "16h"
+}
+```
+
+### Formula
+
+MVP counted-days formula:
+
+```text
+total_present = total_ontime + total_late + total_early
+total_absent = total_alpha
+total_counted_days = total_present + total_absent
+attendance_rate = round((total_present / total_counted_days) * 100)
+attendance_rate_label = `${attendance_rate}%`
+attendance_rate_denominator = "total_counted_days"
+```
+
+When `total_counted_days === 0`:
+
+```json
+{
+  "attendance_rate": null,
+  "attendance_rate_label": "N/A",
+  "attendance_rate_denominator": "total_counted_days"
+}
+```
+
+### Working-day denominator
+
+For INF-233:
+
+```json
+"total_working_days": null
+```
+
+Reason: backend must not fabricate official working days from counted attendance rows. If product later needs official working-day denominator, implement it from reliable business calendar / operational settings in a separate issue.
+
+## Required mode distribution
+
+Add `summary.mode_distribution`:
+
+```json
+{
+  "total": 3,
+  "wfo": {
+    "key": "wfo",
+    "label": "WFO",
+    "count": 3,
+    "percentage": 100
+  },
+  "wfa": {
+    "key": "wfa",
+    "label": "WFA",
+    "count": 0,
+    "percentage": 0
+  },
+  "wfh": {
+    "key": "wfh",
+    "label": "WFH",
+    "count": 0,
+    "percentage": 0
+  }
+}
+```
+
+Formula:
+
+```text
+distribution_total = total_wfo + total_wfa + total_wfh
+percentage = distribution_total > 0 ? round((count / distribution_total) * 100) : 0
+```
+
+## Alpha timeline display contract
+
+For rows where `status_key === "alpha"`, UI-facing time fields must be safe:
+
+```json
+{
+  "time_in": null,
+  "time_out": null,
+  "time_range": "--:-- - --:--",
+  "work_hour": null,
+  "work_hour_raw": 0
+}
+```
+
+Preserve raw system-generated values additively:
+
+```json
+{
+  "raw_time_in": "23:55",
+  "raw_time_out": "23:55",
+  "raw_time_range": "23:55 - 23:55"
+}
+```
+
+For non-alpha rows, raw time fields mirror display time values:
+
+```json
+{
+  "raw_time_in": "08:00",
+  "raw_time_out": "17:00",
+  "raw_time_range": "08:00 - 17:00"
+}
+```
+
+Rationale:
+
+- Android should consume `time_in`, `time_out`, and `time_range` directly for UI display.
+- Raw fields remain available for audit/debugging if backend generated system timestamps for alpha.
+
+## Example expected response fragment
+
+```json
+{
+  "success": true,
+  "data": {
+    "summary": {
+      "total_ontime": 2,
+      "total_late": 0,
+      "total_early": 0,
+      "total_alpha": 1,
+      "total_present": 2,
+      "total_absent": 1,
+      "total_counted_days": 3,
+      "total_working_days": null,
+      "attendance_rate": 67,
+      "attendance_rate_label": "67%",
+      "attendance_rate_denominator": "total_counted_days",
+      "total_wfo": 3,
+      "total_wfa": 0,
+      "total_wfh": 0,
+      "total_work_hours": 16,
+      "total_work_hours_label": "16h",
+      "mode_distribution": {
+        "total": 3,
+        "wfo": { "key": "wfo", "label": "WFO", "count": 3, "percentage": 100 },
+        "wfa": { "key": "wfa", "label": "WFA", "count": 0, "percentage": 0 },
+        "wfh": { "key": "wfh", "label": "WFH", "count": 0, "percentage": 0 }
+      }
+    },
+    "attendances": [
+      {
+        "status_key": "alpha",
+        "status_label": "Alpha",
+        "display_badge_key": "alpha",
+        "display_badge_label": "Alpha",
+        "time_in": null,
+        "time_out": null,
+        "time_range": "--:-- - --:--",
+        "raw_time_in": "23:55",
+        "raw_time_out": "23:55",
+        "raw_time_range": "23:55 - 23:55",
+        "work_hour": null,
+        "work_hour_raw": 0
+      }
+    ]
+  },
+  "message": "Riwayat absensi berhasil diambil"
+}
+```
+
+## Backward compatibility
+
+Keep all existing fields:
+
+```text
+summary.total_ontime
+summary.total_late
+summary.total_early
+summary.total_alpha
+summary.total_wfo
+summary.total_wfa
+summary.total_wfh
+summary.total_work_hours
+row.date
+row.monthYear
+row.category
+row.status
+row.location
+row.notes
+```
+
+Value-level change:
+
+- For alpha rows, UI-facing `time_in`, `time_out`, and `time_range` become safe display values.
+- Raw system timestamps move to `raw_time_*` fields.
+
+This is treated as a correctness fix for UI contract, not a final-state mutation.
+
+## Acceptance criteria
+
+- `data.summary.attendance_rate` exists.
+- `data.summary.attendance_rate_label` exists.
+- `data.summary.attendance_rate_denominator` exists and is `total_counted_days`.
+- `data.summary.total_present`, `total_absent`, and `total_counted_days` exist.
+- `data.summary.total_working_days` exists and is `null` for INF-233 MVP.
+- `data.summary.total_work_hours_label` exists.
+- `data.summary.mode_distribution` exists with WFO/WFA/WFH count and percentage.
+- Existing summary fields remain.
+- Alpha rows expose UI-safe `time_in`, `time_out`, and `time_range`.
+- Alpha rows preserve raw values in `raw_time_in`, `raw_time_out`, `raw_time_range`.
+- Contract tests cover rate formula, denominator, mode distribution, and alpha display behavior.
+- OpenAPI is updated.
+- Postman evidence for `period=monthly&page=1&limit=3` is provided after implementation/deploy.
+
+## Verification commands
+
+```bash
+npm test -- --runTestsByPath tests/attendanceHistoryTimelineContract.test.js
+npm run lint
+npm test
+```
+
+Runtime evidence:
+
+```http
+GET /api/attendance/history?period=monthly&page=1&limit=3
+Authorization: Bearer <token>
+```

--- a/src/controllers/attendance.controller.js
+++ b/src/controllers/attendance.controller.js
@@ -241,6 +241,65 @@ const buildPeriodLabel = (period) => {
   }
 };
 
+const roundPercentage = (count, total) => {
+  if (!total) return 0;
+  return Math.round((count / total) * 100);
+};
+
+const formatWorkHoursLabel = (workHours) => {
+  if (!workHours) return '0h';
+  const totalMinutes = Math.round(workHours * 60);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+};
+
+const buildModeDistribution = (summary) => {
+  const total = summary.total_wfo + summary.total_wfa + summary.total_wfh;
+
+  return {
+    total,
+    wfo: {
+      key: 'wfo',
+      label: 'WFO',
+      count: summary.total_wfo,
+      percentage: roundPercentage(summary.total_wfo, total)
+    },
+    wfa: {
+      key: 'wfa',
+      label: 'WFA',
+      count: summary.total_wfa,
+      percentage: roundPercentage(summary.total_wfa, total)
+    },
+    wfh: {
+      key: 'wfh',
+      label: 'WFH',
+      count: summary.total_wfh,
+      percentage: roundPercentage(summary.total_wfh, total)
+    }
+  };
+};
+
+const enrichHistorySummaryForReport = (summary) => {
+  const totalPresent = summary.total_ontime + summary.total_late + summary.total_early;
+  const totalAbsent = summary.total_alpha;
+  const totalCountedDays = totalPresent + totalAbsent;
+  const attendanceRate = totalCountedDays > 0 ? Math.round((totalPresent / totalCountedDays) * 100) : null;
+
+  return {
+    ...summary,
+    total_present: totalPresent,
+    total_absent: totalAbsent,
+    total_counted_days: totalCountedDays,
+    total_working_days: null,
+    attendance_rate: attendanceRate,
+    attendance_rate_label: attendanceRate == null ? 'N/A' : `${attendanceRate}%`,
+    attendance_rate_denominator: 'total_counted_days',
+    total_work_hours_label: formatWorkHoursLabel(summary.total_work_hours),
+    mode_distribution: buildModeDistribution(summary)
+  };
+};
+
 const buildPersonalReportQuery = (query = {}) => {
   const safeQuery = { ...query };
   delete safeQuery.user_id;
@@ -490,6 +549,7 @@ export const getAttendanceHistory = async (req, res) => {
     const totalWorkHours = Number.parseFloat(workHourSummary?.[0]?.total_work_hours);
     summary.total_work_hours = Number.isFinite(totalWorkHours) ? Number(totalWorkHours.toFixed(2)) : 0;
 
+    const reportSummary = enrichHistorySummaryForReport(summary);
     const todayDate = getJakartaDateString();
     const transformedData = attendanceData.rows.map((att) => {
       const [dateYear, dateMonth, dateDay] = String(att.attendance_date).split('-').map(Number);
@@ -500,8 +560,11 @@ export const getAttendanceHistory = async (req, res) => {
       const statusContract = deriveStatusContract(att);
       const isAlpha = statusContract.status_key === 'alpha';
       const isActiveSession = Boolean(att.time_in && !att.time_out && att.attendance_date === todayDate);
-      const timeIn = att.time_in ? formatTimeOnly(att.time_in) : null;
-      const timeOut = att.time_out ? formatTimeOnly(att.time_out) : null;
+      const rawTimeIn = att.time_in ? formatTimeOnly(att.time_in) : null;
+      const rawTimeOut = att.time_out ? formatTimeOnly(att.time_out) : null;
+      const rawTimeRange = `${rawTimeIn || '--:--'} - ${rawTimeOut || '--:--'}`;
+      const timeIn = isAlpha ? null : rawTimeIn;
+      const timeOut = isAlpha ? null : rawTimeOut;
 
       const notesStr = att.notes || '';
       const smartMatch = notesStr.match(/\[Smart AC\]\s*pred=([^,]+),\s*used=([^,]+),/);
@@ -541,7 +604,10 @@ export const getAttendanceHistory = async (req, res) => {
         mode_label: modeContract.mode_label,
         time_in: timeIn,
         time_out: timeOut,
-        time_range: `${timeIn || '--:--'} - ${timeOut || '--:--'}`,
+        time_range: isAlpha ? '--:-- - --:--' : rawTimeRange,
+        raw_time_in: rawTimeIn,
+        raw_time_out: rawTimeOut,
+        raw_time_range: rawTimeRange,
         work_hour: isAlpha ? null : formatWorkHour(workHourDisplay),
         work_hour_raw: workHourDisplay,
         status_key: statusContract.status_key,
@@ -567,7 +633,7 @@ export const getAttendanceHistory = async (req, res) => {
           start_date: startDateOnly,
           end_date: endDateOnly
         },
-        summary,
+        summary: reportSummary,
         attendances: transformedData,
         pagination: {
           current_page: pageNum,

--- a/tests/attendanceHistoryTimelineContract.test.js
+++ b/tests/attendanceHistoryTimelineContract.test.js
@@ -200,10 +200,27 @@ describe('getAttendanceHistory timeline contract', () => {
     expect(body.data.summary).toEqual(
       expect.objectContaining({
         total_ontime: 1,
+        total_late: 0,
+        total_early: 0,
+        total_alpha: 0,
+        total_present: 1,
+        total_absent: 0,
+        total_counted_days: 1,
+        total_working_days: null,
+        attendance_rate: 100,
+        attendance_rate_label: '100%',
+        attendance_rate_denominator: 'total_counted_days',
         total_wfo: 1,
         total_wfh: 2,
         total_wfa: 3,
-        total_work_hours: 12.75
+        total_work_hours: 12.75,
+        total_work_hours_label: '12h 45m',
+        mode_distribution: {
+          total: 6,
+          wfo: { key: 'wfo', label: 'WFO', count: 1, percentage: 17 },
+          wfh: { key: 'wfh', label: 'WFH', count: 2, percentage: 33 },
+          wfa: { key: 'wfa', label: 'WFA', count: 3, percentage: 50 }
+        }
       })
     );
     expect(body.data.attendances[0]).toEqual(
@@ -216,6 +233,9 @@ describe('getAttendanceHistory timeline contract', () => {
         time_in: '08:04',
         time_out: null,
         time_range: '08:04 - --:--',
+        raw_time_in: '08:04',
+        raw_time_out: null,
+        raw_time_range: '08:04 - --:--',
         status_key: 'ontime',
         status_label: 'On Time',
         display_badge_key: 'active',
@@ -300,8 +320,63 @@ describe('getAttendanceHistory timeline contract', () => {
         status_label: 'Alpha',
         display_badge_key: 'alpha',
         display_badge_label: 'Alpha',
+        time_in: null,
+        time_out: null,
+        time_range: '--:-- - --:--',
+        raw_time_in: '00:00',
+        raw_time_out: '07:00',
+        raw_time_range: '00:00 - 07:00',
         work_hour: null,
         work_hour_raw: 32
+      })
+    );
+  });
+
+  it('returns nullable attendance rate and zeroed mode distribution when counted days are empty', async () => {
+    const activeAttendance = {
+      id_attendance: 700,
+      user_id: 42,
+      category_id: 1,
+      status_id: 1,
+      attendance_date: '2026-05-03',
+      time_in: new Date('2026-05-03T08:04:00+07:00'),
+      time_out: null,
+      work_hour: 0,
+      notes: 'Manual attendance',
+      attendance_category: { category_name: 'Work From Office' },
+      status: { attendance_status_name: 'ontime' },
+      location: { description: 'Kantor Utama' }
+    };
+
+    mockControllerDependencies({
+      findAllResults: [[], [], [{ total_work_hours: null }]],
+      findAndCountAllResult: { count: 1, rows: [activeAttendance] }
+    });
+    const { getAttendanceHistory } = await import('../src/controllers/attendance.controller.js');
+
+    const req = { user: { id: 42 }, query: { period: 'monthly', page: '1', limit: '5' } };
+    const res = buildRes();
+
+    await getAttendanceHistory(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json.mock.calls[0][0].data.summary).toEqual(
+      expect.objectContaining({
+        total_present: 0,
+        total_absent: 0,
+        total_counted_days: 0,
+        total_working_days: null,
+        attendance_rate: null,
+        attendance_rate_label: 'N/A',
+        attendance_rate_denominator: 'total_counted_days',
+        total_work_hours: 0,
+        total_work_hours_label: '0h',
+        mode_distribution: {
+          total: 0,
+          wfo: { key: 'wfo', label: 'WFO', count: 0, percentage: 0 },
+          wfh: { key: 'wfh', label: 'WFH', count: 0, percentage: 0 },
+          wfa: { key: 'wfa', label: 'WFA', count: 0, percentage: 0 }
+        }
       })
     );
   });


### PR DESCRIPTION
## Summary
- Extend `GET /api/attendance/history` with Android My Attendance Report summary fields.
- Add `total_present`, `total_absent`, `total_counted_days`, `total_working_days=null`, `attendance_rate`, `attendance_rate_label`, `attendance_rate_denominator`, `total_work_hours_label`, and `mode_distribution`.
- Harden alpha rows so UI-facing time fields do not display misleading system-generated timestamps.
- Preserve raw alpha/system timestamps in additive `raw_time_in`, `raw_time_out`, and `raw_time_range` fields.
- Update OpenAPI and add tracked spec/plan docs.

## Formula / contract decisions
- `total_present = total_ontime + total_late + total_early`
- `total_absent = total_alpha`
- `total_counted_days = total_present + total_absent`
- `attendance_rate = round(total_present / total_counted_days * 100)`
- `attendance_rate_label = "N/A"` when denominator is zero, otherwise `%`
- `attendance_rate_denominator = "total_counted_days"`
- `total_working_days = null` for MVP to avoid fabricating an official business-calendar denominator.

## Alpha UI-safe display
For `status_key=alpha`:
- `time_in = null`
- `time_out = null`
- `time_range = "--:-- - --:--"`
- `work_hour = null`
- raw system timestamps remain available in `raw_time_*` fields.

## Scope control
- Existing `GET /api/attendance/history` only.
- No endpoint path change.
- No DB migration.
- No attendance final-state mutation.
- No scheduler/job changes.
- No Android UI changes.
- No Personal Insight or recommendation text.

## Verification
- `npm test -- --runTestsByPath tests/attendanceHistoryTimelineContract.test.js` ✅ — 6 tests
- `npm run lint` ✅
- `npm test` ✅ — 89 suites / 575 tests
- `git diff --check` ✅

## Runtime follow-up
After merge/deploy, verify:
`GET /api/attendance/history?period=monthly&page=1&limit=3`

Expected evidence:
- `summary.attendance_rate`
- `summary.attendance_rate_label`
- `summary.attendance_rate_denominator = total_counted_days`
- `summary.total_present / total_absent / total_counted_days`
- `summary.total_work_hours_label`
- `summary.mode_distribution`
- alpha row UI-safe `time_in/time_out/time_range`
- alpha row raw fields `raw_time_in/raw_time_out/raw_time_range`

## Docs
DOCS/ADR UPDATE REQUIRED: OpenAPI updated and tracked spec/plan docs added. Full ADR not required because response shape change is additive and does not introduce an official working-day denominator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Attendance history responses now include richer summary metrics, including present/absent totals, attendance rate details, work-hours labeling, and mode breakdowns.
  * Timeline entries now show separate display-friendly time fields alongside preserved raw time values for better clarity.

* **Bug Fixes**
  * Improved handling for rows with incomplete or alpha-stage time data so the API returns safer, more consistent values.
  * Added clear “N/A” behavior when attendance rate cannot be calculated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->