### PR TITLE
hotfix: allow web login CORS client type header

### DIFF
--- a/scripts/smoke-test.js
+++ b/scripts/smoke-test.js
@@ -199,7 +199,7 @@ async function testCORS() {
       headers: {
         Origin: disallowedOrigin,
         'Access-Control-Request-Method': 'POST',
-        'Access-Control-Request-Headers': 'Content-Type'
+        'Access-Control-Request-Headers': 'Content-Type,X-Client-Type'
       }
     });
 
@@ -213,17 +213,19 @@ async function testCORS() {
       ?.split(',')
       .map((method) => method.trim().toUpperCase())
       .includes('POST');
-    const allowsContentType = allowedHeaders
+    const normalizedAllowedHeaders = allowedHeaders
       ?.split(',')
-      .map((header) => header.trim().toLowerCase())
-      .includes('content-type');
+      .map((header) => header.trim().toLowerCase());
+    const allowsContentType = normalizedAllowedHeaders?.includes('content-type');
+    const allowsClientType = normalizedAllowedHeaders?.includes('x-client-type');
 
     if (
       [200, 204].includes(response.status) &&
       disallowedOriginRejected &&
       credentialsConfigured &&
       allowsPost &&
-      allowsContentType
+      allowsContentType &&
+      allowsClientType
     ) {
       logTest(
         'CORS Headers',

--- a/src/app.js
+++ b/src/app.js
@@ -43,7 +43,7 @@ app.use(
     origin: config.cors.origin,
     credentials: config.cors.credentials,
     methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'],
-    allowedHeaders: ['Content-Type', 'Authorization', 'X-Request-ID'],
+    allowedHeaders: ['Content-Type', 'Authorization', 'X-Request-ID', 'X-Client-Type'],
     exposedHeaders: ['X-Request-ID'],
     maxAge: 86400 // 24 hours
   })

--- a/tests/configContract.test.js
+++ b/tests/configContract.test.js
@@ -357,6 +357,8 @@ describe('backend runtime config contract', () => {
     expect(smokeTest).toContain("const disallowedOrigin = 'https://example.com';");
     expect(smokeTest).toContain('const disallowedOriginRejected = corsHeader !== disallowedOrigin;');
     expect(smokeTest).toContain("const credentialsConfigured = credentialsHeader === 'true';");
+    expect(smokeTest).toContain('X-Client-Type');
+    expect(smokeTest).toContain('allowsClientType');
     expect(smokeTest).toContain('Allow-Credentials');
     expect(smokeTest).not.toContain("corsHeader === '*'");
     expect(productionTest).toContain('Testing API documentation access control');


### PR DESCRIPTION
## Summary
- Hotfix production login CORS by allowing `X-Client-Type` in backend CORS allowed headers.
- Harden smoke CORS preflight to request and assert `X-Client-Type`.
- Cherry-picked narrowly onto `master` to avoid unrelated `develop` delta.

## Root cause
The Web FE live bundle calls `https://api.infinite-track.tech/api/auth/login` and sends `X-Client-Type: web`. Production backend preflight did not include `X-Client-Type` in `Access-Control-Allow-Headers`, so the browser blocked the login request and Axios surfaced it as a network/server connection error.

## Verification
- [x] `npm run lint`
- [x] `npm test -- --runTestsByPath tests/configContract.test.js`
- [ ] GitHub CI
- [ ] Production deploy + smoke after merge
- [ ] Confirm production preflight includes `X-Client-Type`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
