### PR TITLE
test(INF-252): close Phase 0b with the two auto-checkout diagnostics

### DIFF
--- a/docs/architecture/api-contract-inventory.md
+++ b/docs/architecture/api-contract-inventory.md
@@ -46,8 +46,8 @@ with successful list responses adding `data` and `pagination`. Two documented de
 | Method | Path | Auth | Roles | Request | Error codes | Happy | RBAC | Validation |
 |---|---|---|---|---|---|---|---|---|
 | POST | `/api/auth/login` | none, rate-limited | — | body: email, password | 400, 401, 429 | covered | covered | covered |
-| POST | `/api/auth/refresh` | refresh token | — | `refresh_token` **cookie or body** | 401 | covered | covered | **gap** |
-| POST | `/api/auth/logout` | none | — | `refresh_token` cookie or body; access token also identifies the session | 200; 5xx paths **needs verification** | covered | n/a | **gap** |
+| POST | `/api/auth/refresh` | refresh token | — | `refresh_token` **cookie or body** | 401 | covered | covered | n/a |
+| POST | `/api/auth/logout` | none | — | `refresh_token` cookie or body; access token also identifies the session | 200; 5xx paths **needs verification** | covered | n/a | n/a |
 | GET | `/api/auth/me` | Bearer or cookie | any | — | 401 | covered | covered | n/a |
 
 Strongest-covered module in the codebase: seven dedicated auth test files.
@@ -105,21 +105,21 @@ All require `verifyToken`. Roles column shows the additional `roleGuard`.
 | POST | `/checkout/:id` | any | 400, 403, 404 | covered | covered | covered |
 | GET | `/history/personal/pdf` | any | 400 | covered | covered | covered |
 | GET | `/history/export.pdf` | any | 400 | covered | covered | covered |
-| GET | `/history` | any | 200, 401 | covered | covered | **gap** |
+| GET | `/history` | any | 200, 401 | covered | covered | n/a |
 | GET | `/status-today` | any | 200 | partial | covered | n/a |
 | GET | `/debug-checkin-time` | Admin, Management | 200, 400, 401, 403 | covered | covered | covered |
 | POST | `/manual-auto-checkout` | Admin, Management | 401, 403 | covered | covered | n/a |
-| GET | `/auto-checkout-settings` | Admin, Management | 401, 403 | route-only | covered | n/a |
+| GET | `/auto-checkout-settings` | Admin, Management | 401, 403 | covered | covered | n/a |
 | POST | `/manual-resolve-wfa-bookings` | Admin, Management | 401, 403 | covered | covered | n/a |
 | POST | `/manual-general-alpha` | Admin, Management | 400 | covered | covered | covered |
 | POST | `/manual-resolve-wfa-for-date` | Admin, Management | 400 | covered | covered | covered |
 | POST | `/manual-smart-auto-checkout` | Admin, Management | 400 | covered | covered | covered |
 | POST | `/research-trigger/daily` | Admin, Management | 400, 409 `E_INVALID_REFERENCE_STATE` | covered | covered | covered |
 | POST | `/research-trigger/full-day` | Admin, Management | 400, 409 `E_INVALID_REFERENCE_STATE` | covered | covered | covered |
-| POST | `/test-weighted-prediction` | Admin, Management | 200 | partial | covered | **gap** |
+| POST | `/test-weighted-prediction` | Admin, Management | 200 | partial | covered | n/a |
 | DELETE | `/:id` | Admin, Management | 401, 403, 404 | covered | covered | n/a |
 | GET | `/smart-config` | Admin, Management | 200 | route-only | covered | n/a |
-| GET | `/enhanced-auto-checkout-settings` | Admin, Management | 200 | route-only | covered | **gap** |
+| GET | `/enhanced-auto-checkout-settings` | Admin, Management | 200 | covered | covered | n/a |
 
 `/check-in` and `/checkout/:id` are both fully pinned as of 2026-07-26, by `tests/attendanceCheckinContract.test.js` (17 tests) and `tests/attendanceCheckoutContract.test.js` (10 tests). `attendanceDuplicateSafety.test.js` continues to own the two 409 duplicate paths.
 
@@ -277,6 +277,7 @@ Baseline as measured on 2026-07-26, before any Phase 0b work:
 | Reference data payloads | **done** | `tests/referenceDataContract.test.js`, 10 tests |
 | Attendance — five `manual-*` operational triggers | **done** | `tests/attendanceManualTriggersContract.test.js`, 30 tests |
 | Attendance — `getAllAttendances` and `logLocationEvent` | **done** | `tests/attendanceReadsContract.test.js`, 19 tests |
+| Attendance — the two auto-checkout diagnostic reads | **done** | `tests/attendanceSettingsReadsContract.test.js`, 10 tests |
 
 **The Users module is fully characterized.** All six endpoints have routing, authorization, validation and controller behavior pinned across four test files and 56 tests. It is the first module scheduled for extraction in Phase 3, and it is now the best-covered feature in the codebase.
 
@@ -302,12 +303,11 @@ Every slice on the Phase 0b list is done. That is **not** the same as full cover
 
 **Still open, in the priority set:**
 
-| Endpoint | What is missing | Why it matters |
-|---|---|---|
-| `GET /api/attendance/auto-checkout-settings` | controller behavior | Read-only diagnostic, no mutation, no external call |
-| `GET /api/attendance/enhanced-auto-checkout-settings` | controller behavior | Read-only diagnostic, no mutation, no external call |
+**All 60 route-file endpoints are now classified with no remaining gap on any axis.**
 
-Two endpoints, both Admin/Management diagnostics that read settings and return them. Their routing and authorization are pinned. They are the lowest-value coverage left in the codebase, and are listed rather than quietly dropped.
+Every endpoint has its routing and authorization pinned. Every endpoint that performs a mutation, calls an external service, or transforms a response has its controller behavior pinned. The four rows whose Validation axis reads `n/a` do so because **those routes carry no validation middleware at all** — recorded as F34, since sibling routes in the same files do have validators.
+
+This claim has been wrong twice before in this document. It is stated here only after counting: `grep -c '\*\*gap\*\*'` returns 1, and that single occurrence is in the methodology prose above, not in any endpoint row.
 
 **The five `manual-*` triggers are now covered** by `tests/attendanceManualTriggersContract.test.js` (30 tests) — each one's job delegation, its response shape, the shared `target_date` validator, and the three request locations that validator reads from.
 
@@ -375,6 +375,9 @@ Recorded, deliberately **not fixed** under INF-252. Each needs its own issue.
 | F15 | Nine `console.log` calls sit in the `checkOut` final-state mutation path, printing raw attendance rows. They bypass the winston logger used everywhere else, so they carry no request ID and no structured format | `src/controllers/attendance.controller.js:1503-1508,1525-1529` |
 | **F16** | **The `EARLY` check-in status is unreachable.** The working-hours gate returns 400 when `currentTimeMinutes < checkinStartMinutes`, and the classifier below tests that identical condition to assign `status_id: 4` / `EARLY`. Nothing can satisfy the second test after passing the first, so `status_id 4` can never be produced by check-in | `attendance.controller.js:757` vs `:918-921` |
 | F18 | `debugGeoapifyApi` is exported from `wfa.controller.js` but imported nowhere and mounted on no route — roughly 127 lines of dead code in a 586-line controller. It also calls Geoapify directly, so it duplicates the integration logic that Phase 4 is meant to consolidate | `src/controllers/wfa.controller.js:459-586` |
+| F34 | **Four routes carry no validation middleware at all**, so their Validation axis is `n/a` rather than a gap: `POST /api/auth/refresh`, `POST /api/auth/logout`, `GET /api/attendance/history`, and `POST /api/attendance/test-weighted-prediction`. Sibling routes in the same files do have validators — `today-locations` and `geofence-evidence` both do — so this is inconsistency, not a deliberate policy. `/history` in particular reads query parameters with nothing validating them | `auth.routes.js:11-12`, `attendance.routes.js:68,115` |
+| **F33** | **`getEnhancedAutoCheckoutSettings` is an N+1.** It loads the open sessions in one query, then loops over them issuing a further `Attendance.findAll` per session for that user's month of history. N open sessions cost N+1 queries. This is the concrete instance of what INF-252 Phase 8 calls *"audit N+1 and indexes based on actual queries"* | `attendance.controller.js` — `getEnhancedAutoCheckoutSettings` |
+| F32 | `getAutoCheckoutSettings` and `getEnhancedAutoCheckoutSettings` duplicate roughly thirty lines verbatim — the same setting lookup, the same manual Jakarta-offset arithmetic, and the same open-session query with an identical `include`. The enhanced variant is the simple one plus a prediction loop | `attendance.controller.js` — both getters |
 | **F30** | **The pagination guard lets non-numeric input past.** `getAllAttendances` checks `pageNum < 1 \|\| limitNum < 1`. `parseInt('abc')` is `NaN`, and every comparison with `NaN` is false, so `?page=abc&limit=xyz` walks past a guard whose message promises *"harus berupa angka positif"* and reaches Sequelize as `NaN` | `attendance.controller.js` — `getAllAttendances` |
 | F31 | **A third error-code convention.** `logLocationEvent` reports its four refusals in an `error` field (`INVALID_LOCATION_ID`, `INVALID_TIMESTAMP`, `NO_ACTIVE_SESSION`, `SESSION_ALREADY_ENDED`). The codebase now has three: `code: 'E_VALIDATION'` (validator, WFA), the code embedded in the message string (`updateUser`, F27), and this | `attendance.controller.js` — `logLocationEvent` |
 | **F28** | **The five `manual-*` triggers duplicate an authorization check the route already performs.** All five routes carry `roleGuard(['Admin', 'Management'])`, so the controllers' own 403 branch is unreachable through the mounted route. This is the mirror image of F10 — `/api/discipline` enforces authorization in the controller with *no* `roleGuard`, while these have both. Neither places it consistently | `attendance.controller.js:1746,1829,1857,1883,1909` |

--- a/tests/attendanceSettingsReadsContract.test.js
+++ b/tests/attendanceSettingsReadsContract.test.js
@@ -1,0 +1,247 @@
+import { jest } from '@jest/globals';
+
+/**
+ * Characterization coverage for the two auto-checkout diagnostic reads
+ * (INF-252 Phase 0b, final slice).
+ *
+ * These are the last two uncovered endpoints. They are low-risk on their own,
+ * but writing them surfaced two things worth pinning: the pair duplicates
+ * roughly thirty lines verbatim (F32), and the enhanced variant issues one
+ * extra query per active attendance (F33) -- a concrete N+1 of exactly the
+ * kind Phase 8 is meant to audit.
+ */
+
+const buildRes = () => {
+  const res = {};
+  res.status = jest.fn(() => res);
+  res.json = jest.fn(() => res);
+  return res;
+};
+
+const activeRow = (id, userId) => ({
+  id_attendance: id,
+  user_id: userId,
+  attendance_date: '2026-07-28',
+  time_in: '2026-07-28 09:00:00',
+  user: { id_users: userId, full_name: `User ${userId}`, nip_nim: `A${userId}` }
+});
+
+const loadSettingsReads = async ({ autoTimeSetting = { setting_value: '18:30:00' }, active = [] } = {}) => {
+  jest.resetModules();
+
+  const settingsFindOne = jest.fn().mockResolvedValue(autoTimeSetting);
+  // First call returns the active list; later calls are the per-user history
+  // lookups the enhanced endpoint makes inside its loop.
+  const attendanceFindAll = jest.fn().mockResolvedValueOnce(active).mockResolvedValue([]);
+  const getOperationalSettings = jest.fn().mockResolvedValue({
+    autoCheckoutIdleMin: 12,
+    autoCheckoutTBufferMin: 45,
+    defaultShiftEnd: '18:30:00'
+  });
+
+  jest.unstable_mockModule('../src/config/database.js', () => ({
+    default: { transaction: jest.fn() }
+  }));
+
+  jest.unstable_mockModule('../src/models/index.js', () => ({
+    Attendance: {
+      findAll: attendanceFindAll,
+      findOne: jest.fn(),
+      findByPk: jest.fn(),
+      findAndCountAll: jest.fn(),
+      create: jest.fn()
+    },
+    Settings: { findOne: settingsFindOne, findAll: jest.fn().mockResolvedValue([]) },
+    User: {},
+    Booking: { findOne: jest.fn() },
+    Location: { findOne: jest.fn() },
+    LocationEvent: { create: jest.fn() },
+    AttendanceCategory: {},
+    AttendanceStatus: {},
+    BookingStatus: {},
+    Role: {},
+    Photo: {}
+  }));
+
+  jest.unstable_mockModule('../src/utils/settings.js', () => ({ getOperationalSettings }));
+
+  jest.unstable_mockModule('../src/utils/geofence.js', () => ({
+    calculateDistance: jest.fn(() => 0),
+    getJakartaTime: jest.fn(() => new Date()),
+    getJakartaDateString: jest.fn(() => '2026-07-28'),
+    getCurrentTimeForDB: jest.fn(() => new Date()),
+    toJakartaTime: jest.fn((d) => d)
+  }));
+
+  jest.unstable_mockModule('../src/utils/workHourFormatter.js', () => ({
+    calculateWorkHour: jest.fn(() => 0),
+    formatWorkHour: jest.fn(() => '00:00:00'),
+    formatTimeOnly: jest.fn(() => '09:00')
+  }));
+
+  jest.unstable_mockModule('../src/utils/searchHelper.js', () => ({ applySearch: jest.fn() }));
+
+  jest.unstable_mockModule('../src/jobs/autoCheckout.job.js', () => ({
+    triggerAutoCheckout: jest.fn(),
+    runSmartAutoCheckoutForDate: jest.fn()
+  }));
+
+  jest.unstable_mockModule('../src/utils/logger.js', () => ({
+    default: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() }
+  }));
+
+  jest.unstable_mockModule('../src/utils/fuzzyAhpEngine.js', () => ({
+    default: { calculateSmartCheckoutScore: jest.fn(() => ({ score: 50, label: 'MEDIUM' })) }
+  }));
+  jest.unstable_mockModule('../src/analytics/fahp.extent.js', () => ({
+    extentWeightsTFN: jest.fn(() => [0.4, 0.2, 0.2, 0.2])
+  }));
+  jest.unstable_mockModule('../src/analytics/fahp.js', () => ({
+    defuzzifyMatrixTFN: jest.fn(() => []),
+    computeCR: jest.fn(() => ({ CR: 0.05 }))
+  }));
+  jest.unstable_mockModule('../src/analytics/config.fahp.js', () => ({
+    SMART_AC_PAIRWISE_TFN: []
+  }));
+
+  const mod = await import('../src/controllers/attendance.controller.js');
+  return { ...mod, settingsFindOne, attendanceFindAll, getOperationalSettings };
+};
+
+const req = () => ({ query: {}, body: {}, params: {}, user: { id: 1, role_name: 'Admin' } });
+
+describe('getAutoCheckoutSettings', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('reads the configured auto-checkout time', async () => {
+    const { getAutoCheckoutSettings, settingsFindOne } = await loadSettingsReads();
+    const res = buildRes();
+
+    await getAutoCheckoutSettings(req(), res, jest.fn());
+
+    expect(settingsFindOne).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { setting_key: 'checkout.auto_time' } })
+    );
+    expect(res.json.mock.calls[0][0].data.auto_checkout_time).toBe('18:30:00');
+  });
+
+  it('reports "Not configured" when the setting is absent', async () => {
+    const { getAutoCheckoutSettings } = await loadSettingsReads({ autoTimeSetting: null });
+    const res = buildRes();
+
+    await getAutoCheckoutSettings(req(), res, jest.fn());
+
+    expect(res.json.mock.calls[0][0].data.auto_checkout_time).toBe('Not configured');
+  });
+
+  it('selects only sessions that are still open today', async () => {
+    const { getAutoCheckoutSettings, attendanceFindAll } = await loadSettingsReads();
+
+    await getAutoCheckoutSettings(req(), buildRes(), jest.fn());
+
+    expect(attendanceFindAll).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ time_out: null })
+      })
+    );
+  });
+
+  it('maps each open session to the documented shape', async () => {
+    const { getAutoCheckoutSettings } = await loadSettingsReads({
+      active: [activeRow(1, 7), activeRow(2, 8)]
+    });
+    const res = buildRes();
+
+    await getAutoCheckoutSettings(req(), res, jest.fn());
+
+    const { data } = res.json.mock.calls[0][0];
+    expect(data.active_attendances_count).toBe(2);
+    expect(data.active_attendances[0]).toEqual({
+      id_attendance: 1,
+      user_id: 7,
+      user_name: 'User 7',
+      time_in: '09:00',
+      attendance_date: '2026-07-28'
+    });
+  });
+
+  it('forwards a query failure to the error handler', async () => {
+    const boom = new Error('db down');
+    const mod = await loadSettingsReads();
+    mod.settingsFindOne.mockRejectedValueOnce(boom);
+    const res = buildRes();
+    const next = jest.fn();
+
+    await mod.getAutoCheckoutSettings(req(), res, next);
+
+    expect(next).toHaveBeenCalledWith(boom);
+    expect(res.json).not.toHaveBeenCalled();
+  });
+});
+
+describe('getEnhancedAutoCheckoutSettings', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('additionally loads the operational settings', async () => {
+    const { getEnhancedAutoCheckoutSettings, getOperationalSettings } = await loadSettingsReads();
+
+    await getEnhancedAutoCheckoutSettings(req(), buildRes(), jest.fn());
+
+    expect(getOperationalSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('reads the same setting key as its simpler sibling', async () => {
+    const { getEnhancedAutoCheckoutSettings, settingsFindOne } = await loadSettingsReads();
+
+    await getEnhancedAutoCheckoutSettings(req(), buildRes(), jest.fn());
+
+    expect(settingsFindOne).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { setting_key: 'checkout.auto_time' } })
+    );
+  });
+
+  /**
+   * F33, characterized not fixed.
+   *
+   * The endpoint fetches the open sessions in one query, then loops over them
+   * and issues a further Attendance.findAll per session to load that user's
+   * month of history. N open sessions cost N+1 queries.
+   *
+   * This is the concrete instance of what INF-252 Phase 8 calls "audit N+1
+   * and indexes based on actual queries".
+   */
+  it('issues one extra query per open session', async () => {
+    const { getEnhancedAutoCheckoutSettings, attendanceFindAll } = await loadSettingsReads({
+      active: [activeRow(1, 7), activeRow(2, 8), activeRow(3, 9)]
+    });
+
+    await getEnhancedAutoCheckoutSettings(req(), buildRes(), jest.fn());
+
+    // 1 query for the open sessions, then 1 per session.
+    expect(attendanceFindAll).toHaveBeenCalledTimes(4);
+  });
+
+  it('makes no per-session query when nothing is open', async () => {
+    const { getEnhancedAutoCheckoutSettings, attendanceFindAll } = await loadSettingsReads({
+      active: []
+    });
+
+    await getEnhancedAutoCheckoutSettings(req(), buildRes(), jest.fn());
+
+    expect(attendanceFindAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('answers 200 with a success envelope', async () => {
+    const { getEnhancedAutoCheckoutSettings } = await loadSettingsReads({
+      active: [activeRow(1, 7)]
+    });
+    const res = buildRes();
+    const next = jest.fn();
+
+    await getEnhancedAutoCheckoutSettings(req(), res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json.mock.calls[0][0].success).toBe(true);
+  });
+});


### PR DESCRIPTION
Completes [INF-252](https://linear.app/infinite-track-palu/issue/INF-252/backendarchitecture-adopt-modular-mvc-per-feature-with-safe) Phase 0b. **Tests and documentation only — zero production code changes.**

The last two uncovered endpoints. Low-risk on their own, but writing them surfaced three findings.

## F33 — a concrete N+1

`getEnhancedAutoCheckoutSettings` loads the open sessions in one query, then **loops over them** issuing a further `Attendance.findAll` per session for that user's month of history.

```js
// three open sessions
expect(attendanceFindAll).toHaveBeenCalledTimes(4);   // 1 + N
```

This is the concrete instance of what INF-252 Phase 8 calls *"audit N+1 and indexes based on actual queries"* — now pinned, so the count cannot quietly grow.

## F32 — thirty duplicated lines

The two getters share the same setting lookup, the same manual Jakarta-offset arithmetic, and the same open-session query with an identical `include`. The enhanced variant is literally the simple one plus a prediction loop.

## F34 — four routes have no validation middleware at all

`POST /api/auth/refresh`, `POST /api/auth/logout`, `GET /api/attendance/history`, and `POST /api/attendance/test-weighted-prediction` carry **no validator**. Sibling routes in the same files do — `today-locations` and `geofence-evidence` both have one — so this is inconsistency, not policy. `/history` reads query parameters with nothing validating them.

Those four rows are **reclassified from `gap` to `n/a`** after checking the route definitions: there is no validation chain to assert against, so calling it a coverage gap was wrong.

## Phase 0b is complete — and this time it is counted

All 60 route-file endpoints are classified with **no remaining gap on any axis**.

I have made this claim twice before in this project and been wrong both times. So it is now backed by a count rather than a recollection:

```
$ grep -c '\*\*gap\*\*' docs/architecture/api-contract-inventory.md
1
```

That single occurrence is in the methodology prose explaining what `gap` means — not in any endpoint row.

## Where the whole effort landed

| | Start (`5ce2f69`) | Now |
|---|---|---|
| Tests | 579 | **955** |
| Production code changed | — | **101 insertions, 0 deletions** |

376 tests added, every one of them pinning behavior that already existed. **28 findings (F7–F34)**, six raised as their own Linear issues.

## Verification

```
npm run lint    clean
npm test        111 suites / 955 tests passing  (945 on develop + 10)
git diff --stat develop..HEAD -- src/    (no output)
```

## What now blocks progress

Nothing in Phase 0b. The next meaningful step is the baseline schema dump — `db/baseline/README.md` has the procedure. Until it exists, every one of these 955 tests mocks Sequelize, and the four transaction findings (F14, F24, F25, F26) cannot be verified against a real database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)