### PR TITLE
test(INF-252): pin createUser orchestration, find F25

### DIFF
--- a/docs/architecture/api-contract-inventory.md
+++ b/docs/architecture/api-contract-inventory.md
@@ -68,7 +68,7 @@ The body form is what mobile clients use. Recording only the cookie would let an
 |---|---|---|---|---|---|---|---|
 | GET | `/api/users` | Admin, Management | query: `search`, `sortBy`, `sortOrder` — **no pagination** | 401, 403 | covered | covered | n/a |
 | GET | `/api/users/:id` | Admin, Management | param: id | 401, 403, 404 `E_NOT_FOUND` | covered | covered | n/a |
-| POST | `/api/users` | Admin, Management | multipart + body | 400, 401, 403 | route-only | covered | covered |
+| POST | `/api/users` | Admin, Management | multipart + body | 400 `E_UPLOAD`/`E_VALIDATION_EMAIL_EXISTS`/`E_VALIDATION_NIP_EXISTS`, 401, 403 | covered | covered | covered |
 | POST | `/api/users/:id/photo` | Admin, Management | multipart `face_photo` | 400, 404, `E_UPLOAD` | covered | covered | covered |
 | PATCH | `/api/users/:id` | Admin, Management | body | 400, 404, `E_VALIDATION_NIP_EXISTS`, `E_VALIDATION_EMAIL_EXISTS` | route-only | covered | covered |
 | DELETE | `/api/users/:id` | Admin | param: id | 401, 403, 404 (no code) | covered | covered | n/a |
@@ -263,7 +263,8 @@ Baseline as measured on 2026-07-26, before any Phase 0b work:
 | **Authorization matrix — every remaining route file** | **done** | `tests/routeAuthorizationMatrix.test.js`, 87 tests |
 | Users — read and delete payloads | **done** | `tests/usersPayloadContract.test.js`, 16 tests |
 | `DELETE /api/attendance/:id` — controller behavior | **done** | `tests/attendanceDeleteContract.test.js`, 7 tests |
-| Users — `createUser` / `updateUser` | open | Spaces uploads plus transaction orchestration |
+| Users — `createUser` | **done** | `tests/usersCreateContract.test.js`, 11 tests |
+| Users — `updateUser` | open | the last Users mutation |
 
 **The authorization axis is now closed for the entire API.** Every one of the 60 route-file endpoints has its middleware chain pinned: `/api/users` by `usersRouteContract`, `/api/attendance` by `attendanceRouteContract`, `/api/bookings` by `bookingsReadinessContract`, and the remaining seven route files by `routeAuthorizationMatrix`.
 
@@ -279,7 +280,7 @@ That closes the RBAC axis for the whole module, including all nine operational t
 
 Remaining gaps, in order — all are **controller response bodies**, since routing and authorization are fully pinned:
 
-1. `createUser` and `updateUser` — the two Users mutations, both involving Spaces uploads and transactions.
+1. `updateUser` — the last Users mutation.
 2. `/api/discipline` response payloads for three of four endpoints.
 3. Reference-data dropdown payloads — lowest risk in the codebase.
 
@@ -309,12 +310,29 @@ Recorded, deliberately **not fixed** under INF-252. Each needs its own issue.
 | F15 | Nine `console.log` calls sit in the `checkOut` final-state mutation path, printing raw attendance rows. They bypass the winston logger used everywhere else, so they carry no request ID and no structured format | `src/controllers/attendance.controller.js:1503-1508,1525-1529` |
 | **F16** | **The `EARLY` check-in status is unreachable.** The working-hours gate returns 400 when `currentTimeMinutes < checkinStartMinutes`, and the classifier below tests that identical condition to assign `status_id: 4` / `EARLY`. Nothing can satisfy the second test after passing the first, so `status_id 4` can never be produced by check-in | `attendance.controller.js:757` vs `:918-921` |
 | F18 | `debugGeoapifyApi` is exported from `wfa.controller.js` but imported nowhere and mounted on no route — roughly 127 lines of dead code in a 586-line controller. It also calls Geoapify directly, so it duplicates the integration logic that Phase 4 is meant to consolidate | `src/controllers/wfa.controller.js:459-586` |
+| **F25** | **`createUser` repeats the F14 post-commit pattern, with a worse blast radius.** The commit is at line 632, but the refetch, mapping and response all remain inside the same `try`. A post-commit throw reaches a `catch` that unconditionally deletes the uploaded Spaces object **and** rolls back an already-committed transaction. Net result: the user exists in the database, its photo has been deleted from object storage, `next(error)` never runs, and the caller receives no response | `src/controllers/user.controller.js:632-726` |
 | **F24** | **`DELETE /api/attendance/:id` hard-deletes authoritative state, unlogged.** The `Attendance` model declares neither `paranoid` nor a `deleted_at` column, so `destroy()` is an irreversible row deletion. The handler opens no transaction, writes no audit log, applies no ownership or finalized-state guard, and treats a completed record with booked work hours exactly like an open one | `src/controllers/attendance.controller.js:1555-1583`, `src/models/attendance.model.js:84-85` |
 | **F20** | **`GET /api/users` has no pagination.** It returns every non-deleted user in a single response, with no `limit` or `offset`. The endpoint accepts `search`, `sortBy` and `sortOrder` only — `page` and `limit` are ignored if sent. This is the scalability problem [INF-250](https://linear.app/infinite-track-palu/issue/INF-250/cross-repo-define-scalable-user-directory-search-filter-sort-and) exists to address, and Phase 2's allowlisted list-query foundation is where it gets fixed | `src/controllers/user.controller.js:95-140` |
 | F21 | `getUserById` returns 404 with `code: 'E_NOT_FOUND'`; `deleteUser` returns 404 for the same condition **without** any code. Two shapes for one meaning, within one module | `user.controller.js:786-790` vs `:481-485` |
 | F22 | `getUserById` excludes soft-deleted rows inside the query (`findOne` with `deleted_at: null`), while `deleteUser` fetches by primary key and inspects `deleted_at` afterwards. Two approaches to the same concern in one file; the extracted repository should settle on one | `user.controller.js:735-739` vs `:479-493` |
 | F23 | `DELETE /api/users/:id` is **not idempotent from the client's view**: deleting an already soft-deleted user returns 404 rather than confirming the desired end state | `user.controller.js:488-493` |
 | **F19** | **Six controller exports are unreachable** — no route mounts them and no module imports them. One of them, `booking.getMyBookings`, shares its purpose with a use case INF-252 Phase 4 plans to extract | see the audit below |
+
+### F25 — the post-commit pattern is not a one-off
+
+`checkOut` (F14) and `createUser` (F25) share the same shape: `commit()` happens, then more work runs **inside the same `try`**, and the `catch` treats any later failure as if the transaction were still open.
+
+| | `checkOut` (F14) | `createUser` (F25) |
+|---|---|---|
+| Post-commit work inside `try` | refetch, format, respond | refetch, map, respond |
+| `catch` does | `rollback()` | `deleteSpacesObject()` **then** `rollback()` |
+| Consequence | rollback throws, `next(error)` never runs, no response | same — **plus the committed user's photo is deleted from Spaces** |
+
+`createUser` is worse because its compensation is not idempotent with respect to commit state. The Spaces cleanup is correct for a *failed* create and actively destructive for a *successful* one, and nothing distinguishes the two.
+
+`checkIn` shows the codebase already knows the right shape — it tracks `transactionFinished` and only rolls back when the transaction is still open. Two of its three sibling mutations were never updated to match.
+
+Both are pinned by tests that assert the current, broken outcome, so a fix makes them fail deliberately.
 
 ### F24 — the delete asymmetry
 

--- a/tests/usersCreateContract.test.js
+++ b/tests/usersCreateContract.test.js
@@ -1,0 +1,340 @@
+import { jest } from '@jest/globals';
+
+/**
+ * Characterization coverage for createUser (INF-252 Phase 0b).
+ *
+ * This is the most involved mutation in the Users module: it hashes a
+ * password, writes three tables inside one transaction, uploads to
+ * DigitalOcean Spaces -- which is not transactional -- and compensates by
+ * deleting the uploaded object if anything fails.
+ *
+ * Users is the first module scheduled for extraction in Phase 3, and this is
+ * the flow whose orchestration a service layer has to reproduce exactly.
+ */
+
+const buildRes = () => {
+  const res = {};
+  res.status = jest.fn(() => res);
+  res.json = jest.fn(() => res);
+  return res;
+};
+
+const createdUserRow = () => ({
+  id_users: 7,
+  full_name: 'Nadia Putri',
+  email: 'nadia@example.com',
+  nip_nim: 'A12345',
+  phone: '081234567890',
+  role: { role_name: 'User' },
+  position: { position_name: 'Backend Engineer' },
+  program: { program_name: 'Internship' },
+  division: { division_name: 'Engineering' },
+  photo_file: { photo_url: 'https://cdn.example/nadia.jpg', photo_updated_at: '2026-07-01' },
+  wfh_location: {
+    location_id: 12,
+    latitude: '-0.8917',
+    longitude: '119.8707',
+    radius: '150',
+    description: 'Rumah Nadia',
+    attendance_category: { category_name: 'Work From Home' }
+  }
+});
+
+const loadCreateUser = async ({
+  existingEmail = null,
+  existingNip = null,
+  refetched,
+  userCreate,
+  uploadImpl
+} = {}) => {
+  jest.resetModules();
+
+  // Faithful transaction: rolling back after commit throws, as Sequelize does.
+  const txState = { committed: false };
+  const commit = jest.fn().mockImplementation(async () => {
+    txState.committed = true;
+  });
+  const rollback = jest.fn().mockImplementation(async () => {
+    if (txState.committed) {
+      throw new Error('Transaction cannot be rolled back because it has been finished');
+    }
+  });
+
+  const findOne = jest
+    .fn()
+    .mockResolvedValueOnce(existingEmail)
+    .mockResolvedValueOnce(existingNip)
+    .mockResolvedValue(null);
+
+  // The controller calls newUser.update(...) after the photo row exists, to
+  // attach id_photos. A plain object is not enough.
+  const createdInstance = { id_users: 7, update: jest.fn().mockResolvedValue(undefined) };
+  const create = userCreate || jest.fn().mockResolvedValue(createdInstance);
+  const findByPk = jest
+    .fn()
+    .mockResolvedValue(refetched === undefined ? createdUserRow() : refetched);
+
+  const photoCreate = jest.fn().mockResolvedValue({ id_photos: 3 });
+  const locationCreate = jest.fn().mockResolvedValue({ location_id: 12 });
+  const uploadBufferToSpaces =
+    uploadImpl || jest.fn().mockResolvedValue({ key: 'users/7/face.jpg', url: 'https://cdn' });
+  const deleteSpacesObject = jest.fn().mockResolvedValue(undefined);
+  const hash = jest.fn().mockResolvedValue('hashed-password');
+
+  jest.unstable_mockModule('bcryptjs', () => ({ default: { hash } }));
+
+  jest.unstable_mockModule('../src/models/index.js', () => ({
+    User: { findOne, create, findByPk, findAll: jest.fn() },
+    Photo: { create: photoCreate },
+    Location: { create: locationCreate },
+    Role: {},
+    Program: {},
+    Position: {},
+    Division: {},
+    AttendanceCategory: {},
+    sequelize: { transaction: jest.fn().mockResolvedValue({ commit, rollback }) }
+  }));
+
+  jest.unstable_mockModule('../src/utils/logger.js', () => ({
+    default: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() }
+  }));
+
+  jest.unstable_mockModule('../src/config/spaces.js', () => ({
+    buildUserProfilePhotoKey: jest.fn(() => 'users/7/face.jpg'),
+    uploadBufferToSpaces,
+    deleteSpacesObject
+  }));
+
+  const { createUser } = await import('../src/controllers/user.controller.js');
+
+  return {
+    createUser,
+    commit,
+    rollback,
+    create,
+    photoCreate,
+    locationCreate,
+    uploadBufferToSpaces,
+    deleteSpacesObject,
+    hash
+  };
+};
+
+const validBody = {
+  full_name: 'Nadia Putri',
+  email: 'nadia@example.com',
+  password: 'rahasia123',
+  phone: '081234567890',
+  nip_nim: 'A12345',
+  id_roles: 3,
+  id_programs: 1,
+  id_position: 2,
+  latitude: -0.8917,
+  longitude: 119.8707,
+  radius: 150,
+  description: 'Rumah Nadia'
+};
+
+const buildReq = (overrides = {}) => ({
+  body: { ...validBody, ...(overrides.body || {}) },
+  file:
+    'file' in overrides
+      ? overrides.file
+      : { buffer: Buffer.from('img'), originalname: 'face.jpg', mimetype: 'image/jpeg' },
+  user: { id: 1 }
+});
+
+describe('createUser refusals', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('requires a face photo', async () => {
+    const { createUser, rollback, create } = await loadCreateUser();
+    const res = buildRes();
+
+    await createUser(buildReq({ file: undefined }), res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json.mock.calls[0][0]).toMatchObject({ success: false, code: 'E_UPLOAD' });
+    expect(rollback).toHaveBeenCalledTimes(1);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('rejects a duplicate email before creating anything', async () => {
+    const { createUser, rollback, create } = await loadCreateUser({
+      existingEmail: { id_users: 99 }
+    });
+    const res = buildRes();
+
+    await createUser(buildReq(), res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      code: 'E_VALIDATION_EMAIL_EXISTS',
+      message: 'Email sudah digunakan'
+    });
+    expect(rollback).toHaveBeenCalledTimes(1);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('rejects a duplicate NIP/NIM', async () => {
+    const { createUser, create } = await loadCreateUser({ existingNip: { id_users: 98 } });
+    const res = buildRes();
+
+    await createUser(buildReq(), res, jest.fn());
+
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      code: 'E_VALIDATION_NIP_EXISTS',
+      message: 'NIP/NIM sudah digunakan'
+    });
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('scopes both uniqueness checks to non-deleted rows', async () => {
+    const { createUser } = await loadCreateUser();
+    await createUser(buildReq(), buildRes(), jest.fn());
+
+    const { User } = await import('../src/models/index.js');
+    expect(User.findOne).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ where: { email: validBody.email, deleted_at: null } })
+    );
+    expect(User.findOne).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ where: { nip_nim: validBody.nip_nim, deleted_at: null } })
+    );
+  });
+});
+
+describe('createUser success orchestration', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('hashes the password and never persists it in clear text', async () => {
+    const { createUser, hash, create } = await loadCreateUser();
+
+    await createUser(buildReq(), buildRes(), jest.fn());
+
+    expect(hash).toHaveBeenCalledWith('rahasia123', 10);
+    const persisted = create.mock.calls[0][0];
+    expect(persisted.password).toBe('hashed-password');
+    expect(persisted.password).not.toBe('rahasia123');
+  });
+
+  it('writes user, photo and WFH location inside one transaction', async () => {
+    const { createUser, create, photoCreate, locationCreate, commit } = await loadCreateUser();
+
+    await createUser(buildReq(), buildRes(), jest.fn());
+
+    for (const call of [create, photoCreate, locationCreate]) {
+      expect(call).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ transaction: expect.anything() })
+      );
+    }
+    expect(commit).toHaveBeenCalledTimes(1);
+  });
+
+  it('uploads the photo buffer to Spaces under the generated key', async () => {
+    const { createUser, uploadBufferToSpaces } = await loadCreateUser();
+
+    await createUser(buildReq(), buildRes(), jest.fn());
+
+    expect(uploadBufferToSpaces).toHaveBeenCalledWith(
+      expect.objectContaining({ key: 'users/7/face.jpg', contentType: 'image/jpeg' })
+    );
+  });
+
+  it('answers 201 with the mapped user', async () => {
+    const { createUser, deleteSpacesObject } = await loadCreateUser();
+    const res = buildRes();
+    const next = jest.fn();
+
+    await createUser(buildReq(), res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(deleteSpacesObject).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(201);
+    const body = res.json.mock.calls[0][0];
+    expect(body).toMatchObject({ success: true, message: 'User created successfully' });
+    expect(body.data).toMatchObject({ id: 7, email: 'nadia@example.com' });
+  });
+});
+
+describe('createUser compensation', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('deletes the uploaded object and rolls back when a write fails before commit', async () => {
+    const boom = new Error('location insert failed');
+    const { createUser, deleteSpacesObject, rollback, commit } = await loadCreateUser({
+      userCreate: jest.fn().mockRejectedValue(boom)
+    });
+    const res = buildRes();
+    const next = jest.fn();
+
+    await createUser(buildReq(), res, next);
+
+    expect(commit).not.toHaveBeenCalled();
+    expect(rollback).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith(boom);
+    // The upload had not happened yet in this path, so nothing to clean up.
+    expect(deleteSpacesObject).not.toHaveBeenCalled();
+  });
+
+  it('cleans up the uploaded object when a later write fails', async () => {
+    jest.resetModules();
+    const boom = new Error('photo insert failed');
+    const { createUser, deleteSpacesObject, rollback } = await loadCreateUser({
+      userCreate: jest
+        .fn()
+        .mockResolvedValue({ id_users: 7, update: jest.fn().mockResolvedValue(undefined) })
+    });
+
+    // Force the failure after the upload by making Photo.create reject.
+    const { Photo } = await import('../src/models/index.js');
+    Photo.create.mockRejectedValueOnce(boom);
+
+    const next = jest.fn();
+    await createUser(buildReq(), buildRes(), next);
+
+    expect(deleteSpacesObject).toHaveBeenCalledWith('users/7/face.jpg');
+    expect(rollback).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith(boom);
+  });
+
+  /**
+   * DEFECT, characterized not fixed. Same structural bug as F14 in checkOut,
+   * with a worse blast radius.
+   *
+   * The commit happens, then the refetch, mapping and response all run inside
+   * the same try. If anything throws after the commit -- the refetch returning
+   * null is the realistic case -- the catch block runs unconditionally and:
+   *
+   *   1. deletes the photo of a user that WAS successfully created, and
+   *   2. calls rollback() on a committed transaction, which throws, so
+   *      next(error) never runs and the client gets no response.
+   *
+   * Net result: a user exists in the database with a dangling photo reference
+   * pointing at an object that has just been deleted from Spaces, and the
+   * caller is told nothing. Recorded as F25.
+   */
+  it('destroys the photo of a successfully created user when the refetch fails', async () => {
+    const { createUser, commit, rollback, deleteSpacesObject } = await loadCreateUser({
+      refetched: null
+    });
+    const res = buildRes();
+    const next = jest.fn();
+
+    await expect(createUser(buildReq(), res, next)).rejects.toThrow(
+      /Transaction cannot be rolled back/
+    );
+
+    expect(commit).toHaveBeenCalledTimes(1);
+    // The user is committed, yet its photo is deleted from object storage.
+    expect(deleteSpacesObject).toHaveBeenCalledWith('users/7/face.jpg');
+    expect(rollback).toHaveBeenCalledTimes(1);
+    // And the caller is told nothing at all.
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Continues [INF-252](https://linear.app/infinite-track-palu/issue/INF-252/backendarchitecture-adopt-modular-mvc-per-feature-with-safe) Phase 0b. **Tests and documentation only — zero production code changes.**

## Why this one matters

`createUser` is the most involved mutation in the Users module — and Users migrates **first**, in Phase 3. It hashes a password, writes three tables inside one transaction, uploads to DigitalOcean Spaces (which is **not** transactional), and compensates by deleting the uploaded object when something fails. That orchestration is exactly what a service layer has to reproduce.

## What the 11 tests pin

The face-photo requirement, both uniqueness checks scoped to `deleted_at: null`, bcrypt hashing at cost 10 with no plaintext ever reaching `User.create`, all three writes sharing one transaction, the Spaces key derivation, the 201 payload, and **both** compensation paths.

## F25 — the post-commit pattern again, worse

The commit is at line 632. The refetch, mapping and response all stay **inside the same `try`**. A post-commit throw reaches a `catch` that unconditionally:

1. deletes the uploaded Spaces object, **and**
2. calls `rollback()` on an already-committed transaction.

Net result: **the user exists in the database, its photo has been deleted from object storage, `next(error)` never runs, and the caller receives no response.**

| | `checkOut` (F14, [INF-255](https://linear.app/infinite-track-palu/issue/INF-255/backend-checkout-rolls-back-an-already-committed-transaction)) | `createUser` (F25) |
|---|---|---|
| `catch` does | `rollback()` | `deleteSpacesObject()` **then** `rollback()` |
| Consequence | no response to client | no response **plus** the committed user's photo destroyed |

The Spaces cleanup is correct for a *failed* create and actively destructive for a *successful* one — and nothing in the `catch` distinguishes the two.

`checkIn` shows the codebase already knows the right shape: it tracks `transactionFinished` and only rolls back while the transaction is still open. **Two of its three sibling mutations were never updated to match.** That makes this a pattern, not an isolated slip, and worth fixing as one.

The test asserts the current broken outcome, so a fix makes it fail deliberately.

## A note on the tests themselves

Three tests failed on first run with `newUser.update is not a function`. That was **my mock**, not the controller — `User.create` was returning a plain object, while the controller calls `newUser.update(...)` afterwards to attach `id_photos`. Fixed by returning an instance-shaped mock. Recording it because the failure looked at first like a controller bug and was not.

## Verification

```
npm run lint    clean
npm test        105 suites / 856 tests passing  (845 on develop + 11)
git diff --stat develop..HEAD -- src/    (no output)
```

## Review focus

1. F25 and F14 share one root cause. Fix them together in a single PR, or separately?
2. Should the Spaces compensation move outside the `catch` entirely — e.g. only run when the transaction is known to have rolled back?

🤖 Generated with [Claude Code](https://claude.com/claude-code)