### PR TITLE
chore: backport multi-origin CORS hotfix from master to develop

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -9,7 +9,14 @@ if (missingEnvVars.length > 0 && process.env.NODE_ENV === 'production') {
 }
 
 const env = process.env.NODE_ENV || 'development';
-const corsOrigin = process.env.CORS_ORIGIN || (env === 'production' ? '' : '*');
+const rawCorsOrigin = process.env.CORS_ORIGIN || (env === 'production' ? '' : '*');
+const corsOrigin =
+  env === 'production' && rawCorsOrigin.includes(',')
+    ? rawCorsOrigin
+        .split(',')
+        .map((origin) => origin.trim())
+        .filter(Boolean)
+    : rawCorsOrigin;
 
 export default {
   port: process.env.PORT || 3000,

--- a/src/middlewares/security.js
+++ b/src/middlewares/security.js
@@ -173,12 +173,14 @@ export const validateCorsOrigin = () => {
     return;
   }
 
-  if (!origin || origin === '*') {
+  const origins = Array.isArray(origin) ? origin : [origin];
+
+  if (origins.length === 0 || origins.some((value) => !value || value === '*')) {
     throw new Error(
       'CORS_ORIGIN must be set explicitly in production; wildcard or empty origins are not allowed.'
     );
   }
 
-  console.log(`✓ CORS configured for: ${origin}`);
+  console.log(`✓ CORS configured for: ${origins.join(', ')}`);
 };
 

--- a/tests/configContract.test.js
+++ b/tests/configContract.test.js
@@ -192,6 +192,15 @@ describe('backend runtime config contract', () => {
     expect(() => validateCorsOrigin()).not.toThrow();
   });
 
+  test('accepts multiple explicit production CORS origins for credentialed requests', async () => {
+    const { config, validateCorsOrigin } = await loadProductionCorsValidation(
+      'https://app.example.com, https://admin.example.com'
+    );
+
+    expect(config.cors.origin).toEqual(['https://app.example.com', 'https://admin.example.com']);
+    expect(() => validateCorsOrigin()).not.toThrow();
+  });
+
   test('reads DB_PORT and SSL settings into sequelize-cli config for managed database migrations', () => {
     process.env.DB_PORT = '25060';
     process.env.DB_SSL = 'true';


### PR DESCRIPTION
## Fact

`origin/master` carries 3 commits absent from `origin/develop`:

| Commit | Content already in develop? |
| --- | --- |
| `3cb1a46` release: promote INF-232 production gate to master | Yes — squash-promote of develop `#72`..`#85` |
| `1b16d91` hotfix: allow web login CORS client type header | Yes — same change landed on develop as `6727cd3` |
| `74bb405` hotfix: allow multiple production web origins | **No — this is the real gap** |

So only `74bb405` carries content develop lacks. This PR cherry-picks exactly that commit.

## Why not a merge

`git merge origin/master` produces 7 conflicts, 5 of them `add/add`, because `3cb1a46` is a **squash-promote** rather than a merge commit: master holds develop's `#72`..`#85` work as one new commit while develop holds it as individual commits. Git therefore treats the same files as independently added on both sides. Merging would have re-introduced the pre-`#87` version of `attendance.controller.js`, `pdfReportRenderer.js`, `attendanceReport.service.js`, and `config.fahp.js` as conflict noise, over attendance final-state and FAHP code. A targeted cherry-pick avoids that entirely.

## Change

Backports multi-origin `CORS_ORIGIN` support so `develop` cannot regress the production CORS fix on the next `develop -> master` promotion.

- `src/config/index.js` — parse comma-separated `CORS_ORIGIN` into an array in production
- `src/middlewares/security.js` — `validateCorsOrigin()` accepts an array and rejects wildcard/empty entries
- `tests/configContract.test.js` — coverage for multiple explicit production origins

## Risk

- **Area:** env/deploy contract (`src/config/index.js`) — architecture-significant.
- **Behavior change:** in production, a `CORS_ORIGIN` containing a comma now yields an array instead of a single string. Single-origin values are unchanged (no comma -> same string path as before).
- **Guardrail preserved:** production still rejects empty or `*` origins; the array path checks every entry.
- No route, response shape, auth, attendance final-state, or scheduler behavior is touched.

## Verification evidence

Run on this branch, fresh:

```
npm run lint   -> exit 0, no findings
npm test       -> Test Suites: 90 passed, 90 total
                  Tests:       580 passed, 580 total
                  exit 0
```

## Docs/ADR

**DOCS/ADR UPDATE REQUIRED** — env/deploy contract. `CORS_ORIGIN` now documents a comma-separated multi-origin form. `.env.example` and deployment docs should state this; not included here to keep the backport minimal.

## Follow-up (not in this PR)

Promotion `develop -> master` is currently done by squash, which permanently prevents two-way merges between the branches. Recommend switching to a real merge commit so future backports stay trivial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring multiple credentialed CORS origins using comma-separated values.

* **Bug Fixes**
  * Improved production validation to reject empty, wildcard, or invalid CORS origin configurations.
  * Preserved whitespace-free origin values for more reliable security checks.

* **Tests**
  * Added coverage confirming valid multiple-origin configurations are accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->