### PR TITLE
hotfix: allow multiple production web origins

### DIFF
--- a/scripts/smoke-test.js
+++ b/scripts/smoke-test.js
@@ -199,7 +199,7 @@ async function testCORS() {
       headers: {
         Origin: disallowedOrigin,
         'Access-Control-Request-Method': 'POST',
-        'Access-Control-Request-Headers': 'Content-Type'
+        'Access-Control-Request-Headers': 'Content-Type,X-Client-Type'
       }
     });
 
@@ -213,17 +213,19 @@ async function testCORS() {
       ?.split(',')
       .map((method) => method.trim().toUpperCase())
       .includes('POST');
-    const allowsContentType = allowedHeaders
+    const normalizedAllowedHeaders = allowedHeaders
       ?.split(',')
-      .map((header) => header.trim().toLowerCase())
-      .includes('content-type');
+      .map((header) => header.trim().toLowerCase());
+    const allowsContentType = normalizedAllowedHeaders?.includes('content-type');
+    const allowsClientType = normalizedAllowedHeaders?.includes('x-client-type');
 
     if (
       [200, 204].includes(response.status) &&
       disallowedOriginRejected &&
       credentialsConfigured &&
       allowsPost &&
-      allowsContentType
+      allowsContentType &&
+      allowsClientType
     ) {
       logTest(
         'CORS Headers',

--- a/src/app.js
+++ b/src/app.js
@@ -43,7 +43,7 @@ app.use(
     origin: config.cors.origin,
     credentials: config.cors.credentials,
     methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'],
-    allowedHeaders: ['Content-Type', 'Authorization', 'X-Request-ID'],
+    allowedHeaders: ['Content-Type', 'Authorization', 'X-Request-ID', 'X-Client-Type'],
     exposedHeaders: ['X-Request-ID'],
     maxAge: 86400 // 24 hours
   })

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -9,7 +9,14 @@ if (missingEnvVars.length > 0 && process.env.NODE_ENV === 'production') {
 }
 
 const env = process.env.NODE_ENV || 'development';
-const corsOrigin = process.env.CORS_ORIGIN || (env === 'production' ? '' : '*');
+const rawCorsOrigin = process.env.CORS_ORIGIN || (env === 'production' ? '' : '*');
+const corsOrigin =
+  env === 'production' && rawCorsOrigin.includes(',')
+    ? rawCorsOrigin
+        .split(',')
+        .map((origin) => origin.trim())
+        .filter(Boolean)
+    : rawCorsOrigin;
 
 export default {
   port: process.env.PORT || 3000,

--- a/src/middlewares/security.js
+++ b/src/middlewares/security.js
@@ -173,12 +173,14 @@ export const validateCorsOrigin = () => {
     return;
   }
 
-  if (!origin || origin === '*') {
+  const origins = Array.isArray(origin) ? origin : [origin];
+
+  if (origins.length === 0 || origins.some((value) => !value || value === '*')) {
     throw new Error(
       'CORS_ORIGIN must be set explicitly in production; wildcard or empty origins are not allowed.'
     );
   }
 
-  console.log(`✓ CORS configured for: ${origin}`);
+  console.log(`✓ CORS configured for: ${origins.join(', ')}`);
 };
 

--- a/tests/configContract.test.js
+++ b/tests/configContract.test.js
@@ -192,6 +192,15 @@ describe('backend runtime config contract', () => {
     expect(() => validateCorsOrigin()).not.toThrow();
   });
 
+  test('accepts multiple explicit production CORS origins for credentialed requests', async () => {
+    const { config, validateCorsOrigin } = await loadProductionCorsValidation(
+      'https://app.example.com, https://admin.example.com'
+    );
+
+    expect(config.cors.origin).toEqual(['https://app.example.com', 'https://admin.example.com']);
+    expect(() => validateCorsOrigin()).not.toThrow();
+  });
+
   test('reads DB_PORT and SSL settings into sequelize-cli config for managed database migrations', () => {
     process.env.DB_PORT = '25060';
     process.env.DB_SSL = 'true';
@@ -357,6 +366,8 @@ describe('backend runtime config contract', () => {
     expect(smokeTest).toContain("const disallowedOrigin = 'https://example.com';");
     expect(smokeTest).toContain('const disallowedOriginRejected = corsHeader !== disallowedOrigin;');
     expect(smokeTest).toContain("const credentialsConfigured = credentialsHeader === 'true';");
+    expect(smokeTest).toContain('X-Client-Type');
+    expect(smokeTest).toContain('allowsClientType');
     expect(smokeTest).toContain('Allow-Credentials');
     expect(smokeTest).not.toContain("corsHeader === '*'");
     expect(productionTest).toContain('Testing API documentation access control');


### PR DESCRIPTION
## Summary
- Support comma-separated multi-origin `CORS_ORIGIN` so both `https://orca-app-58alv.ondigitalocean.app` and `https://infinite-track.tech` are accepted explicitly.
- Keep `X-Client-Type` in backend CORS allowed headers.
- Harden config contract for multiple explicit production origins.

## Root cause
The initial hotfix allowed `X-Client-Type`, but production runtime still answered with `Access-Control-Allow-Origin: https://orca-app-58alv.ondigitalocean.app` when the user logged in from `https://infinite-track.tech`. Backend needed explicit multi-origin support rather than a single fixed production origin.

## Verification
- [x] `npm run lint`
- [x] `npm test -- --runTestsByPath tests/configContract.test.js`
- [ ] Fresh GitHub CI for this PR head
- [ ] Production deploy + smoke after merge
- [ ] Confirm preflight from `https://infinite-track.tech` returns `Access-Control-Allow-Origin: https://infinite-track.tech`

## Runtime note
Production `CORS_ORIGIN` has been set to:
`https://orca-app-58alv.ondigitalocean.app,https://infinite-track.tech`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
