### PR TITLE
test(INF-252): pin the Users read and delete payloads

### DIFF
--- a/docs/architecture/api-contract-inventory.md
+++ b/docs/architecture/api-contract-inventory.md
@@ -66,12 +66,18 @@ The body form is what mobile clients use. Recording only the cookie would let an
 
 | Method | Path | Roles | Request | Error codes | Happy | RBAC | Validation |
 |---|---|---|---|---|---|---|---|
-| GET | `/api/users` | Admin, Management | query: page, limit, search | 401, 403 | route-only | covered | n/a |
-| GET | `/api/users/:id` | Admin, Management | param: id | 401, 403, 404 | route-only | covered | n/a |
+| GET | `/api/users` | Admin, Management | query: `search`, `sortBy`, `sortOrder` — **no pagination** | 401, 403 | covered | covered | n/a |
+| GET | `/api/users/:id` | Admin, Management | param: id | 401, 403, 404 `E_NOT_FOUND` | covered | covered | n/a |
 | POST | `/api/users` | Admin, Management | multipart + body | 400, 401, 403 | route-only | covered | covered |
 | POST | `/api/users/:id/photo` | Admin, Management | multipart `face_photo` | 400, 404, `E_UPLOAD` | covered | covered | covered |
 | PATCH | `/api/users/:id` | Admin, Management | body | 400, 404, `E_VALIDATION_NIP_EXISTS`, `E_VALIDATION_EMAIL_EXISTS` | route-only | covered | covered |
-| DELETE | `/api/users/:id` | Admin | param: id | 401, 403, 404 | route-only | covered | n/a |
+| DELETE | `/api/users/:id` | Admin | param: id | 401, 403, 404 (no code) | covered | covered | n/a |
+
+**Request-shape correction.** An earlier version of this table recorded `GET /api/users` as accepting `page` and `limit`. It does not. It accepts `search`, `sortBy` (default `created_at`) and `sortOrder` (default `DESC`), and returns every non-deleted user in one response — see F20.
+
+**Payloads pinned 2026-07-26** by `tests/usersPayloadContract.test.js` (16 tests): the 15-field mapped user shape shared by list and detail, string-to-number coercion of the location numerics, `null` for every absent association, the `'Work From Home'` category default, the `deleted_at: null` filter, the search predicate covering `full_name` and `nip_nim` only, and the delete semantics.
+
+`createUser` and `updateUser` remain `route-only`: both run DigitalOcean Spaces uploads and transaction orchestration, and deserve their own slice.
 
 **Updated 2026-07-26 — `tests/usersRouteContract.test.js` added (14 tests).**
 
@@ -255,7 +261,8 @@ Baseline as measured on 2026-07-26, before any Phase 0b work:
 | Attendance — `check-in` controller behavior | **done** | `tests/attendanceCheckinContract.test.js`, 17 tests |
 | WFA — 3 endpoints, controller behavior | **done** | `tests/wfaControllerContract.test.js`, 22 tests |
 | **Authorization matrix — every remaining route file** | **done** | `tests/routeAuthorizationMatrix.test.js`, 87 tests |
-| Users — controller response bodies | open | needs model-level mocking |
+| Users — read and delete payloads | **done** | `tests/usersPayloadContract.test.js`, 16 tests |
+| Users — `createUser` / `updateUser` | open | Spaces uploads plus transaction orchestration |
 | `DELETE /api/attendance/:id` — controller behavior | open | destructive; routing and authorization pinned |
 
 **The authorization axis is now closed for the entire API.** Every one of the 60 route-file endpoints has its middleware chain pinned: `/api/users` by `usersRouteContract`, `/api/attendance` by `attendanceRouteContract`, `/api/bookings` by `bookingsReadinessContract`, and the remaining seven route files by `routeAuthorizationMatrix`.
@@ -272,7 +279,7 @@ That closes the RBAC axis for the whole module, including all nine operational t
 
 Remaining gaps, in order — all are **controller response bodies**, since routing and authorization are fully pinned:
 
-1. Users list and detail payloads — pagination metadata, mapped user shape, 404 for a missing `:id`.
+1. `createUser` and `updateUser` — the two Users mutations, both involving Spaces uploads and transactions.
 2. `DELETE /api/attendance/:id` — destructive, and the only remaining untested attendance mutation.
 3. `/api/discipline` response payloads for three of four endpoints.
 4. Reference-data dropdown payloads — lowest risk in the codebase.
@@ -301,6 +308,10 @@ Recorded, deliberately **not fixed** under INF-252. Each needs its own issue.
 | F15 | Nine `console.log` calls sit in the `checkOut` final-state mutation path, printing raw attendance rows. They bypass the winston logger used everywhere else, so they carry no request ID and no structured format | `src/controllers/attendance.controller.js:1503-1508,1525-1529` |
 | **F16** | **The `EARLY` check-in status is unreachable.** The working-hours gate returns 400 when `currentTimeMinutes < checkinStartMinutes`, and the classifier below tests that identical condition to assign `status_id: 4` / `EARLY`. Nothing can satisfy the second test after passing the first, so `status_id 4` can never be produced by check-in | `attendance.controller.js:757` vs `:918-921` |
 | F18 | `debugGeoapifyApi` is exported from `wfa.controller.js` but imported nowhere and mounted on no route — roughly 127 lines of dead code in a 586-line controller. It also calls Geoapify directly, so it duplicates the integration logic that Phase 4 is meant to consolidate | `src/controllers/wfa.controller.js:459-586` |
+| **F20** | **`GET /api/users` has no pagination.** It returns every non-deleted user in a single response, with no `limit` or `offset`. The endpoint accepts `search`, `sortBy` and `sortOrder` only — `page` and `limit` are ignored if sent. This is the scalability problem [INF-250](https://linear.app/infinite-track-palu/issue/INF-250/cross-repo-define-scalable-user-directory-search-filter-sort-and) exists to address, and Phase 2's allowlisted list-query foundation is where it gets fixed | `src/controllers/user.controller.js:95-140` |
+| F21 | `getUserById` returns 404 with `code: 'E_NOT_FOUND'`; `deleteUser` returns 404 for the same condition **without** any code. Two shapes for one meaning, within one module | `user.controller.js:786-790` vs `:481-485` |
+| F22 | `getUserById` excludes soft-deleted rows inside the query (`findOne` with `deleted_at: null`), while `deleteUser` fetches by primary key and inspects `deleted_at` afterwards. Two approaches to the same concern in one file; the extracted repository should settle on one | `user.controller.js:735-739` vs `:479-493` |
+| F23 | `DELETE /api/users/:id` is **not idempotent from the client's view**: deleting an already soft-deleted user returns 404 rather than confirming the desired end state | `user.controller.js:488-493` |
 | **F19** | **Six controller exports are unreachable** — no route mounts them and no module imports them. One of them, `booking.getMyBookings`, shares its purpose with a use case INF-252 Phase 4 plans to extract | see the audit below |
 
 ### F19 — unreachable controller exports

--- a/tests/usersPayloadContract.test.js
+++ b/tests/usersPayloadContract.test.js
@@ -1,0 +1,370 @@
+import { jest } from '@jest/globals';
+
+/**
+ * Characterization coverage for the Users read and delete payloads
+ * (INF-252 Phase 0b).
+ *
+ * usersRouteContract.test.js pins the middleware chain and the validation
+ * rules. This file pins what the controllers themselves return -- the mapped
+ * user shape, the soft-delete filter, the search predicate, and the 404
+ * semantics. Users is the first module scheduled for extraction in Phase 3,
+ * so these are the payloads the migration has to preserve exactly.
+ *
+ * createUser and updateUser are deliberately out of scope here: both go
+ * through DigitalOcean Spaces uploads and transaction orchestration and
+ * deserve their own slice.
+ */
+
+const buildRes = () => {
+  const res = {};
+  res.status = jest.fn(() => res);
+  res.json = jest.fn(() => res);
+  return res;
+};
+
+/** A Sequelize-shaped row with every association populated. */
+const fullUserRow = (overrides = {}) => ({
+  id_users: 7,
+  full_name: 'Nadia Putri',
+  email: 'nadia@example.com',
+  nip_nim: 'A12345',
+  phone: '081234567890',
+  role: { role_name: 'User' },
+  position: { position_name: 'Backend Engineer' },
+  program: { program_name: 'Internship' },
+  division: { division_name: 'Engineering' },
+  photo_file: { photo_url: 'https://cdn.example/nadia.jpg', photo_updated_at: '2026-07-01' },
+  wfh_location: {
+    location_id: 12,
+    latitude: '-0.8917',
+    longitude: '119.8707',
+    radius: '150',
+    description: 'Rumah Nadia',
+    attendance_category: { category_name: 'Work From Home' }
+  },
+  ...overrides
+});
+
+/**
+ * getUserById queries with findOne (filtering deleted_at in the where clause)
+ * while deleteUser uses findByPk and checks deleted_at afterwards. The helper
+ * exposes both so each test targets the right one.
+ */
+const loadUsers = async ({ findAll = [], findByPk = null, findOne = null, destroy } = {}) => {
+  jest.resetModules();
+
+  const userFindAll = jest.fn().mockResolvedValue(findAll);
+  const userFindByPk = jest.fn().mockResolvedValue(findByPk);
+  const userFindOne = jest.fn().mockResolvedValue(findOne);
+
+  jest.unstable_mockModule('../src/models/index.js', () => ({
+    User: { findAll: userFindAll, findByPk: userFindByPk, findOne: userFindOne, create: jest.fn() },
+    Role: {},
+    Program: {},
+    Position: {},
+    Division: {},
+    Photo: { create: jest.fn(), findByPk: jest.fn() },
+    Location: { create: jest.fn(), findOne: jest.fn() },
+    AttendanceCategory: {},
+    sequelize: { transaction: jest.fn().mockResolvedValue({ commit: jest.fn(), rollback: jest.fn() }) }
+  }));
+
+  jest.unstable_mockModule('../src/utils/logger.js', () => ({
+    default: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() }
+  }));
+
+  jest.unstable_mockModule('../src/config/spaces.js', () => ({
+    buildUserProfilePhotoKey: jest.fn(() => 'users/7/photo.jpg'),
+    uploadBufferToSpaces: jest.fn(async () => ({ key: 'users/7/photo.jpg', url: 'https://cdn' })),
+    deleteSpacesObject: jest.fn()
+  }));
+
+  const mod = await import('../src/controllers/user.controller.js');
+  return { ...mod, userFindAll, userFindByPk, userFindOne, destroy };
+};
+
+const expectedMappedUser = {
+  id: 7,
+  full_name: 'Nadia Putri',
+  email: 'nadia@example.com',
+  role_name: 'User',
+  position_name: 'Backend Engineer',
+  program_name: 'Internship',
+  division_name: 'Engineering',
+  nip_nim: 'A12345',
+  phone: '081234567890',
+  photo: 'https://cdn.example/nadia.jpg',
+  photo_updated_at: '2026-07-01',
+  location: {
+    location_id: 12,
+    latitude: -0.8917,
+    longitude: 119.8707,
+    radius: 150,
+    description: 'Rumah Nadia',
+    category_name: 'Work From Home'
+  }
+};
+
+describe('getAllUsers payload', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('maps a fully populated row to the documented shape', async () => {
+    const { getAllUsers } = await loadUsers({ findAll: [fullUserRow()] });
+    const res = buildRes();
+
+    await getAllUsers({ query: {}, user: { id: 1 } }, res, jest.fn());
+
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      data: [expectedMappedUser],
+      message: 'Users fetched successfully'
+    });
+  });
+
+  it('coerces the location numerics from strings to numbers', async () => {
+    const { getAllUsers } = await loadUsers({ findAll: [fullUserRow()] });
+    const res = buildRes();
+
+    await getAllUsers({ query: {}, user: { id: 1 } }, res, jest.fn());
+
+    const { location } = res.json.mock.calls[0][0].data[0];
+    expect(typeof location.latitude).toBe('number');
+    expect(typeof location.longitude).toBe('number');
+    expect(typeof location.radius).toBe('number');
+  });
+
+  it('nulls every optional association rather than omitting it', async () => {
+    const bare = fullUserRow({
+      role: null,
+      position: null,
+      program: null,
+      division: null,
+      photo_file: null,
+      wfh_location: null
+    });
+    const { getAllUsers } = await loadUsers({ findAll: [bare] });
+    const res = buildRes();
+
+    await getAllUsers({ query: {}, user: { id: 1 } }, res, jest.fn());
+
+    const row = res.json.mock.calls[0][0].data[0];
+    expect(row).toMatchObject({
+      role_name: null,
+      position_name: null,
+      program_name: null,
+      division_name: null,
+      photo: null,
+      photo_updated_at: null,
+      location: null
+    });
+  });
+
+  it('defaults the location category name when the association is missing', async () => {
+    const row = fullUserRow();
+    row.wfh_location = { ...row.wfh_location, attendance_category: null };
+    const { getAllUsers } = await loadUsers({ findAll: [row] });
+    const res = buildRes();
+
+    await getAllUsers({ query: {}, user: { id: 1 } }, res, jest.fn());
+
+    expect(res.json.mock.calls[0][0].data[0].location.category_name).toBe('Work From Home');
+  });
+
+  it('excludes soft-deleted users through the where clause', async () => {
+    const { getAllUsers, userFindAll } = await loadUsers({ findAll: [] });
+
+    await getAllUsers({ query: {}, user: { id: 1 } }, buildRes(), jest.fn());
+
+    expect(userFindAll).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ deleted_at: null })
+      })
+    );
+  });
+
+  it('searches full_name and nip_nim only', async () => {
+    const { getAllUsers, userFindAll } = await loadUsers({ findAll: [] });
+
+    await getAllUsers({ query: { search: 'nadia' }, user: { id: 1 } }, buildRes(), jest.fn());
+
+    const { where } = userFindAll.mock.calls[0][0];
+    const orClause = Object.getOwnPropertySymbols(where)
+      .map((sym) => where[sym])
+      .find(Array.isArray);
+
+    expect(orClause).toHaveLength(2);
+    const searchedFields = orClause.map((clause) => Object.keys(clause)[0]);
+    expect(searchedFields).toEqual(['full_name', 'nip_nim']);
+  });
+
+  it('returns an empty data array rather than 404 when nothing matches', async () => {
+    const { getAllUsers } = await loadUsers({ findAll: [] });
+    const res = buildRes();
+
+    await getAllUsers({ query: { search: 'zzz' }, user: { id: 1 } }, res, jest.fn());
+
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json.mock.calls[0][0].data).toEqual([]);
+  });
+
+  /**
+   * There is no pagination. getAllUsers returns every non-deleted user in one
+   * response. Recorded as F20 -- it is also what INF-250 exists to address.
+   */
+  it('applies no limit or offset', async () => {
+    const { getAllUsers, userFindAll } = await loadUsers({ findAll: [] });
+
+    await getAllUsers({ query: { page: '2', limit: '10' }, user: { id: 1 } }, buildRes(), jest.fn());
+
+    const options = userFindAll.mock.calls[0][0];
+    expect(options.limit).toBeUndefined();
+    expect(options.offset).toBeUndefined();
+  });
+
+  it('forwards a query failure to the error handler', async () => {
+    jest.resetModules();
+    const boom = new Error('db down');
+    jest.unstable_mockModule('../src/models/index.js', () => ({
+      User: { findAll: jest.fn().mockRejectedValue(boom), findByPk: jest.fn(), findOne: jest.fn() },
+      Role: {},
+      Program: {},
+      Position: {},
+      Division: {},
+      Photo: {},
+      Location: {},
+      AttendanceCategory: {},
+      sequelize: { transaction: jest.fn() }
+    }));
+    jest.unstable_mockModule('../src/utils/logger.js', () => ({
+      default: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() }
+    }));
+    jest.unstable_mockModule('../src/config/spaces.js', () => ({
+      buildUserProfilePhotoKey: jest.fn(),
+      uploadBufferToSpaces: jest.fn(),
+      deleteSpacesObject: jest.fn()
+    }));
+
+    const { getAllUsers } = await import('../src/controllers/user.controller.js');
+    const res = buildRes();
+    const next = jest.fn();
+
+    await getAllUsers({ query: {}, user: { id: 1 } }, res, next);
+
+    expect(next).toHaveBeenCalledWith(boom);
+    expect(res.json).not.toHaveBeenCalled();
+  });
+});
+
+describe('getUserById payload', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns the same mapped shape as the list, unwrapped', async () => {
+    const { getUserById } = await loadUsers({ findOne: fullUserRow() });
+    const res = buildRes();
+
+    await getUserById({ params: { id: '7' }, user: { id: 1 } }, res, jest.fn());
+
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      data: expectedMappedUser,
+      message: 'User details fetched successfully'
+    });
+  });
+
+  it('returns 404 with E_NOT_FOUND when the user does not exist', async () => {
+    const { getUserById } = await loadUsers({ findOne: null });
+    const res = buildRes();
+
+    await getUserById({ params: { id: '999' }, user: { id: 1 } }, res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      code: 'E_NOT_FOUND',
+      message: 'User not found'
+    });
+  });
+
+  /**
+   * getUserById excludes soft-deleted rows in the query itself, whereas
+   * deleteUser fetches by primary key and inspects deleted_at afterwards.
+   * Two approaches to the same concern in one file; the extracted repository
+   * should settle on one. Recorded as F22.
+   */
+  it('filters soft-deleted rows in the query rather than after fetching', async () => {
+    const { getUserById, userFindOne, userFindByPk } = await loadUsers({ findOne: fullUserRow() });
+
+    await getUserById({ params: { id: '7' }, user: { id: 1 } }, buildRes(), jest.fn());
+
+    expect(userFindOne).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ id_users: '7', deleted_at: null })
+      })
+    );
+    expect(userFindByPk).not.toHaveBeenCalled();
+  });
+});
+
+describe('deleteUser semantics', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('soft deletes and confirms', async () => {
+    const row = { ...fullUserRow(), deleted_at: null, destroy: jest.fn().mockResolvedValue() };
+    const { deleteUser } = await loadUsers({ findByPk: row });
+    const res = buildRes();
+
+    await deleteUser({ params: { id: '7' }, user: { id: 1 } }, res, jest.fn());
+
+    expect(row.destroy).toHaveBeenCalledTimes(1);
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      message: 'User soft deleted successfully'
+    });
+  });
+
+  it('returns 404 when the user does not exist', async () => {
+    const { deleteUser } = await loadUsers({ findByPk: null });
+    const res = buildRes();
+
+    await deleteUser({ params: { id: '999' }, user: { id: 1 } }, res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'User not found'
+    });
+  });
+
+  /**
+   * An already soft-deleted user is reported as "not found" rather than as a
+   * conflict, and the row is not destroyed twice. That makes delete
+   * non-idempotent from the client's point of view: the second call fails.
+   */
+  it('treats an already soft-deleted user as not found and does not destroy again', async () => {
+    const row = {
+      ...fullUserRow(),
+      deleted_at: '2026-07-01T00:00:00Z',
+      destroy: jest.fn()
+    };
+    const { deleteUser } = await loadUsers({ findByPk: row });
+    const res = buildRes();
+
+    await deleteUser({ params: { id: '7' }, user: { id: 1 } }, res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(row.destroy).not.toHaveBeenCalled();
+  });
+
+  /**
+   * getUserById's 404 carries code E_NOT_FOUND; deleteUser's does not. Both
+   * describe the same condition. Recorded as F21.
+   */
+  it('omits the error code that getUserById includes for the same condition', async () => {
+    const { deleteUser } = await loadUsers({ findByPk: null });
+    const res = buildRes();
+
+    await deleteUser({ params: { id: '999' }, user: { id: 1 } }, res, jest.fn());
+
+    expect(res.json.mock.calls[0][0]).not.toHaveProperty('code');
+  });
+});


### PR DESCRIPTION
Continues [INF-252](https://linear.app/infinite-track-palu/issue/INF-252/backendarchitecture-adopt-modular-mvc-per-feature-with-safe) Phase 0b. **Tests and documentation only — zero production code changes.**

## Why now

Users is the **first module scheduled for extraction** in Phase 3. `usersRouteContract.test.js` already pins its middleware chain and validation rules; this pins what the controllers actually return — the payloads the migration has to preserve byte for byte.

## What is pinned — 16 tests

The 15-field mapped user shape shared by list and detail, string-to-number coercion of the location numerics, `null` for every absent association rather than an omitted key, the `'Work From Home'` category default, the `deleted_at: null` filter, a search predicate covering `full_name` and `nip_nim` only, empty-result behavior, error forwarding, and the delete semantics.

**Out of scope by design:** `createUser` and `updateUser`. Both run DigitalOcean Spaces uploads and transaction orchestration, and bundling them here would make this PR hard to review.

## Findings — four, none fixed

**F20 — `GET /api/users` has no pagination.** It returns every non-deleted user in a single response. `page` and `limit` are ignored if sent; the endpoint accepts `search`, `sortBy` and `sortOrder`.

This also corrects the inventory, which recorded the request shape as *"page, limit, search"*. That was wrong. This is exactly the scalability problem [INF-250](https://linear.app/infinite-track-palu/issue/INF-250/cross-repo-define-scalable-user-directory-search-filter-sort-and) exists to address, and Phase 2's allowlisted list-query foundation is where it gets fixed — worth knowing before anyone designs that foundation against an assumed-existing pagination contract.

**F21 — two 404 shapes for one meaning.** `getUserById` returns `code: 'E_NOT_FOUND'`; `deleteUser` returns 404 for the same condition with no code at all.

**F22 — two soft-delete approaches in one file.** `getUserById` filters `deleted_at: null` inside the query; `deleteUser` fetches by primary key and inspects `deleted_at` afterwards. The extracted repository should settle on one.

**F23 — delete is not idempotent from the client's view.** Deleting an already soft-deleted user returns 404 rather than confirming the desired end state. Whether that is correct is a product call, so it is recorded rather than changed.

## One thing the tests caught about themselves

The first draft mocked `User.findByPk` for `getUserById` and the test failed with a 404. The controller actually uses `findOne`. That mismatch is precisely F22 — and it is why the helper now exposes both, so each test targets the method its endpoint really calls.

## Verification

```
npm run lint    clean
npm test        103 suites / 838 tests passing  (822 on develop + 16)
git diff --stat develop..HEAD -- src/    (no output)
```

## Review focus

1. F23 — should delete be idempotent? That is a contract decision, not a cleanup.
2. F20 — does any client currently send `page`/`limit` to this endpoint and silently get everything back?

🤖 Generated with [Claude Code](https://claude.com/claude-code)