### PR TITLE
test(INF-252): Phase 0b characterization — checkIn controller behavior

### DIFF
--- a/docs/architecture/api-contract-inventory.md
+++ b/docs/architecture/api-contract-inventory.md
@@ -95,7 +95,7 @@ All require `verifyToken`. Roles column shows the additional `roleGuard`.
 | GET | `/` | Admin, Management | 401, 403 | route-only | covered | **gap** |
 | GET | `/today-locations` | Admin, Management | 400, 401, 403 | covered | covered | covered |
 | GET | `/geofence-evidence` | Admin, Management | 400, 401, 403 | covered | covered | covered |
-| POST | `/check-in` | any | 400, 409 | partial | covered | **gap** |
+| POST | `/check-in` | any | 400, 409, 500 | covered | covered | covered |
 | POST | `/checkout/:id` | any | 400, 403, 404 | covered | covered | covered |
 | GET | `/history/personal/pdf` | any | 400 | covered | covered | covered |
 | GET | `/history/export.pdf` | any | 400 | covered | covered | covered |
@@ -115,7 +115,9 @@ All require `verifyToken`. Roles column shows the additional `roleGuard`.
 | GET | `/smart-config` | Admin, Management | 200 | route-only | covered | n/a |
 | GET | `/enhanced-auto-checkout-settings` | Admin, Management | 200 | route-only | covered | **gap** |
 
-`partial` for `/check-in` means `attendanceDuplicateSafety.test.js` exercises `checkIn` at controller level, but only for duplicate-safety behavior — not the general success path. It is now the highest remaining gap in this module: `/checkout/:id`, which was equally uncovered, is fully pinned by `tests/attendanceCheckoutContract.test.js`.
+`/check-in` and `/checkout/:id` are both fully pinned as of 2026-07-26, by `tests/attendanceCheckinContract.test.js` (17 tests) and `tests/attendanceCheckoutContract.test.js` (10 tests). `attendanceDuplicateSafety.test.js` continues to own the two 409 duplicate paths.
+
+What `check-in` coverage now includes: the working-hours window at both ends, the holiday/weekend gate and the deliberate WFA exemption from it, the WFO 500 for missing office configuration, the WFO and WFH radius refusals, all five WFA booking refusals (missing id, unknown, wrong owner, unapproved, wrong day) plus its radius check, the ON TIME and LATE classifications, and the 201 payload including `status_classification`.
 
 `autoCheckout.test.js` tests the FAHP smart-checkout *logic*, not the `/manual-auto-checkout` endpoint. The two must not be conflated.
 
@@ -227,8 +229,8 @@ Baseline as measured on 2026-07-26, before any Phase 0b work:
 | Users — route, RBAC, validation | **done** | `tests/usersRouteContract.test.js`, 14 tests |
 | Attendance — routing and authorization matrix, all 23 endpoints | **done** | `tests/attendanceRouteContract.test.js`, 55 tests |
 | Attendance — `checkout` controller behavior | **done** | `tests/attendanceCheckoutContract.test.js`, 10 tests |
+| Attendance — `check-in` controller behavior | **done** | `tests/attendanceCheckinContract.test.js`, 17 tests |
 | Users — controller response bodies | open | needs model-level mocking |
-| Attendance — `check-in` controller behavior | open | only duplicate-safety covered today |
 | WFA — 3 endpoints | open | — |
 
 **Attendance authorization is now fully pinned.** All 23 endpoints are asserted: the 7 self-service routes reach their controller for a plain User; the 15 privileged routes return 403 for a plain User and 200 for Admin and Management; the lazy-loaded `test-weighted-prediction` trigger is confirmed Admin/Management-only; and unauthenticated requests are refused on both classes of route.
@@ -237,12 +239,14 @@ That closes the RBAC axis for the whole module, including all nine operational t
 
 `POST /api/attendance/checkout/:id` is now fully pinned: ownership 403, double-checkout 400, geofence refusal across all three location sources, the WFO/WFH/WFA lookup shapes, the transaction lifecycle, the success payload, and the pre-commit failure path. Characterizing it surfaced findings F14 and F15.
 
+**Both attendance final-state mutations are now fully pinned.** `check-in` and `checkout` were the two highest-risk endpoints in the codebase; characterizing them surfaced F14, F15, F16 and F17.
+
 Remaining highest-risk gaps, in order:
 
-1. `POST /api/attendance/check-in` — only duplicate-safety behavior is covered, by `attendanceDuplicateSafety.test.js`.
-2. Users controller response bodies, per the note in section 2.
-3. WFA's three endpoints, which still have only route-exposure coverage.
-4. `PATCH /api/settings/operational` — PATCH-specific authorization only; happy path and validation are already covered.
+1. Users controller response bodies, per the note in section 2.
+2. WFA's three endpoints, which still have only route-exposure coverage.
+3. `PATCH /api/settings/operational` — PATCH-specific authorization only; happy path and validation are already covered.
+4. `DELETE /api/attendance/:id` — destructive, routing and authorization pinned, controller behavior not.
 
 ---
 
@@ -266,6 +270,16 @@ Recorded, deliberately **not fixed** under INF-252. Each needs its own issue.
 | F11 | `DELETE /api/attendance/:id` applies `verifyToken` a second time, though `router.use(verifyToken)` already covers it | `src/routes/attendance.routes.js` |
 | **F14** | **`checkOut` rolls back an already-committed transaction.** The commit happens at line 1519, but lines 1522-1548 remain inside the same `try`. Any throw after the commit — the post-commit refetch returning `null` is the realistic one — sends control to the `catch`, which calls `transaction.rollback()` on a finished transaction. Sequelize throws, so `next(error)` is never reached and the request ends in an unhandled rejection with no response to the client | `src/controllers/attendance.controller.js:1519-1552` |
 | F15 | Nine `console.log` calls sit in the `checkOut` final-state mutation path, printing raw attendance rows. They bypass the winston logger used everywhere else, so they carry no request ID and no structured format | `src/controllers/attendance.controller.js:1503-1508,1525-1529` |
+| **F16** | **The `EARLY` check-in status is unreachable.** The working-hours gate returns 400 when `currentTimeMinutes < checkinStartMinutes`, and the classifier below tests that identical condition to assign `status_id: 4` / `EARLY`. Nothing can satisfy the second test after passing the first, so `status_id 4` can never be produced by check-in | `attendance.controller.js:757` vs `:918-921` |
+| F17 | `checkIn` derives the weekend/holiday decision from a raw `new Date()` at line 683, while the two lines above it use the explicit Jakarta helpers `getJakartaTime()` and `getJakartaDateString()`. It is correct in production only because `TZ=Asia/Jakarta` is set process-wide in `server.js`; the calendar gate silently depends on process configuration rather than on the timezone contract used by the surrounding code | `src/controllers/attendance.controller.js:682-684,736-737` |
+
+### F16 — why it matters
+
+`attendance_statuses` reserves id 4 for EARLY, and the classifier is written as though three outcomes are possible. In practice only ON TIME and LATE can occur.
+
+Either the gate is too strict — early arrivals should be recorded as EARLY rather than refused — or the classifier branch is dead code that should go. The two readings imply opposite fixes, which is exactly why this needs a product decision rather than a silent cleanup during extraction.
+
+`tests/attendanceCheckinContract.test.js` pins the current behavior: an early check-in receives 400 and no attendance row is created.
 
 ### F14 — executable evidence
 

--- a/tests/attendanceCheckinContract.test.js
+++ b/tests/attendanceCheckinContract.test.js
@@ -1,0 +1,437 @@
+import { jest } from '@jest/globals';
+
+/**
+ * Characterization coverage for checkIn controller behavior
+ * (INF-252 Phase 0b).
+ *
+ * attendanceDuplicateSafety.test.js already covers the two 409 duplicate
+ * paths. Everything else in this ~340-line function was unpinned: the
+ * holiday/weekend gate, the working-hours window, the three per-category
+ * location branches, the five WFA booking refusals, the status
+ * classification, and the 201 payload.
+ *
+ * Determinism note: the controller derives the weekend/holiday decision from
+ * a raw `new Date()` (line 683) rather than the Jakarta helpers it uses two
+ * lines earlier, so the result depends on the day the suite happens to run.
+ * These tests neutralise that by enabling both weekend and holiday check-in
+ * in settings, and by mocking date-holidays.
+ */
+
+const settingRows = (overrides = {}) => {
+  const base = {
+    'checkin.start_time': '08:00:00',
+    'checkin.end_time': '18:00:00',
+    'checkin.late_time': '10:00:00',
+    'workday.holiday_checkin_enabled': 'true',
+    'workday.weekend_checkin_enabled': 'true',
+    'workday.holiday_region': 'ID',
+    ...overrides
+  };
+  return Object.entries(base).map(([setting_key, setting_value]) => ({
+    setting_key,
+    setting_value
+  }));
+};
+
+const buildRes = () => {
+  const res = {};
+  res.status = jest.fn(() => res);
+  res.json = jest.fn(() => res);
+  return res;
+};
+
+/** Local-time constructor so getHours() is stable regardless of process TZ. */
+const atJakartaClock = (hour, minute = 0) => new Date(2026, 6, 28, hour, minute, 0);
+
+const wfoLocation = {
+  location_id: 5,
+  latitude: -0.89,
+  longitude: 119.87,
+  radius: 100
+};
+
+const loadCheckIn = async ({
+  hour = 9,
+  minute = 0,
+  settings = settingRows(),
+  existingAttendance = null,
+  location = wfoLocation,
+  booking = null,
+  distance = 10,
+  isHoliday = false,
+  createdAttendance
+} = {}) => {
+  jest.resetModules();
+
+  const txState = { committed: false };
+  const commit = jest.fn().mockImplementation(async () => {
+    txState.committed = true;
+  });
+  const rollback = jest.fn().mockImplementation(async () => {
+    if (txState.committed) {
+      throw new Error('Transaction cannot be rolled back because it has been finished');
+    }
+  });
+
+  const attendanceCreate = jest.fn().mockResolvedValue({
+    toJSON: () => createdAttendance ?? { id_attendance: 42, user_id: 1, category_id: 1 }
+  });
+
+  jest.unstable_mockModule('date-holidays', () => ({
+    default: class {
+      isHoliday() {
+        return isHoliday;
+      }
+    }
+  }));
+
+  jest.unstable_mockModule('../src/config/database.js', () => ({
+    default: { transaction: jest.fn().mockResolvedValue({ commit, rollback }) }
+  }));
+
+  jest.unstable_mockModule('../src/models/index.js', () => ({
+    Attendance: {
+      findOne: jest.fn().mockResolvedValue(existingAttendance),
+      findByPk: jest.fn(),
+      findAll: jest.fn(),
+      create: attendanceCreate
+    },
+    Booking: { findOne: jest.fn().mockResolvedValue(booking) },
+    Location: { findOne: jest.fn().mockResolvedValue(location) },
+    Settings: { findAll: jest.fn().mockResolvedValue(settings), findOne: jest.fn() },
+    AttendanceCategory: {},
+    AttendanceStatus: {},
+    BookingStatus: {},
+    User: {},
+    Role: {},
+    LocationEvent: {},
+    Photo: {}
+  }));
+
+  jest.unstable_mockModule('../src/utils/geofence.js', () => ({
+    calculateDistance: jest.fn(() => distance),
+    getJakartaTime: jest.fn(() => atJakartaClock(hour, minute)),
+    getJakartaDateString: jest.fn(() => '2026-07-28'),
+    getCurrentTimeForDB: jest.fn(() => new Date('2026-07-28T09:00:00+07:00')),
+    toJakartaTime: jest.fn((d) => d)
+  }));
+
+  jest.unstable_mockModule('../src/utils/workHourFormatter.js', () => ({
+    calculateWorkHour: jest.fn(() => 0),
+    formatWorkHour: jest.fn(() => '00:00:00'),
+    formatTimeOnly: jest.fn(() => '09:00')
+  }));
+
+  jest.unstable_mockModule('../src/utils/searchHelper.js', () => ({ applySearch: jest.fn() }));
+
+  jest.unstable_mockModule('../src/jobs/autoCheckout.job.js', () => ({
+    triggerAutoCheckout: jest.fn(),
+    runSmartAutoCheckoutForDate: jest.fn()
+  }));
+
+  jest.unstable_mockModule('../src/utils/logger.js', () => ({
+    default: { info: jest.fn(), error: jest.fn(), debug: jest.fn(), warn: jest.fn() }
+  }));
+
+  jest.unstable_mockModule('../src/utils/fuzzyAhpEngine.js', () => ({ default: {} }));
+  jest.unstable_mockModule('../src/analytics/fahp.extent.js', () => ({
+    extentWeightsTFN: jest.fn(() => [0.4, 0.2, 0.2, 0.2])
+  }));
+  jest.unstable_mockModule('../src/analytics/fahp.js', () => ({
+    defuzzifyMatrixTFN: jest.fn(() => []),
+    computeCR: jest.fn(() => ({ CR: 0.05 }))
+  }));
+  jest.unstable_mockModule('../src/analytics/config.fahp.js', () => ({
+    SMART_AC_PAIRWISE_TFN: []
+  }));
+
+  const { checkIn } = await import('../src/controllers/attendance.controller.js');
+
+  return { checkIn, commit, rollback, attendanceCreate };
+};
+
+const buildReq = (body = {}) => ({
+  user: { id: 1 },
+  body: { category_id: 1, latitude: -0.89, longitude: 119.87, notes: '', ...body }
+});
+
+describe('checkIn working-hours and calendar gates', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('refuses a check-in before the configured start time', async () => {
+    const { checkIn, commit, rollback } = await loadCheckIn({ hour: 7 });
+    const res = buildRes();
+
+    await checkIn(buildReq(), res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Check-in hanya bisa dilakukan pada jam 08:00 - 18:00.'
+    });
+    expect(rollback).toHaveBeenCalledTimes(1);
+    expect(commit).not.toHaveBeenCalled();
+  });
+
+  it('refuses a check-in after the configured end time', async () => {
+    const { checkIn } = await loadCheckIn({ hour: 19 });
+    const res = buildRes();
+
+    await checkIn(buildReq(), res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Check-in hanya bisa dilakukan pada jam 08:00 - 18:00.'
+    });
+  });
+
+  it('refuses WFO on a holiday when holiday check-in is disabled', async () => {
+    const { checkIn, rollback } = await loadCheckIn({
+      isHoliday: true,
+      settings: settingRows({
+        'workday.holiday_checkin_enabled': 'false',
+        'workday.weekend_checkin_enabled': 'false'
+      })
+    });
+    const res = buildRes();
+
+    await checkIn(buildReq({ category_id: 1 }), res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Check-in tidak diizinkan pada hari libur.'
+    });
+    expect(rollback).toHaveBeenCalledTimes(1);
+  });
+
+  it('exempts WFA from the holiday gate entirely', async () => {
+    const { checkIn } = await loadCheckIn({
+      isHoliday: true,
+      settings: settingRows({
+        'workday.holiday_checkin_enabled': 'false',
+        'workday.weekend_checkin_enabled': 'false'
+      })
+    });
+    const res = buildRes();
+
+    // No booking_id, so it falls through to the WFA-specific refusal rather
+    // than the holiday one. That is the point: the gate was skipped.
+    await checkIn(buildReq({ category_id: 3 }), res, jest.fn());
+
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Booking ID wajib untuk WFA.'
+    });
+  });
+});
+
+describe('checkIn WFO and WFH location validation', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns 500 when no office location is configured', async () => {
+    const { checkIn, rollback } = await loadCheckIn({ location: null });
+    const res = buildRes();
+
+    await checkIn(buildReq({ category_id: 1 }), res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Konfigurasi lokasi kantor (WFO) tidak ditemukan. Silakan hubungi admin.'
+    });
+    expect(rollback).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses WFO outside the office radius', async () => {
+    const { checkIn, rollback } = await loadCheckIn({ distance: 5000 });
+    const res = buildRes();
+
+    await checkIn(buildReq({ category_id: 1 }), res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(rollback).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses WFH when the user has no registered home location', async () => {
+    const { checkIn } = await loadCheckIn({ location: null });
+    const res = buildRes();
+
+    await checkIn(buildReq({ category_id: 2 }), res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('refuses WFH outside the home radius', async () => {
+    const { checkIn } = await loadCheckIn({ distance: 5000 });
+    const res = buildRes();
+
+    await checkIn(buildReq({ category_id: 2 }), res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+});
+
+describe('checkIn WFA booking validation', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  const approvedBooking = {
+    booking_id: 7,
+    user_id: 1,
+    status: 1,
+    schedule_date: '2026-07-28',
+    location: { latitude: -0.89, longitude: 119.87, radius: 150 }
+  };
+
+  it('requires a booking id', async () => {
+    const { checkIn } = await loadCheckIn();
+    const res = buildRes();
+
+    await checkIn(buildReq({ category_id: 3 }), res, jest.fn());
+
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Booking ID wajib untuk WFA.'
+    });
+  });
+
+  it('refuses an unknown booking', async () => {
+    const { checkIn } = await loadCheckIn({ booking: null });
+    const res = buildRes();
+
+    await checkIn(buildReq({ category_id: 3, booking_id: 7 }), res, jest.fn());
+
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Booking tidak ditemukan.'
+    });
+  });
+
+  it("refuses another user's booking", async () => {
+    const { checkIn } = await loadCheckIn({
+      booking: { ...approvedBooking, user_id: 99 }
+    });
+    const res = buildRes();
+
+    await checkIn(buildReq({ category_id: 3, booking_id: 7 }), res, jest.fn());
+
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Booking tidak valid untuk user ini.'
+    });
+  });
+
+  it('refuses a booking that is not approved', async () => {
+    const { checkIn } = await loadCheckIn({
+      booking: { ...approvedBooking, status: 3 }
+    });
+    const res = buildRes();
+
+    await checkIn(buildReq({ category_id: 3, booking_id: 7 }), res, jest.fn());
+
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Booking belum disetujui.'
+    });
+  });
+
+  it('refuses a booking scheduled for another day', async () => {
+    const { checkIn } = await loadCheckIn({
+      booking: { ...approvedBooking, schedule_date: '2026-07-27' }
+    });
+    const res = buildRes();
+
+    await checkIn(buildReq({ category_id: 3, booking_id: 7 }), res, jest.fn());
+
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Booking tidak berlaku untuk hari ini.'
+    });
+  });
+
+  it('refuses a check-in outside the booked location radius', async () => {
+    const { checkIn } = await loadCheckIn({ booking: approvedBooking, distance: 9000 });
+    const res = buildRes();
+
+    await checkIn(buildReq({ category_id: 3, booking_id: 7 }), res, jest.fn());
+
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Anda berada di luar radius lokasi yang diizinkan.'
+    });
+  });
+});
+
+describe('checkIn success and status classification', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('creates the record and returns 201 with ON TIME classification', async () => {
+    const { checkIn, commit, rollback, attendanceCreate } = await loadCheckIn({ hour: 9 });
+    const res = buildRes();
+    const next = jest.fn();
+
+    await checkIn(buildReq({ category_id: 1 }), res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(commit).toHaveBeenCalledTimes(1);
+    expect(rollback).not.toHaveBeenCalled();
+
+    expect(attendanceCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: 1,
+        category_id: 1,
+        status_id: 1,
+        attendance_date: '2026-07-28',
+        work_hour: 0
+      }),
+      expect.objectContaining({ transaction: expect.anything() })
+    );
+
+    expect(res.status).toHaveBeenCalledWith(201);
+    const body = res.json.mock.calls[0][0];
+    expect(body.success).toBe(true);
+    expect(body.message).toBe('Check-in berhasil dengan status: ON TIME');
+    expect(body.data.status_classification).toEqual({
+      status_id: 1,
+      status_label: 'ON TIME',
+      check_in_time: '09:00',
+      time_rules: { start_time: '08:00:00', late_time: '10:00:00' }
+    });
+  });
+
+  it('classifies a check-in after the late threshold as LATE', async () => {
+    const { checkIn, attendanceCreate } = await loadCheckIn({ hour: 11 });
+    const res = buildRes();
+
+    await checkIn(buildReq({ category_id: 1 }), res, jest.fn());
+
+    expect(attendanceCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ status_id: 2 }),
+      expect.anything()
+    );
+    const body = res.json.mock.calls[0][0];
+    expect(body.data.status_classification.status_label).toBe('LATE');
+  });
+
+  /**
+   * DEAD BRANCH, characterized not fixed.
+   *
+   * The working-hours gate rejects anything earlier than checkin.start_time
+   * with a 400, so the EARLY classification below it -- which tests the same
+   * `currentTimeMinutes < checkinStartMinutes` condition -- can never run.
+   * status_id 4 is therefore unreachable through check-in.
+   *
+   * If EARLY is meant to be reachable, the gate and the classifier disagree
+   * and one of them is wrong. Recorded as F16.
+   */
+  it('never reaches the EARLY classification because the hours gate rejects first', async () => {
+    const { checkIn, attendanceCreate } = await loadCheckIn({ hour: 7 });
+    const res = buildRes();
+
+    await checkIn(buildReq({ category_id: 1 }), res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(attendanceCreate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Continues [INF-252](https://linear.app/infinite-track-palu/issue/INF-252/backendarchitecture-adopt-modular-mvc-per-feature-with-safe) Phase 0b. **Tests and documentation only — zero production code changes.**

## Why

`checkIn` is roughly 340 lines and only its two 409 duplicate paths were covered, by `attendanceDuplicateSafety.test.js`. Everything else was unpinned — and it is one of the two endpoints that write final attendance state.

With this PR, **both attendance final-state mutations are fully pinned**: `check-in` here, `checkout` in #99.

## What is now pinned — 17 tests

- Working-hours window, rejected at both ends
- Holiday/weekend gate, **and** the deliberate WFA exemption from it
- WFO: 500 when no office location is configured; 400 outside radius
- WFH: 400 when the user has no home location; 400 outside radius
- WFA: all five booking refusals — missing id, unknown booking, wrong owner, unapproved, wrong day — plus the radius check
- ON TIME and LATE classification
- The 201 payload, including the `status_classification` block

## A determinism trap worth knowing about

The controller derives the weekend/holiday decision from a raw `new Date()` at line 683, while lines 682 and 684 use the explicit Jakarta helpers `getJakartaTime()` and `getJakartaDateString()`. The calendar gate therefore depends on the day the suite happens to run — and today is a Sunday, so a naive test would have been rejected by the weekend gate.

The tests neutralise this through settings plus a `date-holidays` mock, so they pass on any day. Recorded as **F17**: correct in production only because `TZ=Asia/Jakarta` is set process-wide in `server.js`, which makes the gate depend on process configuration rather than on the timezone contract the surrounding code uses.

## Finding: the EARLY status is unreachable (F16)

```js
// line 757 — gate
if (currentTimeMinutes < checkinStartMinutes || currentTimeMinutes > checkinEndMinutes) {
  return res.status(400).json({ ... });
}

// line 918 — classifier, same condition
if (currentTimeMinutes < checkinStartMinutes) {
  determinedStatusId = 4;   // EARLY
```

Nothing can satisfy the second test after passing the first. **`status_id: 4` can never be produced by check-in**, even though `attendance_statuses` reserves it and the classifier is written as though three outcomes are possible.

Either the gate is too strict — early arrivals should be recorded as EARLY rather than refused — or the branch is dead code that should go. **The two readings imply opposite fixes**, so this needs a product decision, not a cleanup during extraction. Tracked in Linear.

The test pins current behavior: an early check-in gets 400 and no attendance row is created.

## Verification

```
npm run lint    clean, no warnings
npm test        99 suites / 710 tests passing  (693 on develop + 17)
git diff --stat develop..HEAD -- src/    (no output)
```

## Review focus

1. F16 — is EARLY meant to be reachable? That answer decides which side gets fixed.
2. The tests mock at model level rather than route level, matching `attendanceCheckoutContract.test.js`. Consistent enough?

🤖 Generated with [Claude Code](https://claude.com/claude-code)