### PR TITLE
fix: allow web auth client type CORS header

### DIFF
--- a/scripts/smoke-test.js
+++ b/scripts/smoke-test.js
@@ -199,7 +199,7 @@ async function testCORS() {
       headers: {
         Origin: disallowedOrigin,
         'Access-Control-Request-Method': 'POST',
-        'Access-Control-Request-Headers': 'Content-Type'
+        'Access-Control-Request-Headers': 'Content-Type,X-Client-Type'
       }
     });
 
@@ -213,17 +213,19 @@ async function testCORS() {
       ?.split(',')
       .map((method) => method.trim().toUpperCase())
       .includes('POST');
-    const allowsContentType = allowedHeaders
+    const normalizedAllowedHeaders = allowedHeaders
       ?.split(',')
-      .map((header) => header.trim().toLowerCase())
-      .includes('content-type');
+      .map((header) => header.trim().toLowerCase());
+    const allowsContentType = normalizedAllowedHeaders?.includes('content-type');
+    const allowsClientType = normalizedAllowedHeaders?.includes('x-client-type');
 
     if (
       [200, 204].includes(response.status) &&
       disallowedOriginRejected &&
       credentialsConfigured &&
       allowsPost &&
-      allowsContentType
+      allowsContentType &&
+      allowsClientType
     ) {
       logTest(
         'CORS Headers',

--- a/src/app.js
+++ b/src/app.js
@@ -43,7 +43,7 @@ app.use(
     origin: config.cors.origin,
     credentials: config.cors.credentials,
     methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'],
-    allowedHeaders: ['Content-Type', 'Authorization', 'X-Request-ID'],
+    allowedHeaders: ['Content-Type', 'Authorization', 'X-Request-ID', 'X-Client-Type'],
     exposedHeaders: ['X-Request-ID'],
     maxAge: 86400 // 24 hours
   })

--- a/tests/configContract.test.js
+++ b/tests/configContract.test.js
@@ -357,6 +357,8 @@ describe('backend runtime config contract', () => {
     expect(smokeTest).toContain("const disallowedOrigin = 'https://example.com';");
     expect(smokeTest).toContain('const disallowedOriginRejected = corsHeader !== disallowedOrigin;');
     expect(smokeTest).toContain("const credentialsConfigured = credentialsHeader === 'true';");
+    expect(smokeTest).toContain('X-Client-Type');
+    expect(smokeTest).toContain('allowsClientType');
     expect(smokeTest).toContain('Allow-Credentials');
     expect(smokeTest).not.toContain("corsHeader === '*'");
     expect(productionTest).toContain('Testing API documentation access control');


### PR DESCRIPTION
## Summary
- Allow `X-Client-Type` in backend CORS `allowedHeaders` so Web FE login preflight can pass.
- Update smoke test CORS preflight to request `Content-Type,X-Client-Type` and assert `x-client-type` is allowed.
- Add config contract coverage for the new CORS smoke expectation.

## Root cause
Web FE production bundle correctly calls `https://api.infinite-track.tech/api/auth/login` and sends `X-Client-Type: web`. Production backend preflight allowed only `Content-Type,Authorization,X-Request-ID`, so browser blocked login before Axios received a backend response. Axios surfaced this as a network error and the UI showed: `Tidak dapat terhubung ke server. Periksa koneksi internet Anda.`

## Verification
- [x] `npm run lint`
- [x] `npm test -- --runTestsByPath tests/configContract.test.js`
- [ ] Full CI
- [ ] Production deploy + smoke after promotion

## Risk
- API/auth contract change is additive CORS header allowlist only.
- No auth/session behavior or route response shape changed.

## Docs/ADR
DOCS/ADR UPDATE REQUIRED: auth/session integration and env/runtime CORS contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated CORS handling to allow an additional client request header.
  * Preflight checks now validate both supported headers, helping requests from compatible clients succeed.
  * Related checks were tightened to ensure the allowed-header configuration stays consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->