### PR TITLE
test(INF-252): pin discipline and reference-data payloads

### DIFF
--- a/docs/architecture/api-contract-inventory.md
+++ b/docs/architecture/api-contract-inventory.md
@@ -183,10 +183,12 @@ Also pinned: the search radius comes from the `wfa.recommendation.search_radius`
 
 | Method | Path | Authorization | Error codes | Happy | RBAC | Validation |
 |---|---|---|---|---|---|---|
-| GET | `/api/discipline/user/:userId` | in controller | 403, 404 | **gap** | covered | **gap** |
+| GET | `/api/discipline/user/:userId` | in controller | 403, 404 | covered | covered | covered |
 | GET | `/api/discipline/all` | in controller | 403 | covered | covered | n/a |
-| GET | `/api/discipline/config` | in controller | 403 | **gap** | covered | n/a |
-| POST | `/api/discipline/test-ahp` | `roleGuard` | 400, 403 | **gap** | covered | **gap** |
+| GET | `/api/discipline/config` | in controller | 403 | covered | covered | n/a |
+| POST | `/api/discipline/test-ahp` | `roleGuard` | 400, 403 | covered | covered | covered |
+
+`tests/disciplinePayloadContract.test.js` pins the in-controller authorization that F10 describes: a plain User is refused another user's index but served their own, Admin and Management reach any of them, and `getAllDisciplineIndices` and `getDisciplineConfig` refuse a plain User from inside the handler. The FAHP engine is mocked, so the assertions cover access rules and payload shape, never the algorithm.
 
 The RBAC column here means the **route-layer** contract is pinned, which for three of these four routes means proving they have *no* `roleGuard` and that a plain User reaches the handler. `tests/routeAuthorizationMatrix.test.js` asserts exactly that, so finding F10 is now executable rather than prose: authorization is enforced correctly, but in two different places depending on the route.
 
@@ -217,12 +219,16 @@ What is genuinely missing is narrower: the 401 and 403 cases in that file are as
 
 | Method | Path | Roles | Error codes | Happy | RBAC | Validation |
 |---|---|---|---|---|---|---|
-| GET | `/api/roles` | Admin, Management | 401, 403 | **gap** | covered | n/a |
-| GET | `/api/programs` | Admin, Management | 401, 403 | **gap** | covered | n/a |
-| GET | `/api/positions` | Admin, Management | 401, 403 | **gap** | covered | **gap** |
-| GET | `/api/divisions` | Admin, Management | 401, 403 | **gap** | covered | n/a |
+| GET | `/api/roles` | Admin, Management | 401, 403 | covered | covered | n/a |
+| GET | `/api/programs` | Admin, Management | 401, 403 | covered | covered | n/a |
+| GET | `/api/positions` | Admin, Management | 401, 403 | covered | covered | covered |
+| GET | `/api/divisions` | Admin, Management | 401, 403 | covered | covered | n/a |
 
-Authorization is pinned by `tests/routeAuthorizationMatrix.test.js`. The controllers' own response bodies are still uncovered — these are low-risk read-only dropdown endpoints, which is why they remain outside the Phase 0b priority set.
+Authorization is pinned by `tests/routeAuthorizationMatrix.test.js`, payloads by `tests/referenceDataContract.test.js`.
+
+These four are the most uniform controllers in the codebase: each selects an explicit attribute list, orders ascending, and answers with the same `{ success, data, message }` envelope. **The attribute lists are the response contract** — a migration that widened them would silently start leaking columns, so the tests assert them exactly. `getPositions` additionally pins its optional `program_id` filter and the single-column `program` association.
+
+Minor: the doc comments in `referenceData.controller.js` describe the paths as `/api/reference-data/*`, but the router mounts them at `/api/*`. Comment drift only — the tests and the router agree.
 
 ## 11. Health — 2 endpoints
 
@@ -265,6 +271,8 @@ Baseline as measured on 2026-07-26, before any Phase 0b work:
 | `DELETE /api/attendance/:id` — controller behavior | **done** | `tests/attendanceDeleteContract.test.js`, 7 tests |
 | Users — `createUser` | **done** | `tests/usersCreateContract.test.js`, 11 tests |
 | Users — `updateUser` | **done** | `tests/usersUpdateContract.test.js`, 15 tests |
+| Discipline payloads | **done** | `tests/disciplinePayloadContract.test.js`, 15 tests |
+| Reference data payloads | **done** | `tests/referenceDataContract.test.js`, 10 tests |
 
 **The Users module is fully characterized.** All six endpoints have routing, authorization, validation and controller behavior pinned across four test files and 56 tests. It is the first module scheduled for extraction in Phase 3, and it is now the best-covered feature in the codebase.
 
@@ -282,12 +290,60 @@ That closes the RBAC axis for the whole module, including all nine operational t
 
 **Both attendance final-state mutations are now fully pinned.** `check-in` and `checkout` were the two highest-risk endpoints in the codebase; characterizing them surfaced F14, F15, F16 and F17.
 
-Remaining gaps, in order — all are **controller response bodies**, since routing and authorization are fully pinned:
+## Phase 0b — planned slices complete, real gaps remain
 
-1. `/api/discipline` response payloads for three of four endpoints.
-2. Reference-data dropdown payloads — lowest risk in the codebase.
+Every slice on the Phase 0b list is done. That is **not** the same as full coverage, and the distinction matters:
 
-Both are read-only endpoints with no mutations and no external integrations. **Every mutation in the API is now characterized.**
+**Fully characterized:** the Users module end to end, `check-in`, `checkout`, `deleteAttendance`, the three WFA endpoints, discipline, reference data, and the authorization matrix for all 60 route-file endpoints.
+
+**Still open, in the priority set:**
+
+| Endpoint | What is missing | Why it matters |
+|---|---|---|
+| `GET /api/attendance` | controller behavior — the admin list with search and sorting | The busiest admin read; its query shape moves in Phase 2 |
+| `POST /api/attendance/location-event` | controller behavior and validation | Writes `LocationEvent`, feeds geofence evidence |
+| `POST /manual-auto-checkout` | controller behavior | **Triggers a job that mutates final attendance state** |
+| `POST /manual-resolve-wfa-bookings` | controller behavior | **Same** |
+| `POST /manual-general-alpha` | controller behavior | **Same** |
+| `POST /manual-resolve-wfa-for-date` | controller behavior | **Same** |
+| `POST /manual-smart-auto-checkout` | controller behavior | **Same** |
+| `GET /api/summary/reports/pdf` and `/excel` | RBAC assertions | Route-level only today |
+
+The five `manual-*` triggers are the notable ones. Their routing and authorization are pinned, but **what they do once called is not** — and each invokes a background job that writes attendance. An earlier draft of this section claimed "every mutation in the API is characterized"; that was wrong, and these are why.
+
+| Slice | Tests |
+|---|---|
+| Users — routing, RBAC, validation | 14 |
+| Users — read and delete payloads | 16 |
+| Users — `createUser` | 11 |
+| Users — `updateUser` | 15 |
+| Attendance — authorization matrix, 23 endpoints | 55 |
+| Attendance — `checkIn` | 17 |
+| Attendance — `checkOut` | 10 |
+| Attendance — `deleteAttendance` | 7 |
+| WFA — 3 endpoints incl. Geoapify contract | 22 |
+| Authorization matrix — 7 remaining route files | 87 |
+| Discipline payloads | 15 |
+| Reference data payloads | 10 |
+| Controller export reachability guard | 3 |
+
+The suite went from **579 tests at `5ce2f69`** to **896**, with no production behavior changed at any point.
+
+### What characterization actually bought
+
+Seventeen findings, F7 through F27. Six became their own Linear issues. The ones that would have been carried silently into new modules:
+
+- **[INF-255](https://linear.app/infinite-track-palu/issue/INF-255/backend-post-commit-failures-roll-back-committed-transactions-checkout)** — post-commit rollback in `checkOut` **and** `createUser`; the second destroys a committed user's photo.
+- **[INF-258](https://linear.app/infinite-track-palu/issue/INF-258/backend-attendance-deletion-is-irreversible-and-unlogged)** — attendance is hard-deleted, unlogged, untransacted.
+- **[INF-257](https://linear.app/infinite-track-palu/issue/INF-257/backendproduct-the-early-check-in-status-is-unreachable-decide-gate-or)** — the `EARLY` status is unreachable.
+- **F19** — `booking.getMyBookings` is dead code, yet Phase 4 lists `ListMyBookings` as a use case to extract.
+- **F26 / F27** — `updateUser` has no transaction, and reports a NIP conflict in a different shape from `createUser`.
+
+### What the coverage still cannot do
+
+All 896 tests mock Sequelize. They prove what the code *intends*, not that the database behaves accordingly. Three of the most serious findings — F14, F25, F26 — are about transaction behavior, which is precisely what a mock cannot verify.
+
+**[INF-254](https://linear.app/infinite-track-palu/issue/INF-254/backendinfra-database-schema-cannot-be-built-from-the-repository) still blocks the only kind of test that could.** Phase 2 onwards moves queries into repositories and query objects, and no test in this suite would catch a change in the SQL that results.
 
 **Every attendance mutation is now pinned.** `check-in`, `checkout`, and `delete` were the three ways final attendance state changes through the API; all three have characterization coverage, and each one surfaced a defect while being characterized (F14, F16, F24).
 

--- a/tests/disciplinePayloadContract.test.js
+++ b/tests/disciplinePayloadContract.test.js
@@ -1,0 +1,241 @@
+import { jest } from '@jest/globals';
+
+/**
+ * Characterization coverage for the discipline controllers
+ * (INF-252 Phase 0b).
+ *
+ * routeAuthorizationMatrix.test.js proved that three of these four routes
+ * carry no roleGuard (finding F10). This file pins the authorization those
+ * three enforce in the controller body instead, plus their payloads.
+ *
+ * The FAHP engine is mocked. FAHP theory is locked, so the assertions cover
+ * the controller's orchestration and access rules, never the algorithm's
+ * numbers.
+ */
+
+const buildRes = () => {
+  const res = {};
+  res.status = jest.fn(() => res);
+  res.json = jest.fn(() => res);
+  return res;
+};
+
+const userRow = () => ({
+  id_users: 9,
+  full_name: 'Nadia Putri',
+  nip_nim: 'A12345',
+  role: { role_name: 'User' }
+});
+
+const loadDiscipline = async ({ user = userRow(), users = [], attendances = [] } = {}) => {
+  jest.resetModules();
+
+  const userFindByPk = jest.fn().mockResolvedValue(user);
+  const userFindAll = jest.fn().mockResolvedValue(users);
+  const attendanceFindAll = jest.fn().mockResolvedValue(attendances);
+
+  jest.unstable_mockModule('../src/models/index.js', () => ({
+    User: { findByPk: userFindByPk, findAll: userFindAll },
+    Attendance: { findAll: attendanceFindAll },
+    Role: {},
+    Program: {},
+    Position: {},
+    Division: {},
+    AttendanceCategory: {},
+    Location: {},
+    Photo: {}
+  }));
+
+  jest.unstable_mockModule('../src/utils/fuzzyAhpEngine.js', () => ({
+    default: {
+      getDisciplineAhpWeights: () => ({
+        attendance_rate: 0.4,
+        punctuality: 0.3,
+        consistency: 0.3,
+        consistency_ratio: 0.04
+      }),
+      calculateDisciplineIndex: jest.fn(async () => ({
+        score: 82,
+        label: 'DISIPLIN',
+        breakdown: {}
+      }))
+    }
+  }));
+
+  jest.unstable_mockModule('../src/utils/logger.js', () => ({
+    default: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() }
+  }));
+
+  const mod = await import('../src/controllers/discipline.controller.js');
+  return { ...mod, userFindByPk, userFindAll };
+};
+
+const asRole = (role_name, id = 1) => ({ id, role_name });
+
+describe('getUserDisciplineIndex access rules', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("refuses a plain User reading another user's index", async () => {
+    const { getUserDisciplineIndex } = await loadDiscipline();
+    const res = buildRes();
+
+    await getUserDisciplineIndex(
+      { params: { userId: '9' }, query: {}, user: asRole('User', 1) },
+      res,
+      jest.fn()
+    );
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Akses ditolak. Anda hanya dapat melihat indeks kedisiplinan Anda sendiri.'
+    });
+  });
+
+  it('allows a plain User to read their own index', async () => {
+    const { getUserDisciplineIndex } = await loadDiscipline();
+    const res = buildRes();
+
+    await getUserDisciplineIndex(
+      { params: { userId: '9' }, query: {}, user: asRole('User', 9) },
+      res,
+      jest.fn()
+    );
+
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it.each([['Admin'], ['Management']])('allows %s to read any index', async (role) => {
+    const { getUserDisciplineIndex } = await loadDiscipline();
+    const res = buildRes();
+
+    await getUserDisciplineIndex(
+      { params: { userId: '9' }, query: {}, user: asRole(role, 1) },
+      res,
+      jest.fn()
+    );
+
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('returns 404 when the target user does not exist', async () => {
+    const { getUserDisciplineIndex } = await loadDiscipline({ user: null });
+    const res = buildRes();
+
+    await getUserDisciplineIndex(
+      { params: { userId: '999' }, query: {}, user: asRole('Admin') },
+      res,
+      jest.fn()
+    );
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'User tidak ditemukan.'
+    });
+  });
+
+  it('returns user info, analysis period and discipline index', async () => {
+    const { getUserDisciplineIndex } = await loadDiscipline();
+    const res = buildRes();
+
+    await getUserDisciplineIndex(
+      { params: { userId: '9' }, query: { months: 3 }, user: asRole('Admin') },
+      res,
+      jest.fn()
+    );
+
+    const body = res.json.mock.calls[0][0];
+    expect(body.success).toBe(true);
+    expect(body.data.user_info).toEqual({
+      user_id: 9,
+      full_name: 'Nadia Putri',
+      nip_nim: 'A12345',
+      role: 'User'
+    });
+    expect(body.data.analysis_period.months_analyzed).toBe(3);
+    expect(body.data.discipline_index).toMatchObject({ score: 82, label: 'DISIPLIN' });
+  });
+
+  it('defaults the analysis window to one month', async () => {
+    const { getUserDisciplineIndex } = await loadDiscipline();
+    const res = buildRes();
+
+    await getUserDisciplineIndex(
+      { params: { userId: '9' }, query: {}, user: asRole('Admin') },
+      res,
+      jest.fn()
+    );
+
+    expect(res.json.mock.calls[0][0].data.analysis_period.months_analyzed).toBe(1);
+  });
+});
+
+describe('getAllDisciplineIndices and getDisciplineConfig access rules', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it.each([
+    ['getAllDisciplineIndices'],
+    ['getDisciplineConfig']
+  ])('%s refuses a plain User from inside the controller', async (fnName) => {
+    const mod = await loadDiscipline();
+    const res = buildRes();
+
+    await mod[fnName]({ params: {}, query: {}, user: asRole('User') }, res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it.each([['Admin'], ['Management']])('getDisciplineConfig serves %s', async (role) => {
+    const { getDisciplineConfig } = await loadDiscipline();
+    const res = buildRes();
+
+    await getDisciplineConfig({ params: {}, query: {}, user: asRole(role) }, res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json.mock.calls[0][0].success).toBe(true);
+  });
+
+  it('getAllDisciplineIndices returns an empty list when no users match', async () => {
+    const { getAllDisciplineIndices } = await loadDiscipline({ users: [] });
+    const res = buildRes();
+
+    await getAllDisciplineIndices({ params: {}, query: {}, user: asRole('Admin') }, res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json.mock.calls[0][0].success).toBe(true);
+  });
+});
+
+describe('testDisciplineAhp', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('requires metrics', async () => {
+    const { testDisciplineAhp } = await loadDiscipline();
+    const res = buildRes();
+
+    await testDisciplineAhp({ body: {}, user: asRole('Admin') }, res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Parameter metrics wajib diisi'
+    });
+  });
+
+  it('scores the supplied metrics without touching the database', async () => {
+    const { testDisciplineAhp, userFindByPk, userFindAll } = await loadDiscipline();
+    const res = buildRes();
+
+    await testDisciplineAhp(
+      { body: { metrics: { attendance_rate: 0.9 } }, user: asRole('Admin') },
+      res,
+      jest.fn()
+    );
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json.mock.calls[0][0].success).toBe(true);
+    expect(userFindByPk).not.toHaveBeenCalled();
+    expect(userFindAll).not.toHaveBeenCalled();
+  });
+});

--- a/tests/referenceDataContract.test.js
+++ b/tests/referenceDataContract.test.js
@@ -1,0 +1,134 @@
+import { jest } from '@jest/globals';
+
+/**
+ * Characterization coverage for the reference-data dropdowns
+ * (INF-252 Phase 0b).
+ *
+ * The lowest-risk endpoints in the codebase, and the most uniform: four
+ * read-only lookups that each select explicit attributes, order ascending,
+ * and answer with the same { success, data, message } envelope.
+ *
+ * They are worth pinning precisely because they are the template the other
+ * modules should converge on -- the attribute lists are the response contract,
+ * and a migration that widens them would silently start leaking columns.
+ */
+
+const buildRes = () => {
+  const res = {};
+  res.status = jest.fn(() => res);
+  res.json = jest.fn(() => res);
+  return res;
+};
+
+const loadReferenceData = async ({ rows = [], failWith } = {}) => {
+  jest.resetModules();
+
+  const makeModel = () => ({
+    findAll: failWith ? jest.fn().mockRejectedValue(failWith) : jest.fn().mockResolvedValue(rows)
+  });
+
+  const Role = makeModel();
+  const Program = makeModel();
+  const Position = makeModel();
+  const Division = makeModel();
+
+  jest.unstable_mockModule('../src/models/index.js', () => ({
+    Role,
+    Program,
+    Position,
+    Division,
+    User: {},
+    Photo: {},
+    Location: {},
+    AttendanceCategory: {}
+  }));
+
+  const mod = await import('../src/controllers/referenceData.controller.js');
+  return { ...mod, Role, Program, Position, Division };
+};
+
+describe('reference data envelopes', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it.each([
+    ['getRoles', 'Roles retrieved successfully'],
+    ['getPrograms', 'Programs retrieved successfully'],
+    ['getPositions', 'Positions retrieved successfully'],
+    ['getDivisions', 'Divisions retrieved successfully']
+  ])('%s answers 200 with the shared envelope and message "%s"', async (fnName, message) => {
+    const rows = [{ id: 1 }];
+    const mod = await loadReferenceData({ rows });
+    const res = buildRes();
+
+    await mod[fnName]({ query: {} }, res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ success: true, data: rows, message });
+  });
+
+  it.each([
+    ['getRoles', 'Role', ['id_roles', 'role_name'], 'role_name'],
+    ['getPrograms', 'Program', ['id_programs', 'program_name'], 'program_name'],
+    ['getDivisions', 'Division', ['id_divisions', 'division_name'], 'division_name']
+  ])('%s selects explicit attributes and orders by %s ascending', async (
+    fnName,
+    modelKey,
+    attributes,
+    orderField
+  ) => {
+    const mod = await loadReferenceData();
+
+    await mod[fnName]({ query: {} }, buildRes(), jest.fn());
+
+    expect(mod[modelKey].findAll).toHaveBeenCalledWith({
+      attributes,
+      order: [[orderField, 'ASC']]
+    });
+  });
+
+  it('forwards a query failure to the error handler', async () => {
+    const boom = new Error('db down');
+    const { getRoles } = await loadReferenceData({ failWith: boom });
+    const res = buildRes();
+    const next = jest.fn();
+
+    await getRoles({ query: {} }, res, next);
+
+    expect(next).toHaveBeenCalledWith(boom);
+    expect(res.json).not.toHaveBeenCalled();
+  });
+});
+
+describe('getPositions filtering', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('applies no filter when program_id is absent', async () => {
+    const { getPositions, Position } = await loadReferenceData();
+
+    await getPositions({ query: {} }, buildRes(), jest.fn());
+
+    expect(Position.findAll).toHaveBeenCalledWith(expect.objectContaining({ where: {} }));
+  });
+
+  it('filters by program_id when supplied', async () => {
+    const { getPositions, Position } = await loadReferenceData();
+
+    await getPositions({ query: { program_id: '3' } }, buildRes(), jest.fn());
+
+    expect(Position.findAll).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id_programs: '3' } })
+    );
+  });
+
+  it('includes the parent program name and nothing else from it', async () => {
+    const { getPositions, Position } = await loadReferenceData();
+
+    await getPositions({ query: {} }, buildRes(), jest.fn());
+
+    const options = Position.findAll.mock.calls[0][0];
+    expect(options.attributes).toEqual(['id_positions', 'position_name', 'id_programs']);
+    expect(options.include).toEqual([
+      expect.objectContaining({ as: 'program', attributes: ['program_name'] })
+    ]);
+  });
+});


### PR DESCRIPTION
Continues [INF-252](https://linear.app/infinite-track-palu/issue/INF-252/backendarchitecture-adopt-modular-mvc-per-feature-with-safe) Phase 0b. **Tests and documentation only — zero production code changes.**

## What this adds — 25 tests

**Discipline (15).** The in-controller authorization that finding F10 describes: a plain User is refused another user's index but **served their own**, Admin and Management reach any of them, and `getAllDisciplineIndices` / `getDisciplineConfig` refuse a plain User from inside the handler. Plus the 404, the payload shape, the default one-month analysis window, and `testDisciplineAhp` scoring without touching the database.

The FAHP engine is mocked. Theory is locked, so nothing here asserts its numbers.

**Reference data (10).** The shared envelope and per-endpoint message, the explicit attribute lists, ascending order, the optional `program_id` filter, and the single-column `program` association.

The attribute lists *are* the response contract — a migration that widened them would silently start leaking columns — so they are asserted exactly rather than loosely.

## A correction I am shipping alongside

While verifying this slice I found I had written an **overstated claim into the inventory in an earlier commit**:

> "Every endpoint in the priority set, and every mutation in the API, is characterized."

That is false. Fifteen gap markers remain. The significant ones are the **five `manual-*` operational triggers** — `manual-auto-checkout`, `manual-resolve-wfa-bookings`, `manual-general-alpha`, `manual-resolve-wfa-for-date`, `manual-smart-auto-checkout`.

Their routing and authorization are pinned, but **what they do once called is not** — and each invokes a background job that writes attendance state. Also still open: `GET /api/attendance` (the admin list), `POST /location-event`, and RBAC for the two summary export endpoints.

The summary section now lists those gaps in a table instead of claiming completeness. I would rather correct this here than have someone start Phase 2 believing the coverage was total.

## Where Phase 0b actually stands

**Done:** the Users module end to end, `check-in`, `checkout`, `deleteAttendance`, the three WFA endpoints, discipline, reference data, and the authorization matrix for all 60 route-file endpoints. 579 → 896 tests, no production behavior changed at any point.

**Not done:** the eight endpoints above.

## Verification

```
npm run lint    clean
npm test        108 suites / 896 tests passing  (871 on develop + 25)
git diff --stat develop..HEAD -- src/    (no output)
```

## Review focus

1. Are the five `manual-*` triggers worth their own slice, given they mutate state through jobs? My read is yes — they are the largest genuine gap left.
2. The reference-data attribute assertions are strict by design. Too strict?

🤖 Generated with [Claude Code](https://claude.com/claude-code)