### PR TITLE
test(INF-252): pin updateUser, completing the Users module

### DIFF
--- a/docs/architecture/api-contract-inventory.md
+++ b/docs/architecture/api-contract-inventory.md
@@ -70,7 +70,7 @@ The body form is what mobile clients use. Recording only the cookie would let an
 | GET | `/api/users/:id` | Admin, Management | param: id | 401, 403, 404 `E_NOT_FOUND` | covered | covered | n/a |
 | POST | `/api/users` | Admin, Management | multipart + body | 400 `E_UPLOAD`/`E_VALIDATION_EMAIL_EXISTS`/`E_VALIDATION_NIP_EXISTS`, 401, 403 | covered | covered | covered |
 | POST | `/api/users/:id/photo` | Admin, Management | multipart `face_photo` | 400, 404, `E_UPLOAD` | covered | covered | covered |
-| PATCH | `/api/users/:id` | Admin, Management | body | 400, 404, `E_VALIDATION_NIP_EXISTS`, `E_VALIDATION_EMAIL_EXISTS` | route-only | covered | covered |
+| PATCH | `/api/users/:id` | Admin, Management | body, all fields optional; `email` is ignored | 400 (**no `code` field** — see F27), 404 | covered | covered | covered |
 | DELETE | `/api/users/:id` | Admin | param: id | 401, 403, 404 (no code) | covered | covered | n/a |
 
 **Request-shape correction.** An earlier version of this table recorded `GET /api/users` as accepting `page` and `limit`. It does not. It accepts `search`, `sortBy` (default `created_at`) and `sortOrder` (default `DESC`), and returns every non-deleted user in one response — see F20.
@@ -264,7 +264,11 @@ Baseline as measured on 2026-07-26, before any Phase 0b work:
 | Users — read and delete payloads | **done** | `tests/usersPayloadContract.test.js`, 16 tests |
 | `DELETE /api/attendance/:id` — controller behavior | **done** | `tests/attendanceDeleteContract.test.js`, 7 tests |
 | Users — `createUser` | **done** | `tests/usersCreateContract.test.js`, 11 tests |
-| Users — `updateUser` | open | the last Users mutation |
+| Users — `updateUser` | **done** | `tests/usersUpdateContract.test.js`, 15 tests |
+
+**The Users module is fully characterized.** All six endpoints have routing, authorization, validation and controller behavior pinned across four test files and 56 tests. It is the first module scheduled for extraction in Phase 3, and it is now the best-covered feature in the codebase.
+
+Characterizing it produced eight findings — F8, F19, F20, F21, F22, F23, F25 and F27 — none of them fixed, all recorded.
 
 **The authorization axis is now closed for the entire API.** Every one of the 60 route-file endpoints has its middleware chain pinned: `/api/users` by `usersRouteContract`, `/api/attendance` by `attendanceRouteContract`, `/api/bookings` by `bookingsReadinessContract`, and the remaining seven route files by `routeAuthorizationMatrix`.
 
@@ -280,9 +284,10 @@ That closes the RBAC axis for the whole module, including all nine operational t
 
 Remaining gaps, in order — all are **controller response bodies**, since routing and authorization are fully pinned:
 
-1. `updateUser` — the last Users mutation.
-2. `/api/discipline` response payloads for three of four endpoints.
-3. Reference-data dropdown payloads — lowest risk in the codebase.
+1. `/api/discipline` response payloads for three of four endpoints.
+2. Reference-data dropdown payloads — lowest risk in the codebase.
+
+Both are read-only endpoints with no mutations and no external integrations. **Every mutation in the API is now characterized.**
 
 **Every attendance mutation is now pinned.** `check-in`, `checkout`, and `delete` were the three ways final attendance state changes through the API; all three have characterization coverage, and each one surfaced a defect while being characterized (F14, F16, F24).
 
@@ -310,6 +315,8 @@ Recorded, deliberately **not fixed** under INF-252. Each needs its own issue.
 | F15 | Nine `console.log` calls sit in the `checkOut` final-state mutation path, printing raw attendance rows. They bypass the winston logger used everywhere else, so they carry no request ID and no structured format | `src/controllers/attendance.controller.js:1503-1508,1525-1529` |
 | **F16** | **The `EARLY` check-in status is unreachable.** The working-hours gate returns 400 when `currentTimeMinutes < checkinStartMinutes`, and the classifier below tests that identical condition to assign `status_id: 4` / `EARLY`. Nothing can satisfy the second test after passing the first, so `status_id 4` can never be produced by check-in | `attendance.controller.js:757` vs `:918-921` |
 | F18 | `debugGeoapifyApi` is exported from `wfa.controller.js` but imported nowhere and mounted on no route — roughly 127 lines of dead code in a 586-line controller. It also calls Geoapify directly, so it duplicates the integration logic that Phase 4 is meant to consolidate | `src/controllers/wfa.controller.js:459-586` |
+| **F26** | **`updateUser` writes two tables with no transaction.** It updates the user row and then the WFH location as independent operations. A failure between them leaves the user half-updated with nothing to roll it back. `createUser` wraps its three writes in one transaction; this one opens none at all | `src/controllers/user.controller.js:292-472` |
+| **F27** | **The same NIP conflict has two response shapes.** `createUser` returns `{ success: false, code: 'E_VALIDATION_NIP_EXISTS', message: 'NIP/NIM sudah digunakan' }`. `updateUser` returns `{ success: false, message: 'E_VALIDATION_NIP_EXISTS: NIP/NIM already exists' }` — **no `code` field**, the code smuggled into the message string, and a different language | `user.controller.js:560-566` vs `:331-335` |
 | **F25** | **`createUser` repeats the F14 post-commit pattern, with a worse blast radius.** The commit is at line 632, but the refetch, mapping and response all remain inside the same `try`. A post-commit throw reaches a `catch` that unconditionally deletes the uploaded Spaces object **and** rolls back an already-committed transaction. Net result: the user exists in the database, its photo has been deleted from object storage, `next(error)` never runs, and the caller receives no response | `src/controllers/user.controller.js:632-726` |
 | **F24** | **`DELETE /api/attendance/:id` hard-deletes authoritative state, unlogged.** The `Attendance` model declares neither `paranoid` nor a `deleted_at` column, so `destroy()` is an irreversible row deletion. The handler opens no transaction, writes no audit log, applies no ownership or finalized-state guard, and treats a completed record with booked work hours exactly like an open one | `src/controllers/attendance.controller.js:1555-1583`, `src/models/attendance.model.js:84-85` |
 | **F20** | **`GET /api/users` has no pagination.** It returns every non-deleted user in a single response, with no `limit` or `offset`. The endpoint accepts `search`, `sortBy` and `sortOrder` only — `page` and `limit` are ignored if sent. This is the scalability problem [INF-250](https://linear.app/infinite-track-palu/issue/INF-250/cross-repo-define-scalable-user-directory-search-filter-sort-and) exists to address, and Phase 2's allowlisted list-query foundation is where it gets fixed | `src/controllers/user.controller.js:95-140` |

--- a/tests/usersUpdateContract.test.js
+++ b/tests/usersUpdateContract.test.js
@@ -1,0 +1,284 @@
+import { jest } from '@jest/globals';
+
+/**
+ * Characterization coverage for updateUser (INF-252 Phase 0b).
+ *
+ * The last Users mutation. Unlike createUser it runs without any transaction,
+ * writing the user row and the WFH location as two independent operations --
+ * recorded as F26 -- and it reports a NIP conflict in a different shape from
+ * the one createUser uses, recorded as F27.
+ *
+ * Both are pinned as they are, not fixed.
+ */
+
+const buildRes = () => {
+  const res = {};
+  res.status = jest.fn(() => res);
+  res.json = jest.fn(() => res);
+  return res;
+};
+
+const existingUserRow = (overrides = {}) => ({
+  id_users: 7,
+  nip_nim: 'A12345',
+  update: jest.fn().mockResolvedValue(undefined),
+  ...overrides
+});
+
+const refetchedRow = () => ({
+  id_users: 7,
+  full_name: 'Nadia Putri',
+  email: 'nadia@example.com',
+  nip_nim: 'A12345',
+  phone: '081234567890',
+  role: { role_name: 'User' },
+  position: { position_name: 'Backend Engineer' },
+  program: { program_name: 'Internship' },
+  division: { division_name: 'Engineering' },
+  photo_file: null,
+  wfh_location: null
+});
+
+const loadUpdateUser = async ({
+  user = existingUserRow(),
+  conflictingUser = null,
+  locationRow = { location_id: 12, update: jest.fn().mockResolvedValue(undefined) },
+  locationCreated = false
+} = {}) => {
+  jest.resetModules();
+
+  const transaction = jest.fn();
+  const findByPk = jest.fn().mockResolvedValueOnce(user).mockResolvedValue(refetchedRow());
+  const findOne = jest.fn().mockResolvedValue(conflictingUser);
+  const findOrCreate = jest.fn().mockResolvedValue([locationRow, locationCreated]);
+  const hash = jest.fn().mockResolvedValue('hashed-password');
+
+  jest.unstable_mockModule('bcryptjs', () => ({ default: { hash } }));
+
+  jest.unstable_mockModule('../src/models/index.js', () => ({
+    User: { findByPk, findOne, create: jest.fn(), findAll: jest.fn() },
+    Location: { findOrCreate, create: jest.fn(), findOne: jest.fn() },
+    Photo: { create: jest.fn() },
+    Role: {},
+    Program: {},
+    Position: {},
+    Division: {},
+    AttendanceCategory: {},
+    sequelize: { transaction }
+  }));
+
+  jest.unstable_mockModule('../src/utils/logger.js', () => ({
+    default: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() }
+  }));
+
+  jest.unstable_mockModule('../src/config/spaces.js', () => ({
+    buildUserProfilePhotoKey: jest.fn(),
+    uploadBufferToSpaces: jest.fn(),
+    deleteSpacesObject: jest.fn()
+  }));
+
+  const { updateUser } = await import('../src/controllers/user.controller.js');
+  return { updateUser, user, findOne, findOrCreate, locationRow, hash, transaction };
+};
+
+const buildReq = (body = {}) => ({ params: { id: '7' }, body, user: { id: 1 } });
+
+describe('updateUser refusals', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns 404 when the user does not exist', async () => {
+    const { updateUser } = await loadUpdateUser({ user: null });
+    const res = buildRes();
+
+    await updateUser(buildReq({ full_name: 'X' }), res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json.mock.calls[0][0]).toMatchObject({ success: false });
+  });
+
+  /**
+   * F27, characterized not fixed.
+   *
+   * createUser answers a NIP conflict with
+   *   { success: false, code: 'E_VALIDATION_NIP_EXISTS', message: 'NIP/NIM sudah digunakan' }
+   * updateUser answers the same condition with no `code` field at all, and
+   * smuggles the code into the message string in a different language.
+   */
+  it('reports a NIP conflict without a code field, embedding the code in the message', async () => {
+    const { updateUser } = await loadUpdateUser({
+      conflictingUser: { id_users: 99 }
+    });
+    const res = buildRes();
+
+    await updateUser(buildReq({ nip_nim: 'B99999' }), res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    const body = res.json.mock.calls[0][0];
+    expect(body).toEqual({
+      success: false,
+      message: 'E_VALIDATION_NIP_EXISTS: NIP/NIM already exists'
+    });
+    expect(body).not.toHaveProperty('code');
+  });
+
+  it('skips the uniqueness query when the NIP is unchanged', async () => {
+    const { updateUser, findOne } = await loadUpdateUser({
+      user: existingUserRow({ nip_nim: 'A12345' })
+    });
+
+    await updateUser(buildReq({ nip_nim: 'A12345' }), buildRes(), jest.fn());
+
+    expect(findOne).not.toHaveBeenCalled();
+  });
+
+  it('excludes the current user from the uniqueness query', async () => {
+    const { updateUser, findOne } = await loadUpdateUser();
+
+    await updateUser(buildReq({ nip_nim: 'B99999' }), buildRes(), jest.fn());
+
+    expect(findOne).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ nip_nim: 'B99999', deleted_at: null })
+      })
+    );
+  });
+});
+
+describe('updateUser partial semantics', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('writes only the fields that were supplied', async () => {
+    const { updateUser, user } = await loadUpdateUser();
+
+    await updateUser(buildReq({ full_name: 'Nadia P.' }), buildRes(), jest.fn());
+
+    expect(user.update).toHaveBeenCalledWith({ full_name: 'Nadia P.' });
+  });
+
+  it('hashes a supplied password', async () => {
+    const { updateUser, user, hash } = await loadUpdateUser();
+
+    await updateUser(buildReq({ password: 'rahasia123' }), buildRes(), jest.fn());
+
+    expect(hash).toHaveBeenCalledWith('rahasia123', 10);
+    expect(user.update).toHaveBeenCalledWith({ password: 'hashed-password' });
+  });
+
+  it('ignores a blank password rather than hashing it', async () => {
+    const { updateUser, user, hash } = await loadUpdateUser();
+
+    await updateUser(buildReq({ password: '   ' }), buildRes(), jest.fn());
+
+    expect(hash).not.toHaveBeenCalled();
+    expect(user.update).toHaveBeenCalledWith({});
+  });
+
+  it('never writes email, even when one is supplied', async () => {
+    const { updateUser, user } = await loadUpdateUser();
+
+    await updateUser(
+      buildReq({ full_name: 'Nadia P.', email: 'baru@example.com' }),
+      buildRes(),
+      jest.fn()
+    );
+
+    expect(user.update.mock.calls[0][0]).not.toHaveProperty('email');
+  });
+});
+
+describe('updateUser WFH location handling', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('touches no location when no location field is supplied', async () => {
+    const { updateUser, findOrCreate } = await loadUpdateUser();
+
+    await updateUser(buildReq({ full_name: 'Nadia P.' }), buildRes(), jest.fn());
+
+    expect(findOrCreate).not.toHaveBeenCalled();
+  });
+
+  it('looks the location up by user and WFH category', async () => {
+    const { updateUser, findOrCreate } = await loadUpdateUser();
+
+    await updateUser(buildReq({ latitude: -0.9 }), buildRes(), jest.fn());
+
+    expect(findOrCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ user_id: '7', id_attendance_categories: 2 })
+      })
+    );
+  });
+
+  it('updates an existing location rather than leaving it stale', async () => {
+    const locationRow = { location_id: 12, update: jest.fn().mockResolvedValue(undefined) };
+    const { updateUser } = await loadUpdateUser({ locationRow, locationCreated: false });
+
+    await updateUser(buildReq({ latitude: -0.9, radius: 200 }), buildRes(), jest.fn());
+
+    expect(locationRow.update).toHaveBeenCalledWith(
+      expect.objectContaining({ latitude: -0.9, radius: 200 })
+    );
+  });
+
+  it('does not re-update a location that findOrCreate just created', async () => {
+    const locationRow = { location_id: 12, update: jest.fn() };
+    const { updateUser } = await loadUpdateUser({ locationRow, locationCreated: true });
+
+    await updateUser(buildReq({ latitude: -0.9 }), buildRes(), jest.fn());
+
+    expect(locationRow.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('updateUser atomicity', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  /**
+   * F26, characterized not fixed.
+   *
+   * createUser wraps its three writes in one transaction. updateUser opens
+   * none, so the user row and the WFH location are written independently. A
+   * failure between them leaves the user half-updated with no rollback.
+   */
+  it('writes the user and the location without any transaction', async () => {
+    const { updateUser, user, locationRow, transaction } = await loadUpdateUser();
+
+    await updateUser(buildReq({ full_name: 'Nadia P.', latitude: -0.9 }), buildRes(), jest.fn());
+
+    expect(user.update).toHaveBeenCalled();
+    expect(locationRow.update).toHaveBeenCalled();
+    expect(transaction).not.toHaveBeenCalled();
+  });
+
+  it('leaves the user row updated when the location write fails', async () => {
+    const locationRow = {
+      location_id: 12,
+      update: jest.fn().mockRejectedValue(new Error('location write failed'))
+    };
+    const { updateUser, user } = await loadUpdateUser({ locationRow });
+    const next = jest.fn();
+
+    await updateUser(buildReq({ full_name: 'Nadia P.', latitude: -0.9 }), buildRes(), next);
+
+    // The user was already written and there is nothing to undo it.
+    expect(user.update).toHaveBeenCalledWith({ full_name: 'Nadia P.' });
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ message: 'location write failed' }));
+  });
+});
+
+describe('updateUser success payload', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('refetches and answers with the mapped user', async () => {
+    const { updateUser } = await loadUpdateUser();
+    const res = buildRes();
+    const next = jest.fn();
+
+    await updateUser(buildReq({ full_name: 'Nadia P.' }), res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    const body = res.json.mock.calls[0][0];
+    expect(body.success).toBe(true);
+    expect(body.data).toMatchObject({ id: 7, email: 'nadia@example.com' });
+  });
+});


### PR DESCRIPTION
Continues [INF-252](https://linear.app/infinite-track-palu/issue/INF-252/backendarchitecture-adopt-modular-mvc-per-feature-with-safe) Phase 0b. **Tests and documentation only — zero production code changes.**

## Milestone: Users is fully characterized

All six endpoints now have routing, authorization, validation **and** controller behavior pinned — four test files, 56 tests. Users is the **first module scheduled for extraction in Phase 3**, and it is now the best-covered feature in the codebase.

Characterizing it produced eight findings (F8, F19, F20, F21, F22, F23, F25, F27). None fixed, all recorded.

**Every mutation in the API is now characterized.** What remains in Phase 0b is two read-only payload sets with no mutations and no external integrations.

## What these 15 tests pin

The 404, the NIP conflict, skipping the uniqueness query when the NIP is unchanged, partial-update semantics, password hashing and the blank-password case, `email` being ignored, WFH location `findOrCreate` with its created-vs-existing branches, and the refetched payload.

## F26 — two tables, no transaction

`updateUser` writes the user row, then the WFH location, as **independent operations**. There is no transaction anywhere in the function.

`createUser` wraps its three writes in one. This one opens none, so a failure between the two writes leaves the user half-updated with nothing to roll it back. A test pins that outcome directly:

```js
// The user was already written and there is nothing to undo it.
expect(user.update).toHaveBeenCalledWith({ full_name: 'Nadia P.' });
expect(next).toHaveBeenCalledWith(/* location write failed */);
```

## F27 — one conflict, two shapes

| Endpoint | Response |
|---|---|
| `POST /api/users` | `{ success: false, code: 'E_VALIDATION_NIP_EXISTS', message: 'NIP/NIM sudah digunakan' }` |
| `PATCH /api/users/:id` | `{ success: false, message: 'E_VALIDATION_NIP_EXISTS: NIP/NIM already exists' }` |

Same logical error. One has a `code` field, the other **smuggles the code into the message string** — and in a different language.

This matters beyond tidiness: it is direct evidence for [INF-256](https://linear.app/infinite-track-palu/issue/INF-256/backend-harden-the-merged-inf-252-foundations-error-code-override-and). If any client distinguishes these cases today, it can only be by string-matching that message prefix, which constrains how the typed-error taxonomy can be applied during migration.

## Inventory correction

The inventory listed `E_VALIDATION_NIP_EXISTS` and `E_VALIDATION_EMAIL_EXISTS` as PATCH error codes. **PATCH returns no `code` field at all**, and `email` is not updatable — the controller comment says so explicitly and the tests confirm it is dropped even when supplied.

## Verification

```
npm run lint    clean
npm test        106 suites / 871 tests passing  (856 on develop + 15)
git diff --stat develop..HEAD -- src/    (no output)
```

## Review focus

1. F26 — should `updateUser` be transactional? `createUser` sets the precedent, and the extracted service is where this normally gets fixed.
2. F27 — does any client currently parse that `E_VALIDATION_NIP_EXISTS:` message prefix? That answer decides whether the shapes can be unified freely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)