### PR TITLE
feat(INF-252): enforce modular MVC layer contract via ESLint

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -13,5 +13,63 @@ module.exports = {
 	},
 	rules: {
 		'no-unused-vars': ['warn', { argsIgnorePattern: '^_' }]
-	}
+	},
+	// Modular MVC layer contract (ADR-009). Scoped to src/modules/** so legacy
+	// layer-first folders are unaffected during migration.
+	overrides: [
+		{
+			files: ['src/modules/*/*.controller.js'],
+			rules: {
+				'no-restricted-imports': [
+					'error',
+					{
+						patterns: [
+							{
+								group: ['sequelize', 'sequelize/*'],
+								message:
+									'Controllers must not touch the ORM. Move the query into a repository or query object.'
+							},
+							{
+								group: ['**/models', '**/models/*'],
+								message: 'Controllers must not import models. Go through a service.'
+							}
+						]
+					}
+				]
+			}
+		},
+		{
+			files: ['src/modules/*/*.service.js'],
+			rules: {
+				'no-restricted-imports': [
+					'error',
+					{
+						patterns: [
+							{
+								group: ['express', 'express/*'],
+								message: 'Services must not know about HTTP. Keep Express in the controller.'
+							}
+						]
+					}
+				],
+				'id-denylist': ['error', 'req', 'res', 'next']
+			}
+		},
+		{
+			files: ['src/modules/*/*.repository.js'],
+			rules: {
+				'no-restricted-imports': [
+					'error',
+					{
+						patterns: [
+							{
+								group: ['express', 'express/*'],
+								message: 'Repositories must not answer HTTP.'
+							}
+						]
+					}
+				]
+			}
+		}
+	]
 };

--- a/tests/architectureLayerRules.test.js
+++ b/tests/architectureLayerRules.test.js
@@ -1,0 +1,68 @@
+import { ESLint } from 'eslint';
+
+const lintAs = async (filePath, code) => {
+  const eslint = new ESLint({ cwd: process.cwd() });
+  const [result] = await eslint.lintText(code, { filePath });
+  return result.messages;
+};
+
+describe('modular MVC layer rules', () => {
+  it('rejects ORM imports inside a module controller', async () => {
+    const messages = await lintAs(
+      'src/modules/users/user.controller.js',
+      "import { Op } from 'sequelize';\nexport const listUsers = () => Op;\n"
+    );
+    expect(messages.some((m) => m.ruleId === 'no-restricted-imports')).toBe(true);
+  });
+
+  it('rejects model imports inside a module controller', async () => {
+    const messages = await lintAs(
+      'src/modules/users/user.controller.js',
+      "import { User } from '../../models/index.js';\nexport const listUsers = () => User;\n"
+    );
+    expect(messages.some((m) => m.ruleId === 'no-restricted-imports')).toBe(true);
+  });
+
+  it('rejects express imports inside a module service', async () => {
+    const messages = await lintAs(
+      'src/modules/users/user.service.js',
+      "import express from 'express';\nexport const listUsers = () => express;\n"
+    );
+    expect(messages.some((m) => m.ruleId === 'no-restricted-imports')).toBe(true);
+  });
+
+  it('rejects req/res/next parameter names inside a module service', async () => {
+    const messages = await lintAs(
+      'src/modules/users/user.service.js',
+      'export const listUsers = (req) => req;\n'
+    );
+    expect(messages.some((m) => m.ruleId === 'id-denylist')).toBe(true);
+  });
+
+  it('rejects express imports inside a module repository', async () => {
+    const messages = await lintAs(
+      'src/modules/users/user.repository.js',
+      "import express from 'express';\nexport const findAllUsers = () => express;\n"
+    );
+    expect(messages.some((m) => m.ruleId === 'no-restricted-imports')).toBe(true);
+  });
+
+  it('allows a module service to import a repository', async () => {
+    const messages = await lintAs(
+      'src/modules/users/user.service.js',
+      "import { findAllUsers } from './user.repository.js';\nexport const listUsers = () => findAllUsers();\n"
+    );
+    // Only the layer rules matter here. import/no-unresolved fires because the
+    // fixture path is synthetic, which is unrelated to the layer contract.
+    const layerRules = ['no-restricted-imports', 'id-denylist'];
+    expect(messages.filter((m) => layerRules.includes(m.ruleId))).toHaveLength(0);
+  });
+
+  it('leaves legacy controllers unaffected', async () => {
+    const messages = await lintAs(
+      'src/controllers/user.controller.js',
+      "import { Op } from 'sequelize';\nexport const getAllUsers = () => Op;\n"
+    );
+    expect(messages.some((m) => m.ruleId === 'no-restricted-imports')).toBe(false);
+  });
+});


### PR DESCRIPTION
Part 2 of 4 for [INF-252](https://linear.app/infinite-track-palu/issue/INF-252/backendarchitecture-adopt-modular-mvc-per-feature-with-safe). Independent of the other parts — reviewable and mergeable on its own.

## What this does

Turns three architecture rules from prose into lint rules, scoped to `src/modules/**`:

| Rule | Enforcement |
|---|---|
| Controllers must not touch the ORM | `src/modules/*/*.controller.js` may not import `sequelize` or `**/models` |
| Services must not know about HTTP | `src/modules/*/*.service.js` may not import `express`; `req`/`res`/`next` are denied identifiers |
| Repositories must not answer HTTP | `src/modules/*/*.repository.js` may not import `express` |

A violation now fails `npm run lint` instead of depending on reviewer attention.

## Why it can land before any module exists

`src/modules/**` does not exist yet. That is deliberate: the guard must be in place **before** the first module lands, and scoping it this narrowly means legacy layer-first folders are completely unaffected. One of the tests asserts exactly that — a legacy controller importing `sequelize` is still allowed.

## How it is tested

`tests/architectureLayerRules.test.js` drives the ESLint API directly, linting synthetic file paths so each rule can be proven to fire where it should and stay silent where it should not:

```js
const [result] = await new ESLint({ cwd: process.cwd() }).lintText(code, { filePath });
```

Seven cases: four rejections, one permitted import, one legacy-path exemption, one repository rejection.

## Verification

```
npm run lint    clean  (proves legacy code is unaffected)
npm test        91 suites / 586 tests passing  (579 baseline + 7)
```

## Review focus

1. Are the three rules the right ones to enforce mechanically, or too strict for the migration period?
2. `id-denylist` for `req`/`res`/`next` in services is the bluntest of the three — it denies those identifiers anywhere in the file, not just as parameters. Acceptable?

## Notes

Implements rule 2 of ADR-009, which is under review in the sibling documentation PR. This PR does not depend on that one merging first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)