### PR TITLE
test(INF-252): guard controller export reachability, correct F7 a second time

### DIFF
--- a/docs/architecture/api-contract-inventory.md
+++ b/docs/architecture/api-contract-inventory.md
@@ -291,9 +291,9 @@ Recorded, deliberately **not fixed** under INF-252. Each needs its own issue.
 | F4 | `contribution.routes.js` is entirely commented out and unmounted — dead file | `src/routes/contribution.routes.js` |
 | F5 | Error `code` is exposed only when status < 500 or the code is allowlisted; `E_INVALID_REFERENCE_STATE` has its extra fields copied one by one | `src/middlewares/errorHandler.js:72-96` |
 | F6 | CI pins Node 18; local development observed on Node v24.16.0 | `.github/workflows/ci.yml:10` |
-| **F7** | **Six 5xx responses across two files return `error: error.message` directly instead of calling `next(err)`. These bypass the global handler, so the production 500-masking in `errorHandler.js:66-70` never applies — internal error text can reach clients in production.** | `attendance.controller.js:153,656,1101,2288`; `user.controller.js:50,69` |
-| F7b | Three responses embed `error.message` inside a **200** body rather than a 5xx: a per-user `error` field in the discipline list, a `scoring_details.breakdown.error` in WFA recommendations, and the Admin-only FAHP diagnostic results. Not a masking bypass, but still client-visible internal error text | `discipline.controller.js:250`, `wfa.controller.js:204,551` |
-| F8 | Four responses use a bare `{ message }` envelope with no `success` flag, breaking the dominant convention | `src/controllers/user.controller.js:45,50,59,69` |
+| **F7** | **Three reachable 5xx responses return `error: error.message` directly instead of calling `next(err)`. These bypass the global handler, so the production 500-masking in `errorHandler.js:66-70` never applies — internal error text can reach clients in production.** | `attendance.controller.js:153` (`testWeightedPrediction`), `:656` (`getAttendanceHistory`), `:1101` (`debugCheckInTime`) |
+| F7b | Two reachable responses embed `error.message` inside a **200** body rather than a 5xx: a per-user `error` field in the discipline list, and `scoring_details.breakdown.error` in WFA recommendations. Not a masking bypass, but still client-visible internal error text | `discipline.controller.js:250`, `wfa.controller.js:204` |
+| F8 | Four responses use a bare `{ message }` envelope with no `success` flag, breaking the dominant convention. **All four are inside `getProfile` and `updateProfile`, which are unreachable — see F19.** No live endpoint emits this shape | `src/controllers/user.controller.js:45,50,59,69` |
 | F9 | `wfa.controller.js` imports `../models/settings.model.js` directly, bypassing `models/index.js` where associations are registered | `src/controllers/wfa.controller.js` |
 | F10 | Authorization for `/api/discipline` lives in the controller body for three routes and in `roleGuard` middleware for the fourth. Enforced correctly in both cases, but inconsistently located | `src/controllers/discipline.controller.js:26-30,163,307` |
 | F11 | `DELETE /api/attendance/:id` applies `verifyToken` a second time, though `router.use(verifyToken)` already covers it | `src/routes/attendance.routes.js` |
@@ -301,6 +301,21 @@ Recorded, deliberately **not fixed** under INF-252. Each needs its own issue.
 | F15 | Nine `console.log` calls sit in the `checkOut` final-state mutation path, printing raw attendance rows. They bypass the winston logger used everywhere else, so they carry no request ID and no structured format | `src/controllers/attendance.controller.js:1503-1508,1525-1529` |
 | **F16** | **The `EARLY` check-in status is unreachable.** The working-hours gate returns 400 when `currentTimeMinutes < checkinStartMinutes`, and the classifier below tests that identical condition to assign `status_id: 4` / `EARLY`. Nothing can satisfy the second test after passing the first, so `status_id 4` can never be produced by check-in | `attendance.controller.js:757` vs `:918-921` |
 | F18 | `debugGeoapifyApi` is exported from `wfa.controller.js` but imported nowhere and mounted on no route — roughly 127 lines of dead code in a 586-line controller. It also calls Geoapify directly, so it duplicates the integration logic that Phase 4 is meant to consolidate | `src/controllers/wfa.controller.js:459-586` |
+| **F19** | **Six controller exports are unreachable** — no route mounts them and no module imports them. One of them, `booking.getMyBookings`, shares its purpose with a use case INF-252 Phase 4 plans to extract | see the audit below |
+
+### F19 — unreachable controller exports
+
+| File | Export | Why it matters |
+|---|---|---|
+| `booking.controller.js` | `getMyBookings` | **Phase 4 lists `ListMyBookings` as a use case to extract.** The live endpoint is `GET /api/bookings/history` → `getBookingHistory`. Extracting the dead function instead would ship an implementation nobody has ever run |
+| `auth.controller.js` | `register` | Self-registration appears to have been withdrawn — users are created through `POST /api/users`, Admin-only — without removing the handler |
+| `user.controller.js` | `getProfile`, `updateProfile` | Contain all four F8 envelope deviations and two of the responses originally counted under F7 |
+| `attendance.controller.js` | `testTimezone` | Contains one more response originally counted under F7 |
+| `wfa.controller.js` | `debugGeoapifyApi` | F18; duplicates the Geoapify integration |
+
+`tests/controllerExportReachability.test.js` pins this set. A **new** unreachable export fails the suite, and removing one of these fails a second assertion so the recorded list has to shrink in the same commit.
+
+These are not deleted here. Removal needs intent confirmed per export — `auth.register` in particular may be a deliberately parked feature rather than an oversight.
 | F17 | `checkIn` derives the weekend/holiday decision from a raw `new Date()` at line 683, while the two lines above it use the explicit Jakarta helpers `getJakartaTime()` and `getJakartaDateString()`. It is correct in production only because `TZ=Asia/Jakarta` is set process-wide in `server.js`; the calendar gate silently depends on process configuration rather than on the timezone contract used by the surrounding code | `src/controllers/attendance.controller.js:682-684,736-737` |
 
 ### F16 — why it matters
@@ -329,18 +344,23 @@ expect(res.status).not.toHaveBeenCalled();
 
 **F7 is the most serious.** It is an information-disclosure risk in production, not merely an architectural inconsistency, and it is invisible to the existing tests because they run with `env: 'test'`. It should be raised as its own issue rather than absorbed into a migration PR — see [INF-253](https://linear.app/infinite-track-palu/issue/INF-253/backendsecurity-controller-responses-bypass-production-error-masking).
 
-### F7 — corrected count
+### F7 — corrected twice
 
-The first published version of this finding claimed *"13 responses across 7 files"*. That was wrong, and the error was methodological: the count came from `grep -rnE "error:\s*(error|err)\.message"`, which matches the pattern **anywhere in a file**, including inside `logger.error(...)` calls that never reach `res.json`.
+This finding has been wrong twice. Both errors came from classifying by pattern match rather than by what a client can actually receive.
 
-Reclassifying all 13 occurrences by whether they reach the client:
+**First version:** *"13 responses across 7 files"*, from `grep -rnE "error:\s*(error|err)\.message"`. That matches the pattern **anywhere in a file**, including inside `logger.error(...)` calls. Caught in review of PR #96.
+
+**Second version:** *"6 responses across 2 files"*, after separating responses from logger metadata. Still wrong, because it never checked whether the enclosing function is **reachable**. Three of those six sit in exports that no route mounts.
+
+Final classification of all 13 occurrences:
 
 | Category | Count | Locations |
 |---|---|---|
-| **5xx response — bypasses production masking (F7)** | 6 | `attendance.controller.js:153,656,1101,2288`; `user.controller.js:50,69` |
-| 200 response — client-visible but not a masking bypass (F7b) | 3 | `discipline.controller.js:250`; `wfa.controller.js:204,551` |
+| **Reachable 5xx response — bypasses production masking (F7)** | **3** | `attendance.controller.js:153` (`testWeightedPrediction`), `:656` (`getAttendanceHistory`), `:1101` (`debugCheckInTime`) |
+| Reachable 200 response — client-visible, not a masking bypass (F7b) | 2 | `discipline.controller.js:250` (`getAllDisciplineIndices`), `wfa.controller.js:204` (`getWfaRecommendations`) |
+| **Inside unreachable exports — cannot be triggered** | 4 | `attendance.controller.js:2288` (`testTimezone`), `user.controller.js:50,69` (`getProfile`, `updateProfile`), `wfa.controller.js:551` (`debugGeoapifyApi`) |
 | Logger metadata — never reaches the client | 4 | `analysis.controller.js:79`; `attendance.controller.js:1616`; `auth.controller.js:165`; `health.controller.js:46` |
 
-`auth.controller.js` and `health.controller.js` were implicated by the original count and should **not** have been: both occurrences are structured-logging fields. The security remediation scope is six responses in two files, not thirteen across seven.
+**The security remediation scope is three responses in one file.** `user.controller.js`, `auth.controller.js` and `health.controller.js` were all implicated at some point and none of them belong.
 
-Credit: caught in review of PR #96.
+The lesson generalizes beyond this finding: **a grep hit is not a contract fact.** Both a call-site check and a reachability check are needed before a pattern count means anything. That is what F19 and `tests/controllerExportReachability.test.js` now enforce.

--- a/tests/controllerExportReachability.test.js
+++ b/tests/controllerExportReachability.test.js
@@ -1,0 +1,104 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Guards against dead controller exports (INF-252 Phase 0b).
+ *
+ * A controller export that no route mounts and no module imports is code that
+ * still gets carried into a feature module during migration, reviewed as if it
+ * were live, and maintained forever. Three concrete problems came out of the
+ * audit that produced this test:
+ *
+ *   - booking.getMyBookings is dead, yet INF-252 Phase 4 lists "ListMyBookings"
+ *     as a use case to extract. The live endpoint is /api/bookings/history via
+ *     getBookingHistory. Extracting the dead one would have shipped an
+ *     implementation nobody has ever run.
+ *   - Two of the responses originally counted under finding F7 turned out to
+ *     live in dead functions, so the security remediation scope was smaller
+ *     than reported.
+ *   - auth.register suggests self-registration was withdrawn without removing
+ *     the handler.
+ *
+ * This test does not demand the dead exports be deleted -- that needs intent
+ * confirmed. It pins the known set so a NEW one cannot appear unnoticed, and
+ * so the list shrinks visibly as they are removed.
+ */
+
+const CONTROLLER_DIR = path.join(process.cwd(), 'src', 'controllers');
+const SRC_DIR = path.join(process.cwd(), 'src');
+
+/**
+ * Known unreachable exports as of 2026-07-26. Recorded as finding F19.
+ * Remove entries here when the corresponding export is deleted.
+ */
+const KNOWN_UNREACHABLE = [
+  'attendance.controller.js::testTimezone',
+  'auth.controller.js::register',
+  'booking.controller.js::getMyBookings',
+  'user.controller.js::getProfile',
+  'user.controller.js::updateProfile',
+  'wfa.controller.js::debugGeoapifyApi'
+];
+
+const collectJsFiles = (dir) => {
+  const out = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...collectJsFiles(full));
+    else if (entry.name.endsWith('.js') || entry.name.endsWith('.cjs')) out.push(full);
+  }
+  return out;
+};
+
+const findUnreachableExports = () => {
+  const controllerFiles = readdirSync(CONTROLLER_DIR).filter((f) => f.endsWith('.controller.js'));
+  const allSources = collectJsFiles(SRC_DIR).map((file) => ({
+    file,
+    text: readFileSync(file, 'utf8')
+  }));
+
+  const unreachable = [];
+
+  for (const controllerFile of controllerFiles) {
+    const controllerPath = path.join(CONTROLLER_DIR, controllerFile);
+    const text = readFileSync(controllerPath, 'utf8');
+    const exportNames = [...text.matchAll(/^export const ([a-zA-Z_$][\w$]*)/gm)].map((m) => m[1]);
+
+    for (const name of exportNames) {
+      const referencedElsewhere = allSources.some(
+        ({ file, text: body }) =>
+          file !== controllerPath && new RegExp(`\\b${name}\\b`).test(body)
+      );
+      if (!referencedElsewhere) {
+        unreachable.push(`${controllerFile}::${name}`);
+      }
+    }
+  }
+
+  return unreachable.sort();
+};
+
+describe('controller export reachability', () => {
+  it('has no unreachable export beyond the recorded set', () => {
+    const unreachable = findUnreachableExports();
+    const unexpected = unreachable.filter((entry) => !KNOWN_UNREACHABLE.includes(entry));
+
+    expect(unexpected).toEqual([]);
+  });
+
+  it('still lists every recorded dead export, so the list shrinks visibly when one is removed', () => {
+    const unreachable = findUnreachableExports();
+    const alreadyRemoved = KNOWN_UNREACHABLE.filter((entry) => !unreachable.includes(entry));
+
+    // If this fails, a dead export was deleted -- good. Drop it from
+    // KNOWN_UNREACHABLE in the same commit.
+    expect(alreadyRemoved).toEqual([]);
+  });
+
+  it('confirms the live bookings listing is getBookingHistory, not getMyBookings', () => {
+    const routes = readFileSync(path.join(SRC_DIR, 'routes', 'booking.routes.js'), 'utf8');
+
+    expect(routes).toContain('getBookingHistory');
+    expect(routes).not.toContain('getMyBookings');
+  });
+});


### PR DESCRIPTION
Continues [INF-252](https://linear.app/infinite-track-palu/issue/INF-252/backendarchitecture-adopt-modular-mvc-per-feature-with-safe) Phase 0b. **Tests and documentation only — zero production code changes.**

> Branch name says `users-controller-payloads`; the work turned into a reachability audit when the first thing I looked at in `user.controller.js` turned out to be dead. Users payloads are the next slice.

## The finding that matters

An audit of every controller export found **six that no route mounts and no module imports**.

| File | Export |
|---|---|
| `booking.controller.js` | `getMyBookings` |
| `auth.controller.js` | `register` |
| `user.controller.js` | `getProfile`, `updateProfile` |
| `attendance.controller.js` | `testTimezone` |
| `wfa.controller.js` | `debugGeoapifyApi` |

**`booking.getMyBookings` is the consequential one.** INF-252 Phase 4 explicitly lists `ListMyBookings` as a use case to extract. The live endpoint is `GET /api/bookings/history` → `getBookingHistory`. Without this audit, Phase 4 could have extracted an implementation **nobody has ever run**, reviewed it as if it were live, and carried it into the new module.

`auth.register` suggests self-registration was withdrawn in favour of Admin-only `POST /api/users` without removing the handler.

## F7 is corrected a second time — 6 → 3

I got this wrong twice, both times by classifying on pattern matches instead of on what a client can actually receive.

| Version | Claim | Why it was wrong |
|---|---|---|
| First | 13 responses across 7 files | The grep matched `logger.error(...)` metadata as well as responses. Caught in review of #96 |
| Second | 6 responses across 2 files | Never checked **reachability**. Three of the six sit in dead exports |
| **Final** | **3 responses in 1 file** | `attendance.controller.js:153, 656, 1101` |

`user.controller.js`, `auth.controller.js` and `health.controller.js` were each implicated at some point. **None of them belong.**

F8 is affected the same way: all four bare-`{ message }` envelope deviations live in `getProfile`/`updateProfile`, so no live endpoint emits that shape.

[INF-253](https://linear.app/infinite-track-palu/issue/INF-253/backendsecurity-controller-responses-bypass-production-error-masking) has been updated to the corrected scope.

The lesson generalises, and is why this PR ships a test rather than just a corrected document: **a grep hit is not a contract fact.** Both a call-site check and a reachability check are needed before a pattern count means anything.

## What the test does

`tests/controllerExportReachability.test.js` walks `src/`, resolves every `export const` in every controller, and checks whether anything outside that file references it.

- A **new** unreachable export fails the suite.
- **Removing** a recorded one fails a second assertion, so the allowlist has to shrink in the same commit — it cannot rot into a permanent list of excuses.
- A third assertion pins that bookings listing is `getBookingHistory` and *not* `getMyBookings`, so the Phase 4 trap cannot be re-set.

## Nothing is deleted

Removal needs intent confirmed per export. `auth.register` in particular may be a parked feature rather than an oversight — that is a product call, not a cleanup.

## Verification

```
npm run lint    clean
npm test        102 suites / 822 tests passing  (819 on develop + 3)
git diff --stat develop..HEAD -- src/    (no output)
```

## Review focus

1. Is `auth.register` parked deliberately, or safe to delete?
2. Should the six dead exports be removed now, or tracked as their own cleanup issue?

🤖 Generated with [Claude Code](https://claude.com/claude-code)