### PR TITLE
test(INF-252): pin deleteAttendance, the last attendance mutation

### DIFF
--- a/docs/architecture/api-contract-inventory.md
+++ b/docs/architecture/api-contract-inventory.md
@@ -117,7 +117,7 @@ All require `verifyToken`. Roles column shows the additional `roleGuard`.
 | POST | `/research-trigger/daily` | Admin, Management | 400, 409 `E_INVALID_REFERENCE_STATE` | covered | covered | covered |
 | POST | `/research-trigger/full-day` | Admin, Management | 400, 409 `E_INVALID_REFERENCE_STATE` | covered | covered | covered |
 | POST | `/test-weighted-prediction` | Admin, Management | 200 | partial | covered | **gap** |
-| DELETE | `/:id` | Admin, Management | 401, 403, 404 | route-only | covered | **gap** |
+| DELETE | `/:id` | Admin, Management | 401, 403, 404 | covered | covered | n/a |
 | GET | `/smart-config` | Admin, Management | 200 | route-only | covered | n/a |
 | GET | `/enhanced-auto-checkout-settings` | Admin, Management | 200 | route-only | covered | **gap** |
 
@@ -262,8 +262,8 @@ Baseline as measured on 2026-07-26, before any Phase 0b work:
 | WFA — 3 endpoints, controller behavior | **done** | `tests/wfaControllerContract.test.js`, 22 tests |
 | **Authorization matrix — every remaining route file** | **done** | `tests/routeAuthorizationMatrix.test.js`, 87 tests |
 | Users — read and delete payloads | **done** | `tests/usersPayloadContract.test.js`, 16 tests |
+| `DELETE /api/attendance/:id` — controller behavior | **done** | `tests/attendanceDeleteContract.test.js`, 7 tests |
 | Users — `createUser` / `updateUser` | open | Spaces uploads plus transaction orchestration |
-| `DELETE /api/attendance/:id` — controller behavior | open | destructive; routing and authorization pinned |
 
 **The authorization axis is now closed for the entire API.** Every one of the 60 route-file endpoints has its middleware chain pinned: `/api/users` by `usersRouteContract`, `/api/attendance` by `attendanceRouteContract`, `/api/bookings` by `bookingsReadinessContract`, and the remaining seven route files by `routeAuthorizationMatrix`.
 
@@ -280,9 +280,10 @@ That closes the RBAC axis for the whole module, including all nine operational t
 Remaining gaps, in order — all are **controller response bodies**, since routing and authorization are fully pinned:
 
 1. `createUser` and `updateUser` — the two Users mutations, both involving Spaces uploads and transactions.
-2. `DELETE /api/attendance/:id` — destructive, and the only remaining untested attendance mutation.
-3. `/api/discipline` response payloads for three of four endpoints.
-4. Reference-data dropdown payloads — lowest risk in the codebase.
+2. `/api/discipline` response payloads for three of four endpoints.
+3. Reference-data dropdown payloads — lowest risk in the codebase.
+
+**Every attendance mutation is now pinned.** `check-in`, `checkout`, and `delete` were the three ways final attendance state changes through the API; all three have characterization coverage, and each one surfaced a defect while being characterized (F14, F16, F24).
 
 ---
 
@@ -308,11 +309,29 @@ Recorded, deliberately **not fixed** under INF-252. Each needs its own issue.
 | F15 | Nine `console.log` calls sit in the `checkOut` final-state mutation path, printing raw attendance rows. They bypass the winston logger used everywhere else, so they carry no request ID and no structured format | `src/controllers/attendance.controller.js:1503-1508,1525-1529` |
 | **F16** | **The `EARLY` check-in status is unreachable.** The working-hours gate returns 400 when `currentTimeMinutes < checkinStartMinutes`, and the classifier below tests that identical condition to assign `status_id: 4` / `EARLY`. Nothing can satisfy the second test after passing the first, so `status_id 4` can never be produced by check-in | `attendance.controller.js:757` vs `:918-921` |
 | F18 | `debugGeoapifyApi` is exported from `wfa.controller.js` but imported nowhere and mounted on no route — roughly 127 lines of dead code in a 586-line controller. It also calls Geoapify directly, so it duplicates the integration logic that Phase 4 is meant to consolidate | `src/controllers/wfa.controller.js:459-586` |
+| **F24** | **`DELETE /api/attendance/:id` hard-deletes authoritative state, unlogged.** The `Attendance` model declares neither `paranoid` nor a `deleted_at` column, so `destroy()` is an irreversible row deletion. The handler opens no transaction, writes no audit log, applies no ownership or finalized-state guard, and treats a completed record with booked work hours exactly like an open one | `src/controllers/attendance.controller.js:1555-1583`, `src/models/attendance.model.js:84-85` |
 | **F20** | **`GET /api/users` has no pagination.** It returns every non-deleted user in a single response, with no `limit` or `offset`. The endpoint accepts `search`, `sortBy` and `sortOrder` only — `page` and `limit` are ignored if sent. This is the scalability problem [INF-250](https://linear.app/infinite-track-palu/issue/INF-250/cross-repo-define-scalable-user-directory-search-filter-sort-and) exists to address, and Phase 2's allowlisted list-query foundation is where it gets fixed | `src/controllers/user.controller.js:95-140` |
 | F21 | `getUserById` returns 404 with `code: 'E_NOT_FOUND'`; `deleteUser` returns 404 for the same condition **without** any code. Two shapes for one meaning, within one module | `user.controller.js:786-790` vs `:481-485` |
 | F22 | `getUserById` excludes soft-deleted rows inside the query (`findOne` with `deleted_at: null`), while `deleteUser` fetches by primary key and inspects `deleted_at` afterwards. Two approaches to the same concern in one file; the extracted repository should settle on one | `user.controller.js:735-739` vs `:479-493` |
 | F23 | `DELETE /api/users/:id` is **not idempotent from the client's view**: deleting an already soft-deleted user returns 404 rather than confirming the desired end state | `user.controller.js:488-493` |
 | **F19** | **Six controller exports are unreachable** — no route mounts them and no module imports them. One of them, `booking.getMyBookings`, shares its purpose with a use case INF-252 Phase 4 plans to extract | see the audit below |
+
+### F24 — the delete asymmetry
+
+The codebase soft-deletes users and hard-deletes attendance:
+
+| | `User` | `Attendance` |
+|---|---|---|
+| Model | `paranoid: true`, `deletedAt: 'deleted_at'` | no `paranoid`, no `deleted_at` column |
+| `destroy()` | sets `deleted_at`, row recoverable | **irreversible `DELETE`** |
+| Audit log | `logger.info('User {id} soft deleted ... by user {actor}')` | **none** |
+| Transaction | n/a | **none**, unlike `checkIn` and `checkOut` |
+
+Attendance is the record the backend is authoritative for. Deleting one is the most consequential single action in the API, and it is the only mutation that leaves no application-level trace of who performed it.
+
+Whether attendance *should* be soft-deletable is a product decision — there may be a deliberate reason not to keep tombstones in a table that jobs scan nightly. The audit-log gap is harder to defend on those grounds. Both are recorded, neither changed.
+
+`tests/attendanceDeleteContract.test.js` pins current behavior, including the three absences: no transaction, no log, no finalized-state guard.
 
 ### F19 — unreachable controller exports
 

--- a/tests/attendanceDeleteContract.test.js
+++ b/tests/attendanceDeleteContract.test.js
@@ -1,0 +1,202 @@
+import { jest } from '@jest/globals';
+
+/**
+ * Characterization coverage for deleteAttendance (INF-252 Phase 0b).
+ *
+ * This is the last untested attendance mutation, and the most destructive one
+ * in the codebase: the Attendance model declares neither `paranoid` nor a
+ * `deleted_at` column, so `destroy()` is an irreversible DELETE of a row the
+ * backend treats as its authoritative final state.
+ *
+ * The tests below pin that behavior as it exists today, including three things
+ * it does NOT do -- no transaction, no audit log, no guard on finalized
+ * records. Those absences are recorded as F24 rather than fixed here.
+ */
+
+const buildRes = () => {
+  const res = {};
+  res.status = jest.fn(() => res);
+  res.json = jest.fn(() => res);
+  return res;
+};
+
+const loadDeleteAttendance = async ({ record = null } = {}) => {
+  jest.resetModules();
+
+  const transaction = jest.fn();
+  const loggerInfo = jest.fn();
+  const loggerWarn = jest.fn();
+  const findByPk = jest.fn().mockResolvedValue(record);
+
+  jest.unstable_mockModule('../src/config/database.js', () => ({
+    default: { transaction }
+  }));
+
+  jest.unstable_mockModule('../src/models/index.js', () => ({
+    Attendance: { findByPk, findOne: jest.fn(), findAll: jest.fn(), create: jest.fn() },
+    Booking: { findOne: jest.fn() },
+    Location: { findOne: jest.fn() },
+    Settings: { findAll: jest.fn(), findOne: jest.fn() },
+    AttendanceCategory: {},
+    AttendanceStatus: {},
+    BookingStatus: {},
+    User: {},
+    Role: {},
+    LocationEvent: {},
+    Photo: {}
+  }));
+
+  jest.unstable_mockModule('../src/utils/geofence.js', () => ({
+    calculateDistance: jest.fn(() => 0),
+    getJakartaTime: jest.fn(() => new Date()),
+    getJakartaDateString: jest.fn(() => '2026-07-28'),
+    getCurrentTimeForDB: jest.fn(() => new Date()),
+    toJakartaTime: jest.fn((d) => d)
+  }));
+
+  jest.unstable_mockModule('../src/utils/workHourFormatter.js', () => ({
+    calculateWorkHour: jest.fn(() => 0),
+    formatWorkHour: jest.fn(() => '00:00:00'),
+    formatTimeOnly: jest.fn(() => '09:00')
+  }));
+
+  jest.unstable_mockModule('../src/utils/searchHelper.js', () => ({ applySearch: jest.fn() }));
+
+  jest.unstable_mockModule('../src/jobs/autoCheckout.job.js', () => ({
+    triggerAutoCheckout: jest.fn(),
+    runSmartAutoCheckoutForDate: jest.fn()
+  }));
+
+  jest.unstable_mockModule('../src/utils/logger.js', () => ({
+    default: { info: loggerInfo, warn: loggerWarn, error: jest.fn(), debug: jest.fn() }
+  }));
+
+  jest.unstable_mockModule('../src/utils/fuzzyAhpEngine.js', () => ({ default: {} }));
+  jest.unstable_mockModule('../src/analytics/fahp.extent.js', () => ({
+    extentWeightsTFN: jest.fn(() => [0.4, 0.2, 0.2, 0.2])
+  }));
+  jest.unstable_mockModule('../src/analytics/fahp.js', () => ({
+    defuzzifyMatrixTFN: jest.fn(() => []),
+    computeCR: jest.fn(() => ({ CR: 0.05 }))
+  }));
+  jest.unstable_mockModule('../src/analytics/config.fahp.js', () => ({
+    SMART_AC_PAIRWISE_TFN: []
+  }));
+
+  const { deleteAttendance } = await import('../src/controllers/attendance.controller.js');
+  return { deleteAttendance, findByPk, transaction, loggerInfo, loggerWarn };
+};
+
+const req = (id = '10') => ({ params: { id }, user: { id: 1, role_name: 'Admin' } });
+
+describe('deleteAttendance', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns 404 when the record does not exist', async () => {
+    const { deleteAttendance } = await loadDeleteAttendance({ record: null });
+    const res = buildRes();
+
+    await deleteAttendance(req('999'), res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Data absensi tidak ditemukan.'
+    });
+  });
+
+  it('destroys the record and confirms with 200', async () => {
+    const record = { id_attendance: 10, destroy: jest.fn().mockResolvedValue(undefined) };
+    const { deleteAttendance } = await loadDeleteAttendance({ record });
+    const res = buildRes();
+    const next = jest.fn();
+
+    await deleteAttendance(req(), res, next);
+
+    expect(record.destroy).toHaveBeenCalledTimes(1);
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      message: 'Data absensi berhasil dihapus.'
+    });
+  });
+
+  it('looks the record up by primary key only, with no ownership or state filter', async () => {
+    const record = { id_attendance: 10, destroy: jest.fn() };
+    const { deleteAttendance, findByPk } = await loadDeleteAttendance({ record });
+
+    await deleteAttendance(req('10'), buildRes(), jest.fn());
+
+    expect(findByPk).toHaveBeenCalledWith('10');
+  });
+
+  it('forwards a destroy failure to the error handler', async () => {
+    const boom = new Error('fk constraint');
+    const record = { id_attendance: 10, destroy: jest.fn().mockRejectedValue(boom) };
+    const { deleteAttendance } = await loadDeleteAttendance({ record });
+    const res = buildRes();
+    const next = jest.fn();
+
+    await deleteAttendance(req(), res, next);
+
+    expect(next).toHaveBeenCalledWith(boom);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  /**
+   * F24, characterized not fixed.
+   *
+   * checkIn and checkOut both wrap their mutations in a transaction. This one
+   * does not, so the delete is not part of any atomic unit.
+   */
+  it('opens no transaction, unlike every other attendance mutation', async () => {
+    const record = { id_attendance: 10, destroy: jest.fn() };
+    const { deleteAttendance, transaction } = await loadDeleteAttendance({ record });
+
+    await deleteAttendance(req(), buildRes(), jest.fn());
+
+    expect(transaction).not.toHaveBeenCalled();
+  });
+
+  /**
+   * F24, characterized not fixed.
+   *
+   * deleteUser logs who deleted whom. This deletes an authoritative
+   * attendance record and writes nothing at all, so an irreversible change to
+   * final state leaves no application-level trace of who made it.
+   */
+  it('writes no audit log for an irreversible deletion', async () => {
+    const record = { id_attendance: 10, destroy: jest.fn() };
+    const { deleteAttendance, loggerInfo, loggerWarn } = await loadDeleteAttendance({ record });
+
+    await deleteAttendance(req(), buildRes(), jest.fn());
+
+    expect(loggerInfo).not.toHaveBeenCalled();
+    expect(loggerWarn).not.toHaveBeenCalled();
+  });
+
+  /**
+   * F24, characterized not fixed.
+   *
+   * A completed record -- one that has been checked out and has work hours
+   * booked -- is deleted just as readily as an open one. Nothing distinguishes
+   * finalized attendance from in-progress attendance here.
+   */
+  it('deletes a completed record with no additional guard', async () => {
+    const completed = {
+      id_attendance: 10,
+      time_in: '2026-07-28 09:00:00',
+      time_out: '2026-07-28 17:00:00',
+      work_hour: 8,
+      destroy: jest.fn().mockResolvedValue(undefined)
+    };
+    const { deleteAttendance } = await loadDeleteAttendance({ record: completed });
+    const res = buildRes();
+
+    await deleteAttendance(req(), res, jest.fn());
+
+    expect(completed.destroy).toHaveBeenCalledTimes(1);
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+});


### PR DESCRIPTION
Continues [INF-252](https://linear.app/infinite-track-palu/issue/INF-252/backendarchitecture-adopt-modular-mvc-per-feature-with-safe) Phase 0b. **Tests and documentation only — zero production code changes.**

## Milestone

**Every attendance mutation is now characterized.** `check-in`, `checkout` and `delete` are the three ways final attendance state changes through the API — and each one surfaced a defect while being pinned (F14, F16, F24).

## F24 — hard delete of authoritative state, unlogged

The `Attendance` model declares **neither `paranoid` nor a `deleted_at` column**, so `destroy()` here is an irreversible row deletion. The controller comment says so plainly: *"Langkah 4: Lakukan Hard Delete"*.

The asymmetry with users is stark:

| | `User` | `Attendance` |
|---|---|---|
| Model | `paranoid: true`, `deletedAt: 'deleted_at'` | no `paranoid`, no `deleted_at` |
| `destroy()` | sets `deleted_at`, recoverable | **irreversible `DELETE`** |
| Audit log | `logger.info('User {id} soft deleted ... by user {actor}')` | **none** |
| Transaction | n/a | **none**, unlike `checkIn` and `checkOut` |
| Guard on finalized records | n/a | **none** — a completed record with booked work hours deletes like an open one |

Attendance is the record this backend is authoritative for. Deleting one is the most consequential single action in the API, and it is the **only mutation that leaves no application-level trace of who performed it**.

Whether attendance *should* be soft-deletable is a product decision — there may be a deliberate reason not to keep tombstones in a table the nightly jobs scan every night. **The missing audit log is harder to defend on those grounds.** Both are recorded; neither is changed here.

## What the 7 tests pin

404 with its exact message, the destroy-and-confirm path, lookup by primary key with no ownership or state filter, error forwarding — plus the three **absences**, asserted explicitly so they cannot disappear or appear unnoticed:

- no transaction is opened
- no audit log is written
- a completed record is deleted with no additional guard

Asserting an absence is deliberate. If someone later adds a transaction or a log, these tests fail and the change gets discussed rather than slipping in as part of a refactor.

## Verification

```
npm run lint    clean
npm test        104 suites / 845 tests passing  (838 on develop + 7)
git diff --stat develop..HEAD -- src/    (no output)
```

## Review focus

1. Is hard delete deliberate for attendance, or an oversight? That decides whether F24 becomes a schema change or stays as-is.
2. Should the audit log be added regardless of the soft-delete decision? It is the cheaper half and defensible on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)