### PR TITLE
test(INF-252): Phase 0b characterization — /api/wfa controller contract

### DIFF
--- a/docs/architecture/api-contract-inventory.md
+++ b/docs/architecture/api-contract-inventory.md
@@ -137,11 +137,32 @@ Best-covered feature module. `bookingsReadinessContract.test.js` asserts 200, 20
 
 | Method | Path | Roles | Error codes | Happy | RBAC | Validation |
 |---|---|---|---|---|---|---|
-| GET | `/api/wfa/recommendations` | any | 401 | route-only | **gap** | **gap** |
-| GET | `/api/wfa/ahp-config` | any | 401 | route-only | **gap** | **gap** |
-| POST | `/api/wfa/test-ahp` | Admin, Management | 401, 403 | **gap** | **gap** | **gap** |
+| GET | `/api/wfa/recommendations` | any | 400 `E_VALIDATION`, 401, 408 `E_TIMEOUT`, 429 `E_RATE_LIMIT`, 500 `E_CONFIG`/`E_API_KEY`, 503 `E_SERVICE_UNAVAILABLE`/`E_EXTERNAL_SERVER` | covered | **gap** | covered |
+| GET | `/api/wfa/ahp-config` | any | 401 | covered | **gap** | n/a |
+| POST | `/api/wfa/test-ahp` | Admin, Management | 400, 401, 403 | covered | **gap** | covered |
 
 `wfaRouteExposure.test.js` asserts 404 for paths that must **not** be exposed. That is exposure control, not behavioral coverage. The `analysisFuzzyAhpWfa*` tests cover `/api/analysis/fuzzy-ahp/wfa`, a different endpoint.
+
+**Updated 2026-07-26 — `tests/wfaControllerContract.test.js` added (22 tests).** Controller behavior is now pinned; **RBAC remains a gap** because these tests exercise controllers directly and no route-level contract test exists for `/api/wfa`, unlike `/api/users` and `/api/attendance`.
+
+The FAHP engine is mocked throughout. FAHP theory is locked, so the tests assert the controller's orchestration and error contract, never the algorithm's numbers — which is also the boundary Phase 4 will cut along.
+
+### The Geoapify integration contract
+
+`getWfaRecommendations` carries the richest external-integration error mapping in the codebase, and it is now fully pinned:
+
+| Failure | Response |
+|---|---|
+| `ECONNABORTED` / `ETIMEDOUT` | 408 `E_TIMEOUT`, **after 3 attempts** |
+| `ENOTFOUND` / `ECONNREFUSED` | 503 `E_SERVICE_UNAVAILABLE`, no retry |
+| HTTP 401 / 403 | 500 `E_API_KEY` |
+| HTTP 429 | 429 `E_RATE_LIMIT` |
+| HTTP ≥ 500 | 503 `E_EXTERNAL_SERVER` |
+| anything else | `next(error)` |
+
+**Retry behavior:** timeouts are retried twice with a progressive delay of 1s then 2s — three attempts and roughly three seconds before the client sees a 408. Non-timeout failures are not retried. This is the only retry logic in the HTTP layer, and Phase 4 must carry it across when the Geoapify adapter is extracted rather than quietly dropping it.
+
+Also pinned: the search radius comes from the `wfa.recommendation.search_radius` setting and falls back to 5000 when absent, and a missing `GEOAPIFY_API_KEY` produces 500 `E_CONFIG` **before** any outbound call.
 
 ## 6. `/api/summary` — 4 endpoints
 
@@ -230,8 +251,9 @@ Baseline as measured on 2026-07-26, before any Phase 0b work:
 | Attendance — routing and authorization matrix, all 23 endpoints | **done** | `tests/attendanceRouteContract.test.js`, 55 tests |
 | Attendance — `checkout` controller behavior | **done** | `tests/attendanceCheckoutContract.test.js`, 10 tests |
 | Attendance — `check-in` controller behavior | **done** | `tests/attendanceCheckinContract.test.js`, 17 tests |
+| WFA — 3 endpoints, controller behavior | **done** | `tests/wfaControllerContract.test.js`, 22 tests |
 | Users — controller response bodies | open | needs model-level mocking |
-| WFA — 3 endpoints | open | — |
+| WFA — route-level RBAC | open | no route contract test for `/api/wfa` yet |
 
 **Attendance authorization is now fully pinned.** All 23 endpoints are asserted: the 7 self-service routes reach their controller for a plain User; the 15 privileged routes return 403 for a plain User and 200 for Admin and Management; the lazy-loaded `test-weighted-prediction` trigger is confirmed Admin/Management-only; and unauthenticated requests are refused on both classes of route.
 
@@ -244,9 +266,9 @@ That closes the RBAC axis for the whole module, including all nine operational t
 Remaining highest-risk gaps, in order:
 
 1. Users controller response bodies, per the note in section 2.
-2. WFA's three endpoints, which still have only route-exposure coverage.
+2. `DELETE /api/attendance/:id` — destructive, routing and authorization pinned, controller behavior not.
 3. `PATCH /api/settings/operational` — PATCH-specific authorization only; happy path and validation are already covered.
-4. `DELETE /api/attendance/:id` — destructive, routing and authorization pinned, controller behavior not.
+4. Route-level RBAC for `/api/wfa` — controller behavior is pinned, but no route contract test exists for that prefix.
 
 ---
 
@@ -271,6 +293,7 @@ Recorded, deliberately **not fixed** under INF-252. Each needs its own issue.
 | **F14** | **`checkOut` rolls back an already-committed transaction.** The commit happens at line 1519, but lines 1522-1548 remain inside the same `try`. Any throw after the commit — the post-commit refetch returning `null` is the realistic one — sends control to the `catch`, which calls `transaction.rollback()` on a finished transaction. Sequelize throws, so `next(error)` is never reached and the request ends in an unhandled rejection with no response to the client | `src/controllers/attendance.controller.js:1519-1552` |
 | F15 | Nine `console.log` calls sit in the `checkOut` final-state mutation path, printing raw attendance rows. They bypass the winston logger used everywhere else, so they carry no request ID and no structured format | `src/controllers/attendance.controller.js:1503-1508,1525-1529` |
 | **F16** | **The `EARLY` check-in status is unreachable.** The working-hours gate returns 400 when `currentTimeMinutes < checkinStartMinutes`, and the classifier below tests that identical condition to assign `status_id: 4` / `EARLY`. Nothing can satisfy the second test after passing the first, so `status_id 4` can never be produced by check-in | `attendance.controller.js:757` vs `:918-921` |
+| F18 | `debugGeoapifyApi` is exported from `wfa.controller.js` but imported nowhere and mounted on no route — roughly 127 lines of dead code in a 586-line controller. It also calls Geoapify directly, so it duplicates the integration logic that Phase 4 is meant to consolidate | `src/controllers/wfa.controller.js:459-586` |
 | F17 | `checkIn` derives the weekend/holiday decision from a raw `new Date()` at line 683, while the two lines above it use the explicit Jakarta helpers `getJakartaTime()` and `getJakartaDateString()`. It is correct in production only because `TZ=Asia/Jakarta` is set process-wide in `server.js`; the calendar gate silently depends on process configuration rather than on the timezone contract used by the surrounding code | `src/controllers/attendance.controller.js:682-684,736-737` |
 
 ### F16 — why it matters

--- a/tests/wfaControllerContract.test.js
+++ b/tests/wfaControllerContract.test.js
@@ -1,0 +1,340 @@
+import { jest } from '@jest/globals';
+
+/**
+ * Characterization coverage for the /api/wfa controllers
+ * (INF-252 Phase 0b).
+ *
+ * Before this file the three WFA endpoints had only route-exposure coverage --
+ * wfaRouteExposure.test.js asserts which paths must NOT exist. Nothing pinned
+ * their behavior.
+ *
+ * The FAHP engine is mocked throughout. FAHP theory is locked (CLAUDE.md), so
+ * these tests deliberately assert the controller's orchestration and its
+ * error contract, never the algorithm's numbers. That boundary is also the one
+ * Phase 4 will cut along: Geoapify integration and scoring orchestration
+ * become separate units.
+ */
+
+const buildRes = () => {
+  const res = {};
+  res.status = jest.fn(() => res);
+  res.json = jest.fn(() => res);
+  return res;
+};
+
+const loadWfa = async ({
+  axiosGet,
+  radiusSetting = { setting_value: '5000' },
+  apiKey = 'test-geoapify-key'
+} = {}) => {
+  jest.resetModules();
+
+  const get = axiosGet || jest.fn().mockResolvedValue({ data: { features: [] } });
+
+  jest.unstable_mockModule('axios', () => ({ default: { get } }));
+
+  jest.unstable_mockModule('../src/models/settings.model.js', () => ({
+    default: { findOne: jest.fn().mockResolvedValue(radiusSetting) }
+  }));
+
+  jest.unstable_mockModule('../src/utils/logger.js', () => ({
+    default: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() }
+  }));
+
+  jest.unstable_mockModule('../src/utils/fuzzyAhpEngine.js', () => ({
+    default: {
+      getWfaAhpWeights: () => ({
+        location_type: 0.5,
+        amenity_score: 0.3,
+        distance_factor: 0.2,
+        consistency_ratio: 0.05
+      }),
+      calculateWfaScore: jest.fn(async () => ({
+        final_score: 78,
+        label: 'SANGAT SESUAI',
+        weights: [0.5, 0.2, 0.3],
+        breakdown: {}
+      })),
+      getWfaScoreLabel: () => 'SANGAT SESUAI',
+      categorizePlace: () => 'office',
+      getCategoryDisplayName: () => 'Kantor'
+    }
+  }));
+
+  jest.unstable_mockModule('../src/utils/geofence.js', () => ({
+    calculateDistance: jest.fn(() => 120),
+    getJakartaTime: jest.fn(() => new Date()),
+    getJakartaDateString: jest.fn(() => '2026-07-28'),
+    getCurrentTimeForDB: jest.fn(() => new Date()),
+    toJakartaTime: jest.fn((d) => d)
+  }));
+
+  const previousKey = process.env.GEOAPIFY_API_KEY;
+  const previousLegacy = process.env.GEOAPIFY_KEY;
+
+  if (apiKey === null) {
+    delete process.env.GEOAPIFY_API_KEY;
+    delete process.env.GEOAPIFY_KEY;
+  } else {
+    process.env.GEOAPIFY_API_KEY = apiKey;
+  }
+
+  const mod = await import('../src/controllers/wfa.controller.js');
+
+  const restoreEnv = () => {
+    if (previousKey === undefined) delete process.env.GEOAPIFY_API_KEY;
+    else process.env.GEOAPIFY_API_KEY = previousKey;
+    if (previousLegacy === undefined) delete process.env.GEOAPIFY_KEY;
+    else process.env.GEOAPIFY_KEY = previousLegacy;
+  };
+
+  return { ...mod, get, restoreEnv };
+};
+
+const queryReq = (query) => ({ query, user: { id: 1, role_name: 'User' } });
+
+describe('getWfaRecommendations input validation', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it.each([
+    ['both coordinates missing', {}, 'Parameter lat dan lng wajib diisi'],
+    ['only lat supplied', { lat: '-0.89' }, 'Parameter lat dan lng wajib diisi'],
+    ['non-numeric coordinates', { lat: 'abc', lng: 'def' }, 'Format koordinat tidak valid'],
+    ['latitude above range', { lat: '91', lng: '119.87' }, 'Latitude harus antara -90 dan 90'],
+    ['longitude below range', { lat: '-0.89', lng: '-181' }, 'Longitude harus antara -180 dan 180']
+  ])('rejects %s', async (_name, query, message) => {
+    const { getWfaRecommendations, get, restoreEnv } = await loadWfa();
+    const res = buildRes();
+
+    await getWfaRecommendations(queryReq(query), res, jest.fn());
+    restoreEnv();
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      code: 'E_VALIDATION',
+      message
+    });
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it('returns E_CONFIG when no Geoapify key is configured', async () => {
+    const { getWfaRecommendations, get, restoreEnv } = await loadWfa({ apiKey: null });
+    const res = buildRes();
+
+    await getWfaRecommendations(queryReq({ lat: '-0.89', lng: '119.87' }), res, jest.fn());
+    restoreEnv();
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      code: 'E_CONFIG',
+      message: 'API key Geoapify tidak ditemukan'
+    });
+    expect(get).not.toHaveBeenCalled();
+  });
+});
+
+describe('getWfaRecommendations Geoapify error contract', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  const failWith = (error) => jest.fn().mockRejectedValue(error);
+
+  // Argument order matters: the title placeholders consume the first three
+  // entries, so the error shape goes last. Timeout codes are covered
+  // separately below because they trigger the retry loop.
+  it.each([
+    ['ENOTFOUND', 503, 'E_SERVICE_UNAVAILABLE', { code: 'ENOTFOUND' }],
+    ['ECONNREFUSED', 503, 'E_SERVICE_UNAVAILABLE', { code: 'ECONNREFUSED' }],
+    ['HTTP 401', 500, 'E_API_KEY', { response: { status: 401 } }],
+    ['HTTP 403', 500, 'E_API_KEY', { response: { status: 403 } }],
+    ['HTTP 429', 429, 'E_RATE_LIMIT', { response: { status: 429 } }],
+    ['HTTP 502', 503, 'E_EXTERNAL_SERVER', { response: { status: 502 } }]
+  ])('maps %s to %i %s', async (_name, status, code, errorShape) => {
+    const error = Object.assign(new Error('geoapify failed'), errorShape);
+    const { getWfaRecommendations, get, restoreEnv } = await loadWfa({
+      axiosGet: failWith(error)
+    });
+    const res = buildRes();
+    const next = jest.fn();
+
+    await getWfaRecommendations(queryReq({ lat: '-0.89', lng: '119.87' }), res, next);
+    restoreEnv();
+
+    expect(res.status).toHaveBeenCalledWith(status);
+    expect(res.json.mock.calls[0][0]).toMatchObject({ success: false, code });
+    expect(next).not.toHaveBeenCalled();
+    // Non-timeout failures are not retried.
+    expect(get).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([['ECONNABORTED'], ['ETIMEDOUT']])(
+    'retries %s twice with a progressive delay, then answers 408',
+    async (code) => {
+      jest.useFakeTimers();
+
+      const error = Object.assign(new Error('geoapify timeout'), { code });
+      const { getWfaRecommendations, get, restoreEnv } = await loadWfa({
+        axiosGet: failWith(error)
+      });
+      const res = buildRes();
+      const next = jest.fn();
+
+      const pending = getWfaRecommendations(queryReq({ lat: '-0.89', lng: '119.87' }), res, next);
+
+      // Progressive backoff is 1000ms then 2000ms; nothing else should elapse.
+      await jest.advanceTimersByTimeAsync(3000);
+      await pending;
+
+      restoreEnv();
+      jest.useRealTimers();
+
+      // Initial attempt plus two retries.
+      expect(get).toHaveBeenCalledTimes(3);
+      expect(res.status).toHaveBeenCalledWith(408);
+      expect(res.json.mock.calls[0][0]).toMatchObject({
+        success: false,
+        code: 'E_TIMEOUT'
+      });
+      expect(next).not.toHaveBeenCalled();
+    }
+  );
+
+  it('forwards an unrecognised failure to the error handler', async () => {
+    const error = new Error('something else entirely');
+    const { getWfaRecommendations, restoreEnv } = await loadWfa({ axiosGet: failWith(error) });
+    const res = buildRes();
+    const next = jest.fn();
+
+    await getWfaRecommendations(queryReq({ lat: '-0.89', lng: '119.87' }), res, next);
+    restoreEnv();
+
+    expect(next).toHaveBeenCalledWith(error);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+});
+
+describe('getWfaRecommendations Geoapify request contract', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('uses the configured search radius from settings', async () => {
+    const { getWfaRecommendations, get, restoreEnv } = await loadWfa({
+      radiusSetting: { setting_value: '12000' }
+    });
+    const res = buildRes();
+
+    await getWfaRecommendations(queryReq({ lat: '-0.89', lng: '119.87' }), res, jest.fn());
+    restoreEnv();
+
+    expect(get).toHaveBeenCalledWith(
+      'https://api.geoapify.com/v2/places',
+      expect.objectContaining({
+        params: expect.objectContaining({
+          filter: expect.stringContaining('12000')
+        })
+      })
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('falls back to the default radius when the setting is absent', async () => {
+    const { getWfaRecommendations, get, restoreEnv } = await loadWfa({ radiusSetting: null });
+    const res = buildRes();
+
+    await getWfaRecommendations(queryReq({ lat: '-0.89', lng: '119.87' }), res, jest.fn());
+    restoreEnv();
+
+    expect(get).toHaveBeenCalledWith(
+      'https://api.geoapify.com/v2/places',
+      expect.objectContaining({
+        params: expect.objectContaining({ filter: expect.stringContaining('5000') })
+      })
+    );
+  });
+
+  it('returns an empty recommendation list without failing', async () => {
+    const { getWfaRecommendations, restoreEnv } = await loadWfa();
+    const res = buildRes();
+    const next = jest.fn();
+
+    await getWfaRecommendations(queryReq({ lat: '-0.89', lng: '119.87' }), res, next);
+    restoreEnv();
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+    const body = res.json.mock.calls[0][0];
+    expect(body.success).toBe(true);
+    expect(body.data.recommendations).toEqual([]);
+  });
+});
+
+describe('getWfaAhpConfig', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('exposes the engine weights and derives is_consistent from the ratio', async () => {
+    const { getWfaAhpConfig, restoreEnv } = await loadWfa();
+    const res = buildRes();
+
+    await getWfaAhpConfig({}, res, jest.fn());
+    restoreEnv();
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    const body = res.json.mock.calls[0][0];
+    expect(body.success).toBe(true);
+    expect(body.data.current_weights).toEqual({
+      location_type: 0.5,
+      amenity_score: 0.3,
+      distance_factor: 0.2
+    });
+    expect(body.data.consistency_ratio).toBe(0.05);
+    // is_consistent is the controller's own rule: ratio <= 0.1
+    expect(body.data.is_consistent).toBe(true);
+  });
+});
+
+describe('testFuzzyAhp', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('requires place_data', async () => {
+    const { testFuzzyAhp, restoreEnv } = await loadWfa();
+    const res = buildRes();
+
+    await testFuzzyAhp({ body: {} }, res, jest.fn());
+    restoreEnv();
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Parameter place_data wajib diisi untuk testing'
+    });
+  });
+
+  it('scores the supplied place and echoes the scenario name', async () => {
+    const { testFuzzyAhp, restoreEnv } = await loadWfa();
+    const res = buildRes();
+    const next = jest.fn();
+
+    await testFuzzyAhp(
+      { body: { place_data: { properties: { name: 'Kafe Uji' } }, scenario: 'skenario-1' } },
+      res,
+      next
+    );
+    restoreEnv();
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+    const body = res.json.mock.calls[0][0];
+    expect(body.success).toBe(true);
+    expect(body.data.scenario).toBe('skenario-1');
+  });
+
+  it('falls back to the place name when no scenario is given', async () => {
+    const { testFuzzyAhp, restoreEnv } = await loadWfa();
+    const res = buildRes();
+
+    await testFuzzyAhp({ body: { place_data: { properties: { name: 'Kafe Uji' } } } }, res, jest.fn());
+    restoreEnv();
+
+    expect(res.json.mock.calls[0][0].data.scenario).toBe('Kafe Uji');
+  });
+});


### PR DESCRIPTION
Continues [INF-252](https://linear.app/infinite-track-palu/issue/INF-252/backendarchitecture-adopt-modular-mvc-per-feature-with-safe) Phase 0b. **Tests and documentation only — zero production code changes.**

## Why

The three WFA endpoints had only *route-exposure* coverage: `wfaRouteExposure.test.js` asserts which paths must **not** exist. Nothing pinned what they actually do.

`wfa.controller.js` is also where Phase 4 will cut — "separate Geoapify HTTP integration from suitability orchestration" — so its integration contract needs to be recorded before anything moves.

## FAHP boundary

The engine is mocked throughout. FAHP theory is locked per CLAUDE.md, so these tests assert the **controller's orchestration and error contract**, never the algorithm's numbers. That is deliberately the same seam Phase 4 will split along.

## What is now pinned — 22 tests

**Input validation** — five refusals, all `E_VALIDATION`: missing coordinates, only one supplied, non-numeric, latitude out of range, longitude out of range.

**Configuration** — 500 `E_CONFIG` when `GEOAPIFY_API_KEY` is absent, raised **before** any outbound call.

**The Geoapify failure contract** — the richest external-integration mapping in the codebase:

| Failure | Response |
|---|---|
| `ECONNABORTED` / `ETIMEDOUT` | 408 `E_TIMEOUT`, after 3 attempts |
| `ENOTFOUND` / `ECONNREFUSED` | 503 `E_SERVICE_UNAVAILABLE`, no retry |
| HTTP 401 / 403 | 500 `E_API_KEY` |
| HTTP 429 | 429 `E_RATE_LIMIT` |
| HTTP ≥ 500 | 503 `E_EXTERNAL_SERVER` |
| anything else | `next(error)` |

**The retry contract** — this is the one worth reviewer attention. Timeouts are retried twice with a progressive delay of **1s then 2s**: three attempts and roughly three seconds before the client sees a 408. Non-timeout failures are not retried. It is the only retry logic in the HTTP layer, and Phase 4 must carry it across rather than quietly drop it when the adapter is extracted.

The retry tests use fake timers, so characterizing three seconds of backoff costs **14ms** instead of 3s each.

**Also pinned** — search radius sourced from `wfa.recommendation.search_radius` with a 5000 fallback; `getWfaAhpConfig` weights and its `is_consistent` rule (`ratio <= 0.1`); `testFuzzyAhp`'s `place_data` requirement and scenario-name fallback.

## Honest limit

**RBAC is still a gap for this prefix.** These tests exercise controllers directly, and unlike `/api/users` and `/api/attendance` there is no route-level contract test for `/api/wfa`. The inventory records that rather than implying the endpoints are fully covered.

## Finding: F18 — dead code

`debugGeoapifyApi` is exported from `wfa.controller.js` but **imported nowhere and mounted on no route** — roughly 127 lines of a 586-line controller. It also calls Geoapify directly, so it duplicates the very integration Phase 4 is meant to consolidate.

Not deleted here; this is a characterization PR. Worth confirming intent before removal, same as `contribution.routes.js` (F4).

## Verification

```
npm run lint    clean, no warnings
npm test        100 suites / 732 tests passing  (710 on develop + 22)
git diff --stat develop..HEAD -- src/    (no output)
```

## Review focus

1. Is the retry contract (3 attempts, 1s+2s) intentional and worth preserving as-is through Phase 4?
2. Should F18's dead export be removed now or tracked separately?

🤖 Generated with [Claude Code](https://claude.com/claude-code)