### PR TITLE
test(INF-252): pin getAllAttendances and logLocationEvent

### DIFF
--- a/docs/architecture/api-contract-inventory.md
+++ b/docs/architecture/api-contract-inventory.md
@@ -97,8 +97,8 @@ All require `verifyToken`. Roles column shows the additional `roleGuard`.
 
 | Method | Path | Roles | Error codes | Happy | RBAC | Validation |
 |---|---|---|---|---|---|---|
-| POST | `/location-event` | any | 400 | route-only | covered | **gap** |
-| GET | `/` | Admin, Management | 401, 403 | route-only | covered | **gap** |
+| POST | `/location-event` | any | 400 `INVALID_LOCATION_ID`/`INVALID_TIMESTAMP`/`NO_ACTIVE_SESSION`/`SESSION_ALREADY_ENDED` | covered | covered | covered |
+| GET | `/` | Admin, Management | 400, 401, 403 | covered | covered | covered |
 | GET | `/today-locations` | Admin, Management | 400, 401, 403 | covered | covered | covered |
 | GET | `/geofence-evidence` | Admin, Management | 400, 401, 403 | covered | covered | covered |
 | POST | `/check-in` | any | 400, 409, 500 | covered | covered | covered |
@@ -176,8 +176,10 @@ Also pinned: the search radius comes from the `wfa.recommendation.search_radius`
 |---|---|---|---|---|---|---|
 | GET | `/api/summary/dashboard-analytics` | Admin, Management | 400, 401, 403 | covered | covered | covered |
 | GET | `/api/summary/reports` | Admin, Management | 400, 401, 403 | covered | covered | covered |
-| GET | `/api/summary/reports/pdf` | Admin, Management | 400 | covered | **gap** | partial |
-| GET | `/api/summary/reports/excel` | Admin, Management | 400 | covered | **gap** | partial |
+| GET | `/api/summary/reports/pdf` | Admin, Management | 400 | covered | covered | partial |
+| GET | `/api/summary/reports/excel` | Admin, Management | 400 | covered | covered | partial |
+
+**Correction.** These two were listed as RBAC gaps. They are not — `tests/routeAuthorizationMatrix.test.js` covers both in its privileged set. The rows were simply not updated when that file landed.
 
 ## 7. `/api/discipline` — 4 endpoints
 
@@ -274,6 +276,7 @@ Baseline as measured on 2026-07-26, before any Phase 0b work:
 | Discipline payloads | **done** | `tests/disciplinePayloadContract.test.js`, 15 tests |
 | Reference data payloads | **done** | `tests/referenceDataContract.test.js`, 10 tests |
 | Attendance — five `manual-*` operational triggers | **done** | `tests/attendanceManualTriggersContract.test.js`, 30 tests |
+| Attendance — `getAllAttendances` and `logLocationEvent` | **done** | `tests/attendanceReadsContract.test.js`, 19 tests |
 
 **The Users module is fully characterized.** All six endpoints have routing, authorization, validation and controller behavior pinned across four test files and 56 tests. It is the first module scheduled for extraction in Phase 3, and it is now the best-covered feature in the codebase.
 
@@ -301,11 +304,10 @@ Every slice on the Phase 0b list is done. That is **not** the same as full cover
 
 | Endpoint | What is missing | Why it matters |
 |---|---|---|
-| `GET /api/attendance` | controller behavior — the admin list with search and sorting | The busiest admin read; its query shape moves in Phase 2 |
-| `POST /api/attendance/location-event` | controller behavior and validation | Writes `LocationEvent`, feeds geofence evidence |
-| `GET /api/attendance/auto-checkout-settings` | controller behavior | Read-only diagnostic |
-| `GET /api/attendance/enhanced-auto-checkout-settings` | controller behavior | Read-only diagnostic |
-| `GET /api/summary/reports/pdf` and `/excel` | RBAC assertions | Route-level only today |
+| `GET /api/attendance/auto-checkout-settings` | controller behavior | Read-only diagnostic, no mutation, no external call |
+| `GET /api/attendance/enhanced-auto-checkout-settings` | controller behavior | Read-only diagnostic, no mutation, no external call |
+
+Two endpoints, both Admin/Management diagnostics that read settings and return them. Their routing and authorization are pinned. They are the lowest-value coverage left in the codebase, and are listed rather than quietly dropped.
 
 **The five `manual-*` triggers are now covered** by `tests/attendanceManualTriggersContract.test.js` (30 tests) — each one's job delegation, its response shape, the shared `target_date` validator, and the three request locations that validator reads from.
 
@@ -373,6 +375,8 @@ Recorded, deliberately **not fixed** under INF-252. Each needs its own issue.
 | F15 | Nine `console.log` calls sit in the `checkOut` final-state mutation path, printing raw attendance rows. They bypass the winston logger used everywhere else, so they carry no request ID and no structured format | `src/controllers/attendance.controller.js:1503-1508,1525-1529` |
 | **F16** | **The `EARLY` check-in status is unreachable.** The working-hours gate returns 400 when `currentTimeMinutes < checkinStartMinutes`, and the classifier below tests that identical condition to assign `status_id: 4` / `EARLY`. Nothing can satisfy the second test after passing the first, so `status_id 4` can never be produced by check-in | `attendance.controller.js:757` vs `:918-921` |
 | F18 | `debugGeoapifyApi` is exported from `wfa.controller.js` but imported nowhere and mounted on no route — roughly 127 lines of dead code in a 586-line controller. It also calls Geoapify directly, so it duplicates the integration logic that Phase 4 is meant to consolidate | `src/controllers/wfa.controller.js:459-586` |
+| **F30** | **The pagination guard lets non-numeric input past.** `getAllAttendances` checks `pageNum < 1 \|\| limitNum < 1`. `parseInt('abc')` is `NaN`, and every comparison with `NaN` is false, so `?page=abc&limit=xyz` walks past a guard whose message promises *"harus berupa angka positif"* and reaches Sequelize as `NaN` | `attendance.controller.js` — `getAllAttendances` |
+| F31 | **A third error-code convention.** `logLocationEvent` reports its four refusals in an `error` field (`INVALID_LOCATION_ID`, `INVALID_TIMESTAMP`, `NO_ACTIVE_SESSION`, `SESSION_ALREADY_ENDED`). The codebase now has three: `code: 'E_VALIDATION'` (validator, WFA), the code embedded in the message string (`updateUser`, F27), and this | `attendance.controller.js` — `logLocationEvent` |
 | **F28** | **The five `manual-*` triggers duplicate an authorization check the route already performs.** All five routes carry `roleGuard(['Admin', 'Management'])`, so the controllers' own 403 branch is unreachable through the mounted route. This is the mirror image of F10 — `/api/discipline` enforces authorization in the controller with *no* `roleGuard`, while these have both. Neither places it consistently | `attendance.controller.js:1746,1829,1857,1883,1909` |
 | **F29** | **`target_date` is validated by shape, not by calendar.** The check is `/^\d{4}-\d{2}-\d{2}$/`, so `2026-13-45` passes and reaches a job that writes attendance state | `attendance.controller.js:1866,1892,1918` |
 | **F26** | **`updateUser` writes two tables with no transaction.** It updates the user row and then the WFH location as independent operations. A failure between them leaves the user half-updated with nothing to roll it back. `createUser` wraps its three writes in one transaction; this one opens none at all | `src/controllers/user.controller.js:292-472` |

--- a/tests/attendanceReadsContract.test.js
+++ b/tests/attendanceReadsContract.test.js
@@ -1,0 +1,365 @@
+import { jest } from '@jest/globals';
+
+/**
+ * Characterization coverage for the two substantive attendance reads
+ * (INF-252 Phase 0b).
+ *
+ * getAllAttendances is the busiest admin read and the one whose query shape
+ * moves into a query object in Phase 2. logLocationEvent writes LocationEvent
+ * and gates on attendance session state, so it is a mutation despite reading
+ * like a log endpoint.
+ *
+ * Three findings came out of writing these, all recorded rather than fixed:
+ * a validation guard that non-numeric input walks straight past (F30), a third
+ * distinct error-code convention (F31), and the contrast between this endpoint's
+ * pagination and getAllUsers having none at all (F20).
+ */
+
+const buildRes = () => {
+  const res = {};
+  res.status = jest.fn(() => res);
+  res.json = jest.fn(() => res);
+  return res;
+};
+
+const attendanceRow = () => ({
+  id_attendance: 1,
+  user_id: 7,
+  attendance_date: '2026-07-28',
+  time_in: '2026-07-28 09:00:00',
+  time_out: null,
+  work_hour: 0,
+  notes: null,
+  user: { full_name: 'Nadia Putri', nip_nim: 'A12345' },
+  attendance_category: { category_name: 'WFO' },
+  attendance_status: { attendance_status_name: 'ON TIME' },
+  location: null,
+  booking: null
+});
+
+const loadAttendanceReads = async ({
+  findAndCountAll = { count: 0, rows: [] },
+  location = { location_id: 5 },
+  activeAttendance = { id_attendance: 1, time_out: null },
+  locationEventCreate
+} = {}) => {
+  jest.resetModules();
+
+  const applySearch = jest.fn();
+  const findAndCountAllFn = jest.fn().mockResolvedValue(findAndCountAll);
+  const attendanceFindOne = jest.fn().mockResolvedValue(activeAttendance);
+  const locationFindByPk = jest.fn().mockResolvedValue(location);
+  const eventCreate = locationEventCreate || jest.fn().mockResolvedValue({ id: 99 });
+
+  jest.unstable_mockModule('../src/config/database.js', () => ({
+    default: { transaction: jest.fn() }
+  }));
+
+  jest.unstable_mockModule('../src/models/index.js', () => ({
+    Attendance: {
+      findAndCountAll: findAndCountAllFn,
+      findOne: attendanceFindOne,
+      findByPk: jest.fn(),
+      findAll: jest.fn(),
+      create: jest.fn()
+    },
+    LocationEvent: { create: eventCreate },
+    Location: { findByPk: locationFindByPk, findOne: jest.fn() },
+    Booking: { findOne: jest.fn() },
+    Settings: { findAll: jest.fn().mockResolvedValue([]), findOne: jest.fn() },
+    AttendanceCategory: {},
+    AttendanceStatus: {},
+    BookingStatus: {},
+    User: {},
+    Role: {},
+    Photo: {}
+  }));
+
+  jest.unstable_mockModule('../src/utils/searchHelper.js', () => ({ applySearch }));
+
+  jest.unstable_mockModule('../src/utils/geofence.js', () => ({
+    calculateDistance: jest.fn(() => 0),
+    getJakartaTime: jest.fn(() => new Date()),
+    getJakartaDateString: jest.fn(() => '2026-07-28'),
+    getCurrentTimeForDB: jest.fn(() => new Date()),
+    toJakartaTime: jest.fn((d) => d)
+  }));
+
+  jest.unstable_mockModule('../src/utils/workHourFormatter.js', () => ({
+    calculateWorkHour: jest.fn(() => 0),
+    formatWorkHour: jest.fn(() => '00:00:00'),
+    formatTimeOnly: jest.fn(() => '09:00')
+  }));
+
+  jest.unstable_mockModule('../src/jobs/autoCheckout.job.js', () => ({
+    triggerAutoCheckout: jest.fn(),
+    runSmartAutoCheckoutForDate: jest.fn()
+  }));
+
+  jest.unstable_mockModule('../src/utils/logger.js', () => ({
+    default: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() }
+  }));
+
+  jest.unstable_mockModule('../src/utils/fuzzyAhpEngine.js', () => ({ default: {} }));
+  jest.unstable_mockModule('../src/analytics/fahp.extent.js', () => ({
+    extentWeightsTFN: jest.fn(() => [0.4, 0.2, 0.2, 0.2])
+  }));
+  jest.unstable_mockModule('../src/analytics/fahp.js', () => ({
+    defuzzifyMatrixTFN: jest.fn(() => []),
+    computeCR: jest.fn(() => ({ CR: 0.05 }))
+  }));
+  jest.unstable_mockModule('../src/analytics/config.fahp.js', () => ({
+    SMART_AC_PAIRWISE_TFN: []
+  }));
+
+  const mod = await import('../src/controllers/attendance.controller.js');
+  return { ...mod, applySearch, findAndCountAllFn, locationFindByPk, eventCreate };
+};
+
+const listReq = (query = {}) => ({ query, user: { id: 1, role_name: 'Admin' } });
+
+describe('getAllAttendances pagination', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('defaults to page 1 with 10 records', async () => {
+    const { getAllAttendances, findAndCountAllFn } = await loadAttendanceReads();
+
+    await getAllAttendances(listReq(), buildRes(), jest.fn());
+
+    expect(findAndCountAllFn).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 10, offset: 0, distinct: true })
+    );
+  });
+
+  it('computes the offset from page and limit', async () => {
+    const { getAllAttendances, findAndCountAllFn } = await loadAttendanceReads();
+
+    await getAllAttendances(listReq({ page: '3', limit: '25' }), buildRes(), jest.fn());
+
+    expect(findAndCountAllFn).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 25, offset: 50 })
+    );
+  });
+
+  it.each([
+    ['page zero', { page: '0' }],
+    ['negative page', { page: '-1' }],
+    ['limit zero', { limit: '0' }],
+    ['negative limit', { limit: '-5' }]
+  ])('refuses %s', async (_name, query) => {
+    const { getAllAttendances, findAndCountAllFn } = await loadAttendanceReads();
+    const res = buildRes();
+
+    await getAllAttendances(listReq(query), res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Parameter page dan limit harus berupa angka positif'
+    });
+    expect(findAndCountAllFn).not.toHaveBeenCalled();
+  });
+
+  /**
+   * F30, characterized not fixed.
+   *
+   * The guard is `pageNum < 1 || limitNum < 1`. parseInt('abc') is NaN, and
+   * every comparison with NaN is false, so non-numeric input walks straight
+   * past a check whose message promises "harus berupa angka positif" and
+   * reaches Sequelize as NaN.
+   */
+  it('lets non-numeric page and limit past the positive-number guard', async () => {
+    const { getAllAttendances, findAndCountAllFn } = await loadAttendanceReads();
+    const res = buildRes();
+
+    await getAllAttendances(listReq({ page: 'abc', limit: 'xyz' }), res, jest.fn());
+
+    expect(res.status).not.toHaveBeenCalledWith(400);
+    const options = findAndCountAllFn.mock.calls[0][0];
+    expect(Number.isNaN(options.limit)).toBe(true);
+    expect(Number.isNaN(options.offset)).toBe(true);
+  });
+
+  it('returns the full pagination envelope', async () => {
+    const { getAllAttendances } = await loadAttendanceReads({
+      findAndCountAll: { count: 42, rows: [attendanceRow()] }
+    });
+    const res = buildRes();
+
+    await getAllAttendances(listReq({ page: '2', limit: '10' }), res, jest.fn());
+
+    const body = res.json.mock.calls[0][0];
+    expect(body.success).toBe(true);
+    expect(body.message).toBe('Data absensi berhasil diambil');
+    expect(body.pagination).toEqual({
+      current_page: 2,
+      total_pages: 5,
+      total_records: 42,
+      records_per_page: 10,
+      has_next_page: true,
+      has_prev_page: true
+    });
+  });
+
+  it('reports no next page on the last page and no prev page on the first', async () => {
+    const { getAllAttendances } = await loadAttendanceReads({
+      findAndCountAll: { count: 5, rows: [] }
+    });
+    const res = buildRes();
+
+    await getAllAttendances(listReq({ page: '1', limit: '10' }), res, jest.fn());
+
+    expect(res.json.mock.calls[0][0].pagination).toMatchObject({
+      total_pages: 1,
+      has_next_page: false,
+      has_prev_page: false
+    });
+  });
+});
+
+describe('getAllAttendances search', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('searches the joined user name and NIP only', async () => {
+    const { getAllAttendances, applySearch } = await loadAttendanceReads();
+
+    await getAllAttendances(listReq({ search: 'nadia' }), buildRes(), jest.fn());
+
+    expect(applySearch).toHaveBeenCalledWith(expect.anything(), 'nadia', [
+      '$user.full_name$',
+      '$user.nip_nim$'
+    ]);
+  });
+
+  it.each([['absent', {}], ['blank', { search: '   ' }]])(
+    'applies no search when the term is %s',
+    async (_name, query) => {
+      const { getAllAttendances, applySearch } = await loadAttendanceReads();
+
+      await getAllAttendances(listReq(query), buildRes(), jest.fn());
+
+      expect(applySearch).not.toHaveBeenCalled();
+    }
+  );
+
+  it('forwards a query failure to the error handler', async () => {
+    const boom = new Error('db down');
+    const mod = await loadAttendanceReads();
+    mod.findAndCountAllFn.mockRejectedValueOnce(boom);
+    const res = buildRes();
+    const next = jest.fn();
+
+    await mod.getAllAttendances(listReq(), res, next);
+
+    expect(next).toHaveBeenCalledWith(boom);
+    expect(res.json).not.toHaveBeenCalled();
+  });
+});
+
+const eventReq = (body = {}) => ({
+  body: {
+    event_type: 'ENTER',
+    location_id: 5,
+    event_timestamp: '2026-07-28T09:00:00+07:00',
+    ...body
+  },
+  user: { id: 7, role_name: 'User' }
+});
+
+describe('logLocationEvent refusals', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  /**
+   * F31, characterized not fixed.
+   *
+   * These four refusals report their code in an `error` field. That is a third
+   * convention in one codebase: `code: 'E_VALIDATION'` (validator, wfa),
+   * the code embedded in the message string (updateUser, F27), and this.
+   */
+  it('rejects an unknown location with an error field, not a code field', async () => {
+    const { logLocationEvent, eventCreate } = await loadAttendanceReads({ location: null });
+    const res = buildRes();
+
+    await logLocationEvent(eventReq(), res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    const body = res.json.mock.calls[0][0];
+    expect(body).toEqual({
+      success: false,
+      message: 'Location ID tidak valid',
+      error: 'INVALID_LOCATION_ID'
+    });
+    expect(body).not.toHaveProperty('code');
+    expect(eventCreate).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unparseable timestamp', async () => {
+    const { logLocationEvent, eventCreate } = await loadAttendanceReads();
+    const res = buildRes();
+
+    await logLocationEvent(eventReq({ event_timestamp: 'not-a-date' }), res, jest.fn());
+
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Format timestamp tidak valid',
+      error: 'INVALID_TIMESTAMP'
+    });
+    expect(eventCreate).not.toHaveBeenCalled();
+  });
+
+  it('refuses when the user has not checked in on the event date', async () => {
+    const { logLocationEvent, eventCreate } = await loadAttendanceReads({
+      activeAttendance: null
+    });
+    const res = buildRes();
+
+    await logLocationEvent(eventReq(), res, jest.fn());
+
+    expect(res.json.mock.calls[0][0]).toMatchObject({ error: 'NO_ACTIVE_SESSION' });
+    expect(eventCreate).not.toHaveBeenCalled();
+  });
+
+  it('refuses when the session has already been checked out', async () => {
+    const { logLocationEvent, eventCreate } = await loadAttendanceReads({
+      activeAttendance: { id_attendance: 1, time_out: '2026-07-28 17:00:00' }
+    });
+    const res = buildRes();
+
+    await logLocationEvent(eventReq(), res, jest.fn());
+
+    expect(res.json.mock.calls[0][0]).toMatchObject({ error: 'SESSION_ALREADY_ENDED' });
+    expect(eventCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe('logLocationEvent success', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('creates the event against the authenticated user, not a body-supplied id', async () => {
+    const { logLocationEvent, eventCreate } = await loadAttendanceReads();
+
+    await logLocationEvent(eventReq({ user_id: 999 }), buildRes(), jest.fn());
+
+    expect(eventCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ user_id: 7, location_id: 5, event_type: 'ENTER' })
+    );
+  });
+
+  it('looks the attendance session up by the Jakarta date of the event', async () => {
+    const mod = await loadAttendanceReads();
+    const { Attendance } = await import('../src/models/index.js');
+
+    // 2026-07-28T23:30:00Z is 2026-07-29 in Jakarta.
+    await mod.logLocationEvent(
+      eventReq({ event_timestamp: '2026-07-28T23:30:00Z' }),
+      buildRes(),
+      jest.fn()
+    );
+
+    expect(Attendance.findOne).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ user_id: 7, attendance_date: '2026-07-29' })
+      })
+    );
+  });
+});


### PR DESCRIPTION
Continues [INF-252](https://linear.app/infinite-track-palu/issue/INF-252/backendarchitecture-adopt-modular-mvc-per-feature-with-safe) Phase 0b. **Tests and documentation only — zero production code changes.**

The two substantive reads left. `getAllAttendances` is the busiest admin read and the one whose query shape moves into a query object in Phase 2. `logLocationEvent` writes `LocationEvent` and gates on attendance session state, so it is a **mutation** despite reading like a log endpoint.

## What the 19 tests pin

Pagination defaults and offset arithmetic, the four rejection cases, the full pagination envelope with its `has_next_page` / `has_prev_page` derivation, the search predicate and its blank-term skip, all four `logLocationEvent` refusals, and the Jakarta-date session lookup.

That last one is worth calling out — the test uses `2026-07-28T23:30:00Z`, which is **2026-07-29 in Jakarta**, and asserts the session is looked up under the Jakarta date. Unlike `checkIn` (F17), this endpoint derives the date with an explicit `Intl.DateTimeFormat({ timeZone: 'Asia/Jakarta' })` rather than a raw `new Date()`. It is the correct pattern, in the same file as the incorrect one.

## F30 — the pagination guard lets non-numeric input past

```js
if (pageNum < 1 || limitNum < 1) { return res.status(400)... }
```

`parseInt('abc')` is `NaN`, and every comparison with `NaN` is false. So `?page=abc&limit=xyz` walks straight past a guard whose message promises *"harus berupa angka positif"*, and reaches Sequelize as `NaN`:

```js
expect(res.status).not.toHaveBeenCalledWith(400);
expect(Number.isNaN(options.limit)).toBe(true);
expect(Number.isNaN(options.offset)).toBe(true);
```

## F31 — a third error-code convention

`logLocationEvent` reports its four refusals in an **`error`** field. The codebase now has three ways to say the same thing:

| Convention | Where |
|---|---|
| `code: 'E_VALIDATION'` | validator, WFA |
| code embedded in the message string | `updateUser` (F27) |
| `error: 'INVALID_LOCATION_ID'` | `logLocationEvent` |

Relevant to [INF-256](https://linear.app/infinite-track-palu/issue/INF-256/backend-harden-the-merged-inf-252-foundations-error-code-override-and): the typed-error taxonomy has to absorb three shapes, not one.

## Worth knowing before Phase 2

`getAllAttendances` has **full pagination** — page, limit, offset, count, `distinct: true`, and a six-field envelope. `getAllUsers` has **none at all** (F20).

Two admin lists in one codebase, two entirely different contracts. The allowlisted list-query foundation in Phase 2 has to reconcile them, and now both shapes are pinned so neither can drift while that happens.

## Inventory corrections

The summary `pdf` and `excel` exports were marked as RBAC gaps. They are not — `routeAuthorizationMatrix.test.js` covers both. The rows were simply never updated when that file landed.

## Where Phase 0b stands

**Two endpoints remain**, both Admin/Management diagnostics that read settings and return them: `auto-checkout-settings` and `enhanced-auto-checkout-settings`. No mutation, no external call, routing and authorization already pinned. They are the lowest-value coverage left in the codebase — listed rather than quietly dropped.

## Verification

```
npm run lint    clean
npm test        110 suites / 945 tests passing  (926 on develop + 19)
git diff --stat develop..HEAD -- src/    (no output)
```

## Review focus

1. F30 — worth fixing now, or does it fold into Phase 2's query foundation?
2. The `getAllAttendances` vs `getAllUsers` pagination split — should Phase 2 unify on the attendance shape, or design a new one?

🤖 Generated with [Claude Code](https://claude.com/claude-code)