### PR TITLE
feat(INF-252): additive typed error foundation

### DIFF
--- a/src/middlewares/errorHandler.js
+++ b/src/middlewares/errorHandler.js
@@ -1,5 +1,7 @@
 import logger from '../utils/logger.js';
 import config from '../config/index.js';
+import { AppError } from '../shared/errors/AppError.js';
+import { toErrorResponse } from '../shared/http/toErrorResponse.js';
 
 const PUBLIC_ERROR_CODES = new Set([
   'E_OPERATIONAL_SETTINGS_INVALID',
@@ -25,6 +27,20 @@ export const errorHandler = (err, req, res, _next) => {
   }
 
   logger.error(logPayload);
+
+  // Typed application errors (ADR-009, Phase 1). Placed after logging so log
+  // output is unchanged, and ahead of the legacy branches so an AppError never
+  // falls through to them. Everything below this block is untouched legacy
+  // behavior.
+  if (err instanceof AppError) {
+    const { status, body } = toErrorResponse(err, { env: config.env });
+
+    if (config.env === 'development') {
+      body.stack = err.stack;
+    }
+
+    return res.status(status).json(body);
+  }
 
   // Sequelize validation errors
   if (err.name === 'SequelizeValidationError') {

--- a/src/shared/errors/AppError.js
+++ b/src/shared/errors/AppError.js
@@ -1,0 +1,54 @@
+/**
+ * Typed application errors (ADR-009, Phase 1).
+ *
+ * These are additive: `errorHandler` renders an AppError through the typed
+ * path, while every legacy error keeps its existing behavior. The envelope
+ * produced for an AppError is deliberately identical to the convention
+ * already in use, so no client observes a new response shape.
+ */
+export class AppError extends Error {
+  constructor(message, { code, status, details } = {}) {
+    super(message);
+    this.name = new.target.name;
+    this.code = code;
+    this.status = status;
+
+    if (details !== undefined) {
+      this.details = details;
+    }
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, new.target);
+    }
+  }
+}
+
+export class ValidationError extends AppError {
+  constructor(message, details) {
+    super(message, { code: 'E_VALIDATION', status: 400, details });
+  }
+}
+
+export class UnauthorizedError extends AppError {
+  constructor(message, details) {
+    super(message, { code: 'E_UNAUTHORIZED', status: 401, details });
+  }
+}
+
+export class ForbiddenError extends AppError {
+  constructor(message, details) {
+    super(message, { code: 'E_FORBIDDEN', status: 403, details });
+  }
+}
+
+export class NotFoundError extends AppError {
+  constructor(message, details) {
+    super(message, { code: 'E_NOT_FOUND', status: 404, details });
+  }
+}
+
+export class ConflictError extends AppError {
+  constructor(message, details) {
+    super(message, { code: 'E_CONFLICT', status: 409, details });
+  }
+}

--- a/src/shared/http/toErrorResponse.js
+++ b/src/shared/http/toErrorResponse.js
@@ -1,0 +1,31 @@
+/**
+ * Translates a typed AppError into an HTTP status and response body.
+ *
+ * Pure by design: the environment is passed in rather than imported, so
+ * production masking can be tested without mocking the config module.
+ *
+ * The body shape deliberately matches the envelope already used across the
+ * API -- { success, message, code?, details? } -- so routing an error through
+ * this path changes nothing a client can observe.
+ */
+const MASKED_MESSAGE = 'Internal server error';
+
+export const toErrorResponse = (err, { env } = {}) => {
+  const status = err.status || 500;
+  const shouldMask = status >= 500 && env === 'production';
+
+  const body = {
+    success: false,
+    message: shouldMask ? MASKED_MESSAGE : err.message
+  };
+
+  if (err.code) {
+    body.code = err.code;
+  }
+
+  if (err.details !== undefined) {
+    body.details = err.details;
+  }
+
+  return { status, body };
+};

--- a/tests/errorHandler.test.js
+++ b/tests/errorHandler.test.js
@@ -136,4 +136,66 @@ describe('errorHandler middleware', () => {
       hint: 'Jalankan dry_run=true atau siapkan approved WFA booking/lokasi untuk user conflict.'
     });
   });
+
+  // Characterization cases (INF-252 Phase 1). These describe behavior that
+  // already exists, so they must pass on first run. They exist to prove the
+  // AppError branch added afterwards changes nothing here.
+
+  it('maps SequelizeValidationError to 400 with field errors', () => {
+    const err = Object.assign(new Error('Validation failed'), {
+      name: 'SequelizeValidationError',
+      errors: [
+        { path: 'email', message: 'email must be unique' },
+        { path: 'nip_nim', message: 'nip_nim cannot be null' }
+      ]
+    });
+    const res = createResponse();
+
+    errorHandler(err, { path: '/api/users', method: 'POST', ip: '127.0.0.1' }, res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Validation error',
+      errors: [
+        { field: 'email', message: 'email must be unique' },
+        { field: 'nip_nim', message: 'nip_nim cannot be null' }
+      ]
+    });
+  });
+
+  it('maps SequelizeUniqueConstraintError to 400', () => {
+    const err = Object.assign(new Error('duplicate'), {
+      name: 'SequelizeUniqueConstraintError'
+    });
+    const res = createResponse();
+
+    errorHandler(err, { path: '/api/users', method: 'POST', ip: '127.0.0.1' }, res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Resource already exists'
+    });
+  });
+
+  it('maps JsonWebTokenError to 401', () => {
+    const err = Object.assign(new Error('jwt malformed'), { name: 'JsonWebTokenError' });
+    const res = createResponse();
+
+    errorHandler(err, { path: '/api/users', method: 'GET', ip: '127.0.0.1' }, res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ success: false, message: 'Invalid token' });
+  });
+
+  it('maps TokenExpiredError to 401', () => {
+    const err = Object.assign(new Error('jwt expired'), { name: 'TokenExpiredError' });
+    const res = createResponse();
+
+    errorHandler(err, { path: '/api/users', method: 'GET', ip: '127.0.0.1' }, res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ success: false, message: 'Token expired' });
+  });
 });

--- a/tests/errorHandlerAppError.test.js
+++ b/tests/errorHandlerAppError.test.js
@@ -1,0 +1,91 @@
+import { jest } from '@jest/globals';
+
+const mockLoggerError = jest.fn();
+
+jest.unstable_mockModule('../src/utils/logger.js', () => ({
+  __esModule: true,
+  default: { error: mockLoggerError }
+}));
+
+jest.unstable_mockModule('../src/config/index.js', () => ({
+  __esModule: true,
+  default: { env: 'test' }
+}));
+
+const { errorHandler } = await import('../src/middlewares/errorHandler.js');
+const { NotFoundError, ValidationError, ConflictError } = await import(
+  '../src/shared/errors/AppError.js'
+);
+
+const createResponse = () => {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+const req = { path: '/api/users/9', method: 'GET', ip: '127.0.0.1' };
+
+describe('errorHandler AppError branch', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders an AppError through the typed path', () => {
+    const res = createResponse();
+
+    errorHandler(new NotFoundError('User not found'), req, res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'User not found',
+      code: 'E_NOT_FOUND'
+    });
+  });
+
+  it('passes details through', () => {
+    const details = [{ field: 'email', issue: 'required' }];
+    const res = createResponse();
+
+    errorHandler(new ValidationError('Validation error', details), req, res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Validation error',
+      code: 'E_VALIDATION',
+      details
+    });
+  });
+
+  it('exposes the code on a 409 conflict', () => {
+    const res = createResponse();
+
+    errorHandler(new ConflictError('Already checked in today'), req, res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(409);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Already checked in today',
+      code: 'E_CONFLICT'
+    });
+  });
+
+  it('still logs an AppError exactly like any other error', () => {
+    const err = new NotFoundError('User not found');
+    err.stack = 'stack-trace';
+    const res = createResponse();
+
+    errorHandler(err, req, res, jest.fn());
+
+    expect(mockLoggerError).toHaveBeenCalledWith({
+      message: 'User not found',
+      code: 'E_NOT_FOUND',
+      stack: 'stack-trace',
+      path: '/api/users/9',
+      method: 'GET',
+      ip: '127.0.0.1'
+    });
+  });
+});

--- a/tests/errorHandlerProductionMasking.test.js
+++ b/tests/errorHandlerProductionMasking.test.js
@@ -1,0 +1,78 @@
+import { jest } from '@jest/globals';
+
+/**
+ * Characterization test for the production 500-masking branch of errorHandler
+ * (INF-252 Phase 1).
+ *
+ * This lives in its own file because the config module has to be mocked as
+ * production at module scope. Re-mocking it inside the main errorHandler test
+ * would require re-importing under a fresh module registry, which is not
+ * reliably supported when combining jest.unstable_mockModule with ESM dynamic
+ * imports. A separate file is simpler and actually works.
+ */
+
+const mockLoggerError = jest.fn();
+
+jest.unstable_mockModule('../src/utils/logger.js', () => ({
+  __esModule: true,
+  default: { error: mockLoggerError }
+}));
+
+jest.unstable_mockModule('../src/config/index.js', () => ({
+  __esModule: true,
+  default: { env: 'production' }
+}));
+
+const { errorHandler } = await import('../src/middlewares/errorHandler.js');
+
+const createResponse = () => {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+const req = { path: '/api/users', method: 'GET', ip: '127.0.0.1' };
+
+describe('errorHandler in production', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('masks 500 messages', () => {
+    const res = createResponse();
+    const err = Object.assign(new Error('connection string leaked'), { status: 500 });
+
+    errorHandler(err, req, res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Internal server error'
+    });
+  });
+
+  it('does not mask 4xx messages', () => {
+    const res = createResponse();
+    const err = Object.assign(new Error('User not found'), { status: 404 });
+
+    errorHandler(err, req, res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'User not found'
+    });
+  });
+
+  it('omits the stack trace outside development', () => {
+    const res = createResponse();
+    const err = Object.assign(new Error('boom'), { status: 500, stack: 'stack-trace' });
+
+    errorHandler(err, req, res, jest.fn());
+
+    expect(res.json).toHaveBeenCalledWith(
+      expect.not.objectContaining({ stack: expect.anything() })
+    );
+  });
+});

--- a/tests/sharedAppError.test.js
+++ b/tests/sharedAppError.test.js
@@ -1,0 +1,53 @@
+import {
+  AppError,
+  ValidationError,
+  UnauthorizedError,
+  ForbiddenError,
+  NotFoundError,
+  ConflictError
+} from '../src/shared/errors/AppError.js';
+
+describe('AppError taxonomy', () => {
+  it('carries message, code and status', () => {
+    const err = new AppError('boom', { code: 'E_TEST', status: 500 });
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toBe('boom');
+    expect(err.code).toBe('E_TEST');
+    expect(err.status).toBe(500);
+  });
+
+  it('omits details when none are given', () => {
+    const err = new AppError('boom', { code: 'E_TEST', status: 500 });
+    expect('details' in err).toBe(false);
+  });
+
+  it('keeps details when given', () => {
+    const details = [{ field: 'email', issue: 'required' }];
+    const err = new AppError('boom', { code: 'E_TEST', status: 400, details });
+    expect(err.details).toBe(details);
+  });
+
+  it('names each subclass after itself', () => {
+    expect(new NotFoundError('nope').name).toBe('NotFoundError');
+  });
+
+  // Argument order matters: the title placeholders consume the first three
+  // entries, so the class constructor goes last.
+  it.each([
+    ['ValidationError', 400, 'E_VALIDATION', ValidationError],
+    ['UnauthorizedError', 401, 'E_UNAUTHORIZED', UnauthorizedError],
+    ['ForbiddenError', 403, 'E_FORBIDDEN', ForbiddenError],
+    ['NotFoundError', 404, 'E_NOT_FOUND', NotFoundError],
+    ['ConflictError', 409, 'E_CONFLICT', ConflictError]
+  ])('%s maps to status %i and code %s', (_name, status, code, Klass) => {
+    const err = new Klass('message');
+    expect(err).toBeInstanceOf(AppError);
+    expect(err.status).toBe(status);
+    expect(err.code).toBe(code);
+  });
+
+  it('lets a subclass carry details', () => {
+    const details = [{ field: 'nip_nim', issue: 'taken' }];
+    expect(new ValidationError('invalid', details).details).toBe(details);
+  });
+});

--- a/tests/sharedToErrorResponse.test.js
+++ b/tests/sharedToErrorResponse.test.js
@@ -1,0 +1,47 @@
+import { AppError, ValidationError, NotFoundError } from '../src/shared/errors/AppError.js';
+import { toErrorResponse } from '../src/shared/http/toErrorResponse.js';
+
+describe('toErrorResponse', () => {
+  it('produces the existing envelope shape', () => {
+    const result = toErrorResponse(new NotFoundError('User not found'), { env: 'test' });
+    expect(result).toEqual({
+      status: 404,
+      body: { success: false, message: 'User not found', code: 'E_NOT_FOUND' }
+    });
+  });
+
+  it('includes details when present', () => {
+    const details = [{ field: 'email', issue: 'required' }];
+    const result = toErrorResponse(new ValidationError('Validation error', details), {
+      env: 'test'
+    });
+    expect(result.body.details).toBe(details);
+  });
+
+  it('omits details when absent', () => {
+    const result = toErrorResponse(new ValidationError('Validation error'), { env: 'test' });
+    expect('details' in result.body).toBe(false);
+  });
+
+  it('masks 5xx messages in production', () => {
+    const err = new AppError('connection string leaked', { code: 'E_INTERNAL', status: 500 });
+    const result = toErrorResponse(err, { env: 'production' });
+    expect(result.body.message).toBe('Internal server error');
+  });
+
+  it('does not mask 4xx messages in production', () => {
+    const result = toErrorResponse(new NotFoundError('User not found'), { env: 'production' });
+    expect(result.body.message).toBe('User not found');
+  });
+
+  it('does not mask 5xx messages outside production', () => {
+    const err = new AppError('boom', { code: 'E_INTERNAL', status: 500 });
+    expect(toErrorResponse(err, { env: 'development' }).body.message).toBe('boom');
+  });
+
+  it('does not mutate the error it is given', () => {
+    const err = new NotFoundError('User not found');
+    toErrorResponse(err, { env: 'production' });
+    expect(err.message).toBe('User not found');
+  });
+});


### PR DESCRIPTION
Part 3 of 4 for [INF-252](https://linear.app/infinite-track-palu/issue/INF-252/backendarchitecture-adopt-modular-mvc-per-feature-with-safe). Independent of the other parts.

**No observable API behavior changes.** The diff is 101 insertions and zero deletions.

## What this adds

| File | Responsibility |
|---|---|
| `src/shared/errors/AppError.js` | Base class carrying `code`, `status`, `details`, plus `ValidationError` 400, `UnauthorizedError` 401, `ForbiddenError` 403, `NotFoundError` 404, `ConflictError` 409 |
| `src/shared/http/toErrorResponse.js` | Pure `AppError → { status, body }`, unit-testable without Express |

## The only change to existing code

One branch added to `errorHandler.js`, after logging and ahead of the legacy branches:

```js
if (err instanceof AppError) {
  const { status, body } = toErrorResponse(err, { env: config.env });
  if (config.env === 'development') body.stack = err.stack;
  return res.status(status).json(body);
}
```

- **After** `logger.error(...)`, so log output is unchanged.
- **Before** the Sequelize/JWT checks, so an `AppError` never falls through.
- Nothing below it is touched — `git diff` shows 16 added lines and no modified ones.

The envelope it emits is deliberately identical to the existing convention, `{ success, message, code?, details? }`. No client sees a new shape. The one observable difference is that a typed error can now carry a `details` array, which the legacy default path silently dropped.

## Why the env is a parameter

`toErrorResponse(err, { env })` takes the environment rather than importing config, so production masking is testable without mocking a module. Compare `tests/errorHandlerProductionMasking.test.js`, which needs a whole separate file precisely because the legacy handler reads config directly.

## Safety: legacy behavior pinned first

Commit 2 of this PR adds characterization tests for the five `errorHandler` branches that had **no coverage** — `SequelizeValidationError`, `SequelizeUniqueConstraintError`, `JsonWebTokenError`, `TokenExpiredError`, and production 500-masking — **before** the new branch is introduced. Those tests pass on first run by design; they exist so the branch added in commit 4 can be proven inert.

Review the commits in order; the story is deliberate.

## Verification

```
npm run lint    clean
npm test        94 suites / 607 tests passing  (579 baseline + 28)
git diff --stat develop..HEAD -- src/
  src/middlewares/errorHandler.js    | 16 +
  src/shared/errors/AppError.js      | 54 +
  src/shared/http/toErrorResponse.js | 31 +
  3 files changed, 101 insertions(+)      <- zero deletions
```

All 14 `errorHandler` tests pass, including the 10 that describe pre-existing behavior.

## Review focus

1. Is the additive branch placement correct — after logging, before the legacy chain?
2. Are the five status/code pairs the right taxonomy to standardise on?
3. Nothing consumes `AppError` yet. Is landing an unused foundation acceptable, or should it wait for its first consumer?

## Notes

DOCS/ADR UPDATE REQUIRED — implements Phase 1 of ADR-009, under review in the sibling documentation PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)