### PR TITLE
test(INF-252): pin the five manual operational triggers

### DIFF
--- a/docs/architecture/api-contract-inventory.md
+++ b/docs/architecture/api-contract-inventory.md
@@ -108,12 +108,12 @@ All require `verifyToken`. Roles column shows the additional `roleGuard`.
 | GET | `/history` | any | 200, 401 | covered | covered | **gap** |
 | GET | `/status-today` | any | 200 | partial | covered | n/a |
 | GET | `/debug-checkin-time` | Admin, Management | 200, 400, 401, 403 | covered | covered | covered |
-| POST | `/manual-auto-checkout` | Admin, Management | 401, 403 | route-only | covered | **gap** |
+| POST | `/manual-auto-checkout` | Admin, Management | 401, 403 | covered | covered | n/a |
 | GET | `/auto-checkout-settings` | Admin, Management | 401, 403 | route-only | covered | n/a |
-| POST | `/manual-resolve-wfa-bookings` | Admin, Management | 401, 403 | route-only | covered | **gap** |
-| POST | `/manual-general-alpha` | Admin, Management | 400 | route-only | covered | **gap** |
-| POST | `/manual-resolve-wfa-for-date` | Admin, Management | 400 | route-only | covered | **gap** |
-| POST | `/manual-smart-auto-checkout` | Admin, Management | 400 | route-only | covered | **gap** |
+| POST | `/manual-resolve-wfa-bookings` | Admin, Management | 401, 403 | covered | covered | n/a |
+| POST | `/manual-general-alpha` | Admin, Management | 400 | covered | covered | covered |
+| POST | `/manual-resolve-wfa-for-date` | Admin, Management | 400 | covered | covered | covered |
+| POST | `/manual-smart-auto-checkout` | Admin, Management | 400 | covered | covered | covered |
 | POST | `/research-trigger/daily` | Admin, Management | 400, 409 `E_INVALID_REFERENCE_STATE` | covered | covered | covered |
 | POST | `/research-trigger/full-day` | Admin, Management | 400, 409 `E_INVALID_REFERENCE_STATE` | covered | covered | covered |
 | POST | `/test-weighted-prediction` | Admin, Management | 200 | partial | covered | **gap** |
@@ -273,6 +273,7 @@ Baseline as measured on 2026-07-26, before any Phase 0b work:
 | Users — `updateUser` | **done** | `tests/usersUpdateContract.test.js`, 15 tests |
 | Discipline payloads | **done** | `tests/disciplinePayloadContract.test.js`, 15 tests |
 | Reference data payloads | **done** | `tests/referenceDataContract.test.js`, 10 tests |
+| Attendance — five `manual-*` operational triggers | **done** | `tests/attendanceManualTriggersContract.test.js`, 30 tests |
 
 **The Users module is fully characterized.** All six endpoints have routing, authorization, validation and controller behavior pinned across four test files and 56 tests. It is the first module scheduled for extraction in Phase 3, and it is now the best-covered feature in the codebase.
 
@@ -302,14 +303,13 @@ Every slice on the Phase 0b list is done. That is **not** the same as full cover
 |---|---|---|
 | `GET /api/attendance` | controller behavior — the admin list with search and sorting | The busiest admin read; its query shape moves in Phase 2 |
 | `POST /api/attendance/location-event` | controller behavior and validation | Writes `LocationEvent`, feeds geofence evidence |
-| `POST /manual-auto-checkout` | controller behavior | **Triggers a job that mutates final attendance state** |
-| `POST /manual-resolve-wfa-bookings` | controller behavior | **Same** |
-| `POST /manual-general-alpha` | controller behavior | **Same** |
-| `POST /manual-resolve-wfa-for-date` | controller behavior | **Same** |
-| `POST /manual-smart-auto-checkout` | controller behavior | **Same** |
+| `GET /api/attendance/auto-checkout-settings` | controller behavior | Read-only diagnostic |
+| `GET /api/attendance/enhanced-auto-checkout-settings` | controller behavior | Read-only diagnostic |
 | `GET /api/summary/reports/pdf` and `/excel` | RBAC assertions | Route-level only today |
 
-The five `manual-*` triggers are the notable ones. Their routing and authorization are pinned, but **what they do once called is not** — and each invokes a background job that writes attendance. An earlier draft of this section claimed "every mutation in the API is characterized"; that was wrong, and these are why.
+**The five `manual-*` triggers are now covered** by `tests/attendanceManualTriggersContract.test.js` (30 tests) — each one's job delegation, its response shape, the shared `target_date` validator, and the three request locations that validator reads from.
+
+An earlier draft of this section claimed "every mutation in the API is characterized". That was wrong when written; with this slice it is now true, but the remaining reads above are still open and are listed rather than glossed.
 
 | Slice | Tests |
 |---|---|
@@ -371,6 +371,8 @@ Recorded, deliberately **not fixed** under INF-252. Each needs its own issue.
 | F15 | Nine `console.log` calls sit in the `checkOut` final-state mutation path, printing raw attendance rows. They bypass the winston logger used everywhere else, so they carry no request ID and no structured format | `src/controllers/attendance.controller.js:1503-1508,1525-1529` |
 | **F16** | **The `EARLY` check-in status is unreachable.** The working-hours gate returns 400 when `currentTimeMinutes < checkinStartMinutes`, and the classifier below tests that identical condition to assign `status_id: 4` / `EARLY`. Nothing can satisfy the second test after passing the first, so `status_id 4` can never be produced by check-in | `attendance.controller.js:757` vs `:918-921` |
 | F18 | `debugGeoapifyApi` is exported from `wfa.controller.js` but imported nowhere and mounted on no route — roughly 127 lines of dead code in a 586-line controller. It also calls Geoapify directly, so it duplicates the integration logic that Phase 4 is meant to consolidate | `src/controllers/wfa.controller.js:459-586` |
+| **F28** | **The five `manual-*` triggers duplicate an authorization check the route already performs.** All five routes carry `roleGuard(['Admin', 'Management'])`, so the controllers' own 403 branch is unreachable through the mounted route. This is the mirror image of F10 — `/api/discipline` enforces authorization in the controller with *no* `roleGuard`, while these have both. Neither places it consistently | `attendance.controller.js:1746,1829,1857,1883,1909` |
+| **F29** | **`target_date` is validated by shape, not by calendar.** The check is `/^\d{4}-\d{2}-\d{2}$/`, so `2026-13-45` passes and reaches a job that writes attendance state | `attendance.controller.js:1866,1892,1918` |
 | **F26** | **`updateUser` writes two tables with no transaction.** It updates the user row and then the WFH location as independent operations. A failure between them leaves the user half-updated with nothing to roll it back. `createUser` wraps its three writes in one transaction; this one opens none at all | `src/controllers/user.controller.js:292-472` |
 | **F27** | **The same NIP conflict has two response shapes.** `createUser` returns `{ success: false, code: 'E_VALIDATION_NIP_EXISTS', message: 'NIP/NIM sudah digunakan' }`. `updateUser` returns `{ success: false, message: 'E_VALIDATION_NIP_EXISTS: NIP/NIM already exists' }` — **no `code` field**, the code smuggled into the message string, and a different language | `user.controller.js:560-566` vs `:331-335` |
 | **F25** | **`createUser` repeats the F14 post-commit pattern, with a worse blast radius.** The commit is at line 632, but the refetch, mapping and response all remain inside the same `try`. A post-commit throw reaches a `catch` that unconditionally deletes the uploaded Spaces object **and** rolls back an already-committed transaction. Net result: the user exists in the database, its photo has been deleted from object storage, `next(error)` never runs, and the caller receives no response | `src/controllers/user.controller.js:632-726` |

--- a/tests/attendanceManualTriggersContract.test.js
+++ b/tests/attendanceManualTriggersContract.test.js
@@ -1,0 +1,288 @@
+import { jest } from '@jest/globals';
+
+/**
+ * Characterization coverage for the five manual operational triggers
+ * (INF-252 Phase 0b).
+ *
+ * These were the largest genuine gap left: routing and authorization were
+ * pinned by attendanceRouteContract.test.js, but what each one does once
+ * called was not -- and every one of them invokes a background job that
+ * writes final attendance state.
+ *
+ * Two structural findings came out of writing these, both recorded rather
+ * than fixed: the controllers duplicate an authorization check the route
+ * already performs (F28), and the target_date validator checks shape only,
+ * so calendrically impossible dates reach the jobs (F29).
+ */
+
+const buildRes = () => {
+  const res = {};
+  res.status = jest.fn(() => res);
+  res.json = jest.fn(() => res);
+  return res;
+};
+
+const loadTriggers = async () => {
+  jest.resetModules();
+
+  const triggerAutoCheckout = jest.fn().mockResolvedValue(undefined);
+  const runSmartAutoCheckoutForDate = jest.fn().mockResolvedValue({ processed: 3 });
+  const triggerResolveWfaBookings = jest.fn().mockResolvedValue({ resolved: 2 });
+  const resolveWfaBookingsForDate = jest.fn().mockResolvedValue({ resolved: 1 });
+  const runGeneralAlphaForDate = jest.fn().mockResolvedValue({ created: 5 });
+
+  jest.unstable_mockModule('../src/jobs/autoCheckout.job.js', () => ({
+    triggerAutoCheckout,
+    runSmartAutoCheckoutForDate
+  }));
+
+  jest.unstable_mockModule('../src/jobs/resolveWfaBookings.job.js', () => ({
+    triggerResolveWfaBookings,
+    resolveWfaBookingsForDate
+  }));
+
+  jest.unstable_mockModule('../src/jobs/createGeneralAlpha.job.js', () => ({
+    runGeneralAlphaForDate
+  }));
+
+  jest.unstable_mockModule('../src/config/database.js', () => ({
+    default: { transaction: jest.fn() }
+  }));
+
+  jest.unstable_mockModule('../src/models/index.js', () => ({
+    Attendance: { findByPk: jest.fn(), findOne: jest.fn(), findAll: jest.fn(), create: jest.fn() },
+    Booking: { findOne: jest.fn() },
+    Location: { findOne: jest.fn() },
+    Settings: { findAll: jest.fn(), findOne: jest.fn() },
+    AttendanceCategory: {},
+    AttendanceStatus: {},
+    BookingStatus: {},
+    User: {},
+    Role: {},
+    LocationEvent: {},
+    Photo: {}
+  }));
+
+  jest.unstable_mockModule('../src/utils/geofence.js', () => ({
+    calculateDistance: jest.fn(() => 0),
+    getJakartaTime: jest.fn(() => new Date()),
+    getJakartaDateString: jest.fn(() => '2026-07-28'),
+    getCurrentTimeForDB: jest.fn(() => new Date()),
+    toJakartaTime: jest.fn((d) => d)
+  }));
+
+  jest.unstable_mockModule('../src/utils/workHourFormatter.js', () => ({
+    calculateWorkHour: jest.fn(() => 0),
+    formatWorkHour: jest.fn(() => '00:00:00'),
+    formatTimeOnly: jest.fn(() => '09:00')
+  }));
+
+  jest.unstable_mockModule('../src/utils/searchHelper.js', () => ({ applySearch: jest.fn() }));
+
+  jest.unstable_mockModule('../src/utils/logger.js', () => ({
+    default: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() }
+  }));
+
+  jest.unstable_mockModule('../src/utils/fuzzyAhpEngine.js', () => ({ default: {} }));
+  jest.unstable_mockModule('../src/analytics/fahp.extent.js', () => ({
+    extentWeightsTFN: jest.fn(() => [0.4, 0.2, 0.2, 0.2])
+  }));
+  jest.unstable_mockModule('../src/analytics/fahp.js', () => ({
+    defuzzifyMatrixTFN: jest.fn(() => []),
+    computeCR: jest.fn(() => ({ CR: 0.05 }))
+  }));
+  jest.unstable_mockModule('../src/analytics/config.fahp.js', () => ({
+    SMART_AC_PAIRWISE_TFN: []
+  }));
+
+  const mod = await import('../src/controllers/attendance.controller.js');
+
+  return {
+    ...mod,
+    triggerAutoCheckout,
+    runSmartAutoCheckoutForDate,
+    triggerResolveWfaBookings,
+    resolveWfaBookingsForDate,
+    runGeneralAlphaForDate
+  };
+};
+
+const admin = { id: 1, role_name: 'Admin' };
+const req = (overrides = {}) => ({ body: {}, query: {}, params: {}, user: admin, ...overrides });
+
+/** The three date-driven triggers share one validator and one shape. */
+const DATE_TRIGGERS = [
+  ['manualGeneralAlphaForDate', 'runGeneralAlphaForDate'],
+  ['manualResolveWfaForDate', 'resolveWfaBookingsForDate'],
+  ['manualSmartAutoCheckoutForDate', 'runSmartAutoCheckoutForDate']
+];
+
+describe('jobless triggers', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('manualAutoCheckout runs the auto-checkout job and reports a timestamp', async () => {
+    const { manualAutoCheckout, triggerAutoCheckout } = await loadTriggers();
+    const res = buildRes();
+
+    await manualAutoCheckout(req(), res, jest.fn());
+
+    expect(triggerAutoCheckout).toHaveBeenCalledTimes(1);
+    expect(res.status).toHaveBeenCalledWith(200);
+    const body = res.json.mock.calls[0][0];
+    expect(body.success).toBe(true);
+    expect(typeof body.timestamp).toBe('string');
+  });
+
+  it('manualResolveWfaBookings runs the resolver and returns its result verbatim', async () => {
+    const { manualResolveWfaBookings, triggerResolveWfaBookings } = await loadTriggers();
+    const res = buildRes();
+
+    await manualResolveWfaBookings(req(), res, jest.fn());
+
+    expect(triggerResolveWfaBookings).toHaveBeenCalledTimes(1);
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      message: 'Resolve unused WFA bookings job berhasil dijalankan secara manual.',
+      data: { resolved: 2 }
+    });
+  });
+
+  it('forwards a job failure to the error handler', async () => {
+    const mod = await loadTriggers();
+    const boom = new Error('job blew up');
+    mod.triggerAutoCheckout.mockRejectedValueOnce(boom);
+    const res = buildRes();
+    const next = jest.fn();
+
+    await mod.manualAutoCheckout(req(), res, next);
+
+    expect(next).toHaveBeenCalledWith(boom);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+});
+
+describe('date-driven triggers', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it.each(DATE_TRIGGERS)('%s requires target_date', async (fnName, jobName) => {
+    const mod = await loadTriggers();
+    const res = buildRes();
+
+    await mod[fnName](req(), res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'target_date harus YYYY-MM-DD'
+    });
+    expect(mod[jobName]).not.toHaveBeenCalled();
+  });
+
+  it.each(DATE_TRIGGERS)('%s rejects a malformed target_date', async (fnName, jobName) => {
+    const mod = await loadTriggers();
+    const res = buildRes();
+
+    await mod[fnName](req({ body: { target_date: '28-07-2026' } }), res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(mod[jobName]).not.toHaveBeenCalled();
+  });
+
+  it.each(DATE_TRIGGERS)('%s passes a valid target_date to its job', async (fnName, jobName) => {
+    const mod = await loadTriggers();
+    const res = buildRes();
+
+    await mod[fnName](req({ body: { target_date: '2026-07-28' } }), res, jest.fn());
+
+    expect(mod[jobName]).toHaveBeenCalledWith('2026-07-28');
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it.each(DATE_TRIGGERS)('%s trims surrounding whitespace', async (fnName, jobName) => {
+    const mod = await loadTriggers();
+
+    await mod[fnName](req({ body: { target_date: '  2026-07-28  ' } }), buildRes(), jest.fn());
+
+    expect(mod[jobName]).toHaveBeenCalledWith('2026-07-28');
+  });
+
+  /**
+   * The date may arrive in the body, the query string, or the path params.
+   * Clients rely on this; an extracted validator that only reads the body
+   * would silently break the query-string callers.
+   */
+  it.each(DATE_TRIGGERS)('%s accepts target_date from the query string', async (fnName, jobName) => {
+    const mod = await loadTriggers();
+
+    await mod[fnName](req({ query: { target_date: '2026-07-28' } }), buildRes(), jest.fn());
+
+    expect(mod[jobName]).toHaveBeenCalledWith('2026-07-28');
+  });
+
+  it.each(DATE_TRIGGERS)('%s accepts target_date from the path params', async (fnName, jobName) => {
+    const mod = await loadTriggers();
+
+    await mod[fnName](req({ params: { target_date: '2026-07-28' } }), buildRes(), jest.fn());
+
+    expect(mod[jobName]).toHaveBeenCalledWith('2026-07-28');
+  });
+
+  /**
+   * F29, characterized not fixed.
+   *
+   * The validator is /^\d{4}-\d{2}-\d{2}$/ -- a shape check, not a calendar
+   * check. A date that cannot exist passes straight through to a job that
+   * writes attendance state.
+   */
+  it.each(DATE_TRIGGERS)('%s accepts an impossible calendar date', async (fnName, jobName) => {
+    const mod = await loadTriggers();
+    const res = buildRes();
+
+    await mod[fnName](req({ body: { target_date: '2026-13-45' } }), res, jest.fn());
+
+    expect(mod[jobName]).toHaveBeenCalledWith('2026-13-45');
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+});
+
+describe('redundant in-controller authorization', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  /**
+   * F28, characterized not fixed.
+   *
+   * All five routes already carry roleGuard(['Admin', 'Management']), proven
+   * by attendanceRouteContract.test.js. Each controller then repeats the same
+   * check, so this 403 branch is unreachable through the mounted route.
+   *
+   * It is the mirror image of F10: /api/discipline enforces authorization in
+   * the controller with NO roleGuard, while these five have both. Neither
+   * places it consistently. The migrated module should keep it on the route.
+   */
+  it.each([
+    ['manualAutoCheckout'],
+    ['manualResolveWfaBookings'],
+    ['manualGeneralAlphaForDate'],
+    ['manualResolveWfaForDate'],
+    ['manualSmartAutoCheckoutForDate']
+  ])('%s still refuses a plain User when called directly', async (fnName) => {
+    const mod = await loadTriggers();
+    const res = buildRes();
+
+    await mod[fnName](req({ user: { id: 9, role_name: 'User' } }), res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it('never reaches its job when the redundant check fires', async () => {
+    const mod = await loadTriggers();
+
+    await mod.manualGeneralAlphaForDate(
+      req({ user: { id: 9, role_name: 'User' }, body: { target_date: '2026-07-28' } }),
+      buildRes(),
+      jest.fn()
+    );
+
+    expect(mod.runGeneralAlphaForDate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Continues [INF-252](https://linear.app/infinite-track-palu/issue/INF-252/backendarchitecture-adopt-modular-mvc-per-feature-with-safe) Phase 0b. **Tests and documentation only — zero production code changes.**

Closes the largest genuine gap identified in #108. Routing and authorization for these five were already pinned; **what each does once called was not** — and every one invokes a background job that writes final attendance state.

## What the 30 tests pin

Each trigger's job delegation and response shape, plus the validator the three date-driven ones share:

- `target_date` required, and rejected when malformed
- whitespace trimmed
- **read from the body, the query string, *or* the path params**

That last one matters for migration: clients rely on it, and an extracted validator that only read `req.body` would silently break every query-string caller.

## F28 — authorization checked twice, in two places

All five routes carry `roleGuard(['Admin', 'Management'])` — proven by `attendanceRouteContract.test.js`. Each controller then repeats the same check, so **the controllers' 403 branch is unreachable through the mounted route**.

This is the mirror image of F10:

| | `roleGuard` on route | check in controller |
|---|---|---|
| `/api/discipline` (3 of 4 routes) | **no** | yes |
| `manual-*` (all 5) | yes | **yes, redundant** |

Neither places authorization consistently. The tests pin both halves, so whichever way the migrated module unifies it, the change is visible.

## F29 — the date validator checks shape, not calendar

```js
if (!target_date || !/^\d{4}-\d{2}-\d{2}$/.test(String(target_date))) { ... }
```

`2026-13-45` passes this and reaches a job that writes attendance state. Pinned as current behavior:

```js
expect(mod[jobName]).toHaveBeenCalledWith('2026-13-45');
expect(res.status).toHaveBeenCalledWith(200);
```

## Where Phase 0b stands now

**Every mutation in the API is characterized.** The remaining gaps are five read-only endpoints — `GET /api/attendance`, `POST /location-event`, the two auto-checkout settings reads, and RBAC on the two summary exports. They are listed explicitly in the inventory rather than glossed.

I flagged in #108 that I had earlier overstated completeness. That claim is now accurate for mutations, and the inventory says so precisely.

## Verification

```
npm run lint    clean
npm test        109 suites / 926 tests passing  (896 on develop + 30)
git diff --stat develop..HEAD -- src/    (no output)
```

## Review focus

1. F28 — remove the redundant controller checks, or keep them as defence in depth? They are unreachable today either way.
2. F29 — is a real calendar check wanted, given these are Admin-only operational tools?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added comprehensive coverage for manual attendance actions, including successful responses, authorization failures, date validation, and job-error handling.
  - Verified supported date input locations and consistent handling of operational triggers.

- **Documentation**
  - Updated attendance API coverage records to reflect completed contract verification.
  - Documented remaining coverage gaps and identified date-validation and authorization consistency considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->