### PR TITLE
test(INF-252): close the authorization matrix for the whole API

### DIFF
--- a/docs/architecture/api-contract-inventory.md
+++ b/docs/architecture/api-contract-inventory.md
@@ -137,9 +137,9 @@ Best-covered feature module. `bookingsReadinessContract.test.js` asserts 200, 20
 
 | Method | Path | Roles | Error codes | Happy | RBAC | Validation |
 |---|---|---|---|---|---|---|
-| GET | `/api/wfa/recommendations` | any | 400 `E_VALIDATION`, 401, 408 `E_TIMEOUT`, 429 `E_RATE_LIMIT`, 500 `E_CONFIG`/`E_API_KEY`, 503 `E_SERVICE_UNAVAILABLE`/`E_EXTERNAL_SERVER` | covered | **gap** | covered |
-| GET | `/api/wfa/ahp-config` | any | 401 | covered | **gap** | n/a |
-| POST | `/api/wfa/test-ahp` | Admin, Management | 400, 401, 403 | covered | **gap** | covered |
+| GET | `/api/wfa/recommendations` | any | 400 `E_VALIDATION`, 401, 408 `E_TIMEOUT`, 429 `E_RATE_LIMIT`, 500 `E_CONFIG`/`E_API_KEY`, 503 `E_SERVICE_UNAVAILABLE`/`E_EXTERNAL_SERVER` | covered | covered | covered |
+| GET | `/api/wfa/ahp-config` | any | 401 | covered | covered | n/a |
+| POST | `/api/wfa/test-ahp` | Admin, Management | 400, 401, 403 | covered | covered | covered |
 
 `wfaRouteExposure.test.js` asserts 404 for paths that must **not** be exposed. That is exposure control, not behavioral coverage. The `analysisFuzzyAhpWfa*` tests cover `/api/analysis/fuzzy-ahp/wfa`, a different endpoint.
 
@@ -177,10 +177,12 @@ Also pinned: the search radius comes from the `wfa.recommendation.search_radius`
 
 | Method | Path | Authorization | Error codes | Happy | RBAC | Validation |
 |---|---|---|---|---|---|---|
-| GET | `/api/discipline/user/:userId` | in controller | 403, 404 | **gap** | **gap** | **gap** |
-| GET | `/api/discipline/all` | in controller | 403 | covered | partial | n/a |
-| GET | `/api/discipline/config` | in controller | 403 | **gap** | **gap** | n/a |
-| POST | `/api/discipline/test-ahp` | `roleGuard` | 400, 403 | **gap** | **gap** | **gap** |
+| GET | `/api/discipline/user/:userId` | in controller | 403, 404 | **gap** | covered | **gap** |
+| GET | `/api/discipline/all` | in controller | 403 | covered | covered | n/a |
+| GET | `/api/discipline/config` | in controller | 403 | **gap** | covered | n/a |
+| POST | `/api/discipline/test-ahp` | `roleGuard` | 400, 403 | **gap** | covered | **gap** |
+
+The RBAC column here means the **route-layer** contract is pinned, which for three of these four routes means proving they have *no* `roleGuard` and that a plain User reaches the handler. `tests/routeAuthorizationMatrix.test.js` asserts exactly that, so finding F10 is now executable rather than prose: authorization is enforced correctly, but in two different places depending on the route.
 
 ## 8. `/api/analysis` — 5 endpoints
 
@@ -199,7 +201,7 @@ Twelve dedicated `analysisFuzzyAhp*` test files. The thinnest controller in the 
 | Method | Path | Roles | Error codes | Happy | RBAC | Validation |
 |---|---|---|---|---|---|---|
 | GET | `/api/settings/operational` | Admin, Management | 401, 403, 500 `E_OPERATIONAL_SETTINGS_INVALID` | covered | covered | n/a |
-| PATCH | `/api/settings/operational` | Admin, Management | 400, 401, 403 | covered | **gap** | covered |
+| PATCH | `/api/settings/operational` | Admin, Management | 400, 401, 403 | covered | covered | covered |
 
 **Corrected.** An earlier version marked the mutation path as having no coverage at all. `tests/settingsOperationalRoutesContract.test.js` in fact asserts PATCH success for both Admin and Management, a no-op patch, and a 400 on an empty body with its response shape.
 
@@ -209,12 +211,12 @@ What is genuinely missing is narrower: the 401 and 403 cases in that file are as
 
 | Method | Path | Roles | Error codes | Happy | RBAC | Validation |
 |---|---|---|---|---|---|---|
-| GET | `/api/roles` | Admin, Management | 401, 403 | **gap** | **gap** | n/a |
-| GET | `/api/programs` | Admin, Management | 401, 403 | **gap** | **gap** | n/a |
-| GET | `/api/positions` | Admin, Management | 401, 403 | **gap** | **gap** | **gap** |
-| GET | `/api/divisions` | Admin, Management | 401, 403 | **gap** | **gap** | n/a |
+| GET | `/api/roles` | Admin, Management | 401, 403 | **gap** | covered | n/a |
+| GET | `/api/programs` | Admin, Management | 401, 403 | **gap** | covered | n/a |
+| GET | `/api/positions` | Admin, Management | 401, 403 | **gap** | covered | **gap** |
+| GET | `/api/divisions` | Admin, Management | 401, 403 | **gap** | covered | n/a |
 
-No behavioral coverage at all. These are low-risk read-only dropdown endpoints, which is why they are not in the Phase 0b priority set.
+Authorization is pinned by `tests/routeAuthorizationMatrix.test.js`. The controllers' own response bodies are still uncovered — these are low-risk read-only dropdown endpoints, which is why they remain outside the Phase 0b priority set.
 
 ## 11. Health — 2 endpoints
 
@@ -252,8 +254,13 @@ Baseline as measured on 2026-07-26, before any Phase 0b work:
 | Attendance — `checkout` controller behavior | **done** | `tests/attendanceCheckoutContract.test.js`, 10 tests |
 | Attendance — `check-in` controller behavior | **done** | `tests/attendanceCheckinContract.test.js`, 17 tests |
 | WFA — 3 endpoints, controller behavior | **done** | `tests/wfaControllerContract.test.js`, 22 tests |
+| **Authorization matrix — every remaining route file** | **done** | `tests/routeAuthorizationMatrix.test.js`, 87 tests |
 | Users — controller response bodies | open | needs model-level mocking |
-| WFA — route-level RBAC | open | no route contract test for `/api/wfa` yet |
+| `DELETE /api/attendance/:id` — controller behavior | open | destructive; routing and authorization pinned |
+
+**The authorization axis is now closed for the entire API.** Every one of the 60 route-file endpoints has its middleware chain pinned: `/api/users` by `usersRouteContract`, `/api/attendance` by `attendanceRouteContract`, `/api/bookings` by `bookingsReadinessContract`, and the remaining seven route files by `routeAuthorizationMatrix`.
+
+That matters more than the raw test count: who may reach a handler is the property most likely to drift silently when routes move into feature modules, and it is now impossible to change any of it without a test failing.
 
 **Attendance authorization is now fully pinned.** All 23 endpoints are asserted: the 7 self-service routes reach their controller for a plain User; the 15 privileged routes return 403 for a plain User and 200 for Admin and Management; the lazy-loaded `test-weighted-prediction` trigger is confirmed Admin/Management-only; and unauthenticated requests are refused on both classes of route.
 
@@ -263,12 +270,12 @@ That closes the RBAC axis for the whole module, including all nine operational t
 
 **Both attendance final-state mutations are now fully pinned.** `check-in` and `checkout` were the two highest-risk endpoints in the codebase; characterizing them surfaced F14, F15, F16 and F17.
 
-Remaining highest-risk gaps, in order:
+Remaining gaps, in order — all are **controller response bodies**, since routing and authorization are fully pinned:
 
-1. Users controller response bodies, per the note in section 2.
-2. `DELETE /api/attendance/:id` — destructive, routing and authorization pinned, controller behavior not.
-3. `PATCH /api/settings/operational` — PATCH-specific authorization only; happy path and validation are already covered.
-4. Route-level RBAC for `/api/wfa` — controller behavior is pinned, but no route contract test exists for that prefix.
+1. Users list and detail payloads — pagination metadata, mapped user shape, 404 for a missing `:id`.
+2. `DELETE /api/attendance/:id` — destructive, and the only remaining untested attendance mutation.
+3. `/api/discipline` response payloads for three of four endpoints.
+4. Reference-data dropdown payloads — lowest risk in the codebase.
 
 ---
 

--- a/tests/routeAuthorizationMatrix.test.js
+++ b/tests/routeAuthorizationMatrix.test.js
@@ -1,0 +1,283 @@
+import { jest } from '@jest/globals';
+import express from 'express';
+import request from 'supertest';
+
+/**
+ * Route-level authorization contract for every prefix not already covered
+ * (INF-252 Phase 0b).
+ *
+ * usersRouteContract.test.js covers /api/users, attendanceRouteContract covers
+ * /api/attendance, and bookingsReadinessContract covers /api/bookings. This
+ * file closes the remaining seven route files, completing the authorization
+ * matrix for the whole API.
+ *
+ * Controllers are mocked. What is asserted is which middleware chain a route
+ * declares -- who may reach the handler, and who is refused before it runs.
+ * That is the property most at risk of silent drift when routes move into
+ * feature modules.
+ */
+
+const handlersFor = (names) =>
+  Object.fromEntries(
+    names.map((name) => [name, (req, res) => res.status(200).json({ route: name })])
+  );
+
+const passThroughChain = [(req, res, next) => next()];
+const passThrough = (req, res, next) => next();
+
+/**
+ * Mounts one route file with its controller and validators mocked.
+ * `extraMocks` maps module path -> factory, for validators that differ per file.
+ */
+const mountRoute = async ({
+  routeFile,
+  controllerPath,
+  controllerExports,
+  extraMocks = {},
+  prefix,
+  role = 'Admin',
+  verifyTokenImpl
+}) => {
+  jest.resetModules();
+
+  jest.unstable_mockModule(controllerPath, () => handlersFor(controllerExports));
+
+  jest.unstable_mockModule('../src/middlewares/authJwt.js', () => ({
+    verifyToken:
+      verifyTokenImpl ||
+      ((req, res, next) => {
+        req.user = { id: 42, role_name: role };
+        next();
+      })
+  }));
+
+  jest.unstable_mockModule('../src/middlewares/roleGuard.js', () => ({
+    default: (allowedRoles) => (req, res, next) => {
+      if (!allowedRoles.includes(req.user.role_name)) {
+        return res.status(403).json({ message: 'Forbidden' });
+      }
+      next();
+    }
+  }));
+
+  for (const [path, factory] of Object.entries(extraMocks)) {
+    jest.unstable_mockModule(path, factory);
+  }
+
+  const { default: routes } = await import(routeFile);
+  const app = express();
+  app.use(express.json());
+  app.use(prefix, routes);
+  return app;
+};
+
+const validatorMock = () => ({
+  loginValidation: passThroughChain,
+  dashboardAnalyticsValidation: passThroughChain,
+  disciplineFahpValidation: passThroughChain,
+  fuzzyAhpDashboardRecapValidation: passThroughChain,
+  wfaFahpValidation: passThroughChain,
+  validate: passThrough
+});
+
+const securityMock = () => ({
+  loginRateLimit: passThrough
+});
+
+const settingsValidatorMock = () => ({
+  operationalSettingsPatchValidation: passThroughChain
+});
+
+/** One entry per remaining route file. */
+const MODULES = {
+  auth: {
+    routeFile: '../src/routes/auth.routes.js',
+    controllerPath: '../src/controllers/auth.controller.js',
+    controllerExports: ['login', 'refresh', 'logout', 'getCurrentUser'],
+    extraMocks: {
+      '../src/middlewares/validator.js': validatorMock,
+      '../src/middlewares/security.js': securityMock
+    },
+    prefix: '/api/auth'
+  },
+  wfa: {
+    routeFile: '../src/routes/wfa.routes.js',
+    controllerPath: '../src/controllers/wfa.controller.js',
+    controllerExports: ['getWfaRecommendations', 'getWfaAhpConfig', 'testFuzzyAhp'],
+    prefix: '/api/wfa'
+  },
+  summary: {
+    routeFile: '../src/routes/summary.routes.js',
+    controllerPath: '../src/controllers/summary.controller.js',
+    controllerExports: [
+      'getDashboardAnalytics',
+      'getSummaryReport',
+      'getSummaryReportPdf',
+      'getSummaryReportExcel'
+    ],
+    extraMocks: { '../src/middlewares/validator.js': validatorMock },
+    prefix: '/api/summary'
+  },
+  discipline: {
+    routeFile: '../src/routes/discipline.routes.js',
+    controllerPath: '../src/controllers/discipline.controller.js',
+    controllerExports: [
+      'getUserDisciplineIndex',
+      'getAllDisciplineIndices',
+      'getDisciplineConfig',
+      'testDisciplineAhp'
+    ],
+    prefix: '/api/discipline'
+  },
+  analysis: {
+    routeFile: '../src/routes/analysis.routes.js',
+    controllerPath: '../src/controllers/analysis.controller.js',
+    controllerExports: [
+      'getFuzzyAhpAnalysis',
+      'getDisciplineFahp',
+      'getWfaFahp',
+      'getSmartAcFahp',
+      'getFuzzyAhpDashboardRecap'
+    ],
+    extraMocks: { '../src/middlewares/validator.js': validatorMock },
+    prefix: '/api/analysis'
+  },
+  settings: {
+    routeFile: '../src/routes/settings.routes.js',
+    controllerPath: '../src/controllers/settings.controller.js',
+    controllerExports: ['getOperationalSettings', 'patchOperationalSettings'],
+    extraMocks: { '../src/middlewares/settings.validator.js': settingsValidatorMock },
+    prefix: '/api/settings'
+  },
+  referenceData: {
+    routeFile: '../src/routes/referenceData.routes.js',
+    controllerPath: '../src/controllers/referenceData.controller.js',
+    controllerExports: ['getRoles', 'getPrograms', 'getPositions', 'getDivisions'],
+    prefix: '/api'
+  }
+};
+
+const app = (moduleKey, opts = {}) => mountRoute({ ...MODULES[moduleKey], ...opts });
+
+/** [module, method, path, controller] — endpoints restricted to Admin and Management. */
+const PRIVILEGED = [
+  ['summary', 'get', '/api/summary/dashboard-analytics', 'getDashboardAnalytics'],
+  ['summary', 'get', '/api/summary/reports', 'getSummaryReport'],
+  ['summary', 'get', '/api/summary/reports/pdf', 'getSummaryReportPdf'],
+  ['summary', 'get', '/api/summary/reports/excel', 'getSummaryReportExcel'],
+  ['analysis', 'get', '/api/analysis/fuzzy-ahp', 'getFuzzyAhpAnalysis'],
+  ['analysis', 'get', '/api/analysis/fuzzy-ahp/discipline', 'getDisciplineFahp'],
+  ['analysis', 'get', '/api/analysis/fuzzy-ahp/wfa', 'getWfaFahp'],
+  ['analysis', 'get', '/api/analysis/fuzzy-ahp/smart-ac', 'getSmartAcFahp'],
+  ['analysis', 'get', '/api/analysis/fuzzy-ahp/dashboard', 'getFuzzyAhpDashboardRecap'],
+  ['settings', 'get', '/api/settings/operational', 'getOperationalSettings'],
+  ['settings', 'patch', '/api/settings/operational', 'patchOperationalSettings'],
+  ['referenceData', 'get', '/api/roles', 'getRoles'],
+  ['referenceData', 'get', '/api/programs', 'getPrograms'],
+  ['referenceData', 'get', '/api/positions', 'getPositions'],
+  ['referenceData', 'get', '/api/divisions', 'getDivisions'],
+  ['wfa', 'post', '/api/wfa/test-ahp', 'testFuzzyAhp'],
+  ['discipline', 'post', '/api/discipline/test-ahp', 'testDisciplineAhp']
+];
+
+/** Endpoints any authenticated user may reach. */
+const AUTHENTICATED_ONLY = [
+  ['auth', 'get', '/api/auth/me', 'getCurrentUser'],
+  ['wfa', 'get', '/api/wfa/recommendations', 'getWfaRecommendations'],
+  ['wfa', 'get', '/api/wfa/ahp-config', 'getWfaAhpConfig'],
+  ['discipline', 'get', '/api/discipline/user/9', 'getUserDisciplineIndex'],
+  ['discipline', 'get', '/api/discipline/all', 'getAllDisciplineIndices'],
+  ['discipline', 'get', '/api/discipline/config', 'getDisciplineConfig']
+];
+
+/** Endpoints deliberately reachable without any token. */
+const PUBLIC = [
+  ['auth', 'post', '/api/auth/login', 'login'],
+  ['auth', 'post', '/api/auth/refresh', 'refresh'],
+  ['auth', 'post', '/api/auth/logout', 'logout']
+];
+
+describe('privileged routes', () => {
+  test.each(PRIVILEGED)('%s: %s %s reaches its controller for an Admin', async (
+    mod,
+    method,
+    path,
+    route
+  ) => {
+    const server = await app(mod, { role: 'Admin' });
+    await request(server)[method](path).send({}).expect(200, { route });
+  });
+
+  test.each(PRIVILEGED)('%s: %s %s reaches its controller for Management', async (
+    mod,
+    method,
+    path,
+    route
+  ) => {
+    const server = await app(mod, { role: 'Management' });
+    await request(server)[method](path).send({}).expect(200, { route });
+  });
+
+  test.each(PRIVILEGED)('%s: %s %s is refused for a plain User', async (mod, method, path) => {
+    const server = await app(mod, { role: 'User' });
+    await request(server)[method](path).send({}).expect(403);
+  });
+});
+
+describe('authenticated-only routes', () => {
+  test.each(AUTHENTICATED_ONLY)('%s: %s %s reaches its controller for a plain User', async (
+    mod,
+    method,
+    path,
+    route
+  ) => {
+    const server = await app(mod, { role: 'User' });
+    await request(server)[method](path).send({}).expect(200, { route });
+  });
+});
+
+describe('unauthenticated access', () => {
+  const reject401 = (req, res) => res.status(401).json({ success: false, message: 'Unauthorized' });
+
+  test.each([...PRIVILEGED, ...AUTHENTICATED_ONLY])(
+    '%s: %s %s is refused without a token',
+    async (mod, method, path) => {
+      const server = await app(mod, { verifyTokenImpl: reject401 });
+      await request(server)[method](path).send({}).expect(401);
+    }
+  );
+
+  test.each(PUBLIC)('%s: %s %s stays reachable without a token', async (
+    mod,
+    method,
+    path,
+    route
+  ) => {
+    const server = await app(mod, { verifyTokenImpl: reject401 });
+    await request(server)[method](path).send({}).expect(200, { route });
+  });
+});
+
+describe('discipline authorization is enforced in the controller, not the route', () => {
+  /**
+   * Documented as F10. Three of the four /api/discipline routes carry no
+   * roleGuard, so a plain User reaches the handler and is refused inside it
+   * (discipline.controller.js:26-30, 163, 307). Only test-ahp uses middleware.
+   *
+   * Authorization is not missing -- it is enforced in two different places
+   * depending on the route. The migrated module should move it to the route.
+   */
+  test.each([
+    ['/api/discipline/user/9', 'getUserDisciplineIndex'],
+    ['/api/discipline/all', 'getAllDisciplineIndices'],
+    ['/api/discipline/config', 'getDisciplineConfig']
+  ])('%s reaches the controller even for a plain User', async (path, route) => {
+    const server = await app('discipline', { role: 'User' });
+    await request(server).get(path).expect(200, { route });
+  });
+
+  it('guards only test-ahp at the route layer', async () => {
+    const server = await app('discipline', { role: 'User' });
+    await request(server).post('/api/discipline/test-ahp').send({}).expect(403);
+  });
+});


### PR DESCRIPTION
Continues [INF-252](https://linear.app/infinite-track-palu/issue/INF-252/backendarchitecture-adopt-modular-mvc-per-feature-with-safe) Phase 0b. **Tests and documentation only — zero production code changes.**

## What this completes

Three prefixes were already covered — `/api/users`, `/api/attendance`, `/api/bookings`. This adds the remaining **seven route files** in 87 table-driven tests: auth, wfa, summary, discipline, analysis, settings, reference data.

**Every one of the 60 route-file endpoints now has its middleware chain pinned.** Who may reach a handler is the property most likely to drift silently when routes move into feature modules; changing any of it now fails a test.

| Endpoint class | Count | Asserted |
|---|---|---|
| Privileged | 17 | 200 for Admin, 200 for Management, 403 for a plain User |
| Authenticated-only | 6 | reachable by a plain User |
| Both of the above | 23 | 401 without a token |
| Public auth endpoints | 3 | still reachable without a token |

## F10 is now executable, not prose

Three of the four `/api/discipline` routes carry **no `roleGuard`** and enforce authorization inside the controller body instead (`discipline.controller.js:26-30, 163, 307`). Only `test-ahp` guards at the route layer.

The tests prove both halves: a plain User **reaches** those three handlers, and **is refused** at `test-ahp`. Authorization is correct in both cases, but it lives in two different places depending on the route — which the migrated module should unify onto the route, per ADR-009.

That asymmetry was previously a sentence in a document. It is now a failing test if anyone changes it.

## Also closes

The two gaps left open by #101: route-level RBAC for `/api/wfa`, and PATCH-specific RBAC for `/api/settings/operational`.

## Cost worth knowing

Suite wall time goes from ~12s to ~18.7s. The 87 tests each call `jest.resetModules()` and remount an Express app, which is what makes them independent. If that becomes annoying, the fix is to share app instances per role rather than per test — but that trades isolation for speed, so it is not done pre-emptively.

## Verification

```
npm run lint    clean
npm test        101 suites / 819 tests passing  (732 on develop + 87)
git diff --stat develop..HEAD -- src/    (no output)
```

## Review focus

1. The tests assert against a **mocked** `roleGuard` that re-implements the real one's contract. That proves each route declares the right allowed-roles list, not that `roleGuard` itself is correct — the latter is covered separately by the auth middleware tests. Is that split clear enough?
2. Is ~6s of added suite time acceptable for this coverage?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API contract coverage and status information across workforce, discipline, settings, and reference-data endpoints.
  * Clarified that authorization coverage is complete across the API.
  * Refined the list of remaining coverage gaps to focus on response payloads.

* **Tests**
  * Added comprehensive authorization checks for privileged, authenticated, and public routes.
  * Verified expected access behavior for different roles, missing tokens, and discipline endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->