### PR TITLE
test(INF-252): audit OpenAPI against verified runtime, pin the drift

### DIFF
--- a/docs/architecture/api-contract-inventory.md
+++ b/docs/architecture/api-contract-inventory.md
@@ -375,6 +375,8 @@ Recorded, deliberately **not fixed** under INF-252. Each needs its own issue.
 | F15 | Nine `console.log` calls sit in the `checkOut` final-state mutation path, printing raw attendance rows. They bypass the winston logger used everywhere else, so they carry no request ID and no structured format | `src/controllers/attendance.controller.js:1503-1508,1525-1529` |
 | **F16** | **The `EARLY` check-in status is unreachable.** The working-hours gate returns 400 when `currentTimeMinutes < checkinStartMinutes`, and the classifier below tests that identical condition to assign `status_id: 4` / `EARLY`. Nothing can satisfy the second test after passing the first, so `status_id 4` can never be produced by check-in | `attendance.controller.js:757` vs `:918-921` |
 | F18 | `debugGeoapifyApi` is exported from `wfa.controller.js` but imported nowhere and mounted on no route — roughly 127 lines of dead code in a 586-line controller. It also calls Geoapify directly, so it duplicates the integration logic that Phase 4 is meant to consolidate | `src/controllers/wfa.controller.js:459-586` |
+| **F35** | **`GET /api/users` is documented almost entirely wrong.** OpenAPI declares `page`, `limit`, `role_id` and `division_id` query parameters — the controller reads **none** of them. It omits `sortBy` and `sortOrder`, which the controller does read. It describes `search` as covering "name or email"; the controller searches `full_name` and `nip_nim`. It documents `data` as an object wrapping `users` and `pagination`; the runtime returns `data` as a **flat array** with no pagination, plus an undocumented `message` | `docs/openapi.yaml` vs `user.controller.js` |
+| **F36** | **`GET /api/attendance` documents filters that do not exist and the wrong envelope.** `date` and `user_id` are declared and ignored. `search` is again described as covering email. `data` is documented as an object wrapping `attendances` and `pagination`; the runtime returns `data` as a **flat array** with `pagination` as its **sibling** | `docs/openapi.yaml` vs `attendance.controller.js` |
 | F34 | **Four routes carry no validation middleware at all**, so their Validation axis is `n/a` rather than a gap: `POST /api/auth/refresh`, `POST /api/auth/logout`, `GET /api/attendance/history`, and `POST /api/attendance/test-weighted-prediction`. Sibling routes in the same files do have validators — `today-locations` and `geofence-evidence` both do — so this is inconsistency, not a deliberate policy. `/history` in particular reads query parameters with nothing validating them | `auth.routes.js:11-12`, `attendance.routes.js:68,115` |
 | **F33** | **`getEnhancedAutoCheckoutSettings` is an N+1.** It loads the open sessions in one query, then loops over them issuing a further `Attendance.findAll` per session for that user's month of history. N open sessions cost N+1 queries. This is the concrete instance of what INF-252 Phase 8 calls *"audit N+1 and indexes based on actual queries"* | `attendance.controller.js` — `getEnhancedAutoCheckoutSettings` |
 | F32 | `getAutoCheckoutSettings` and `getEnhancedAutoCheckoutSettings` duplicate roughly thirty lines verbatim — the same setting lookup, the same manual Jakarta-offset arithmetic, and the same open-session query with an identical `include`. The enhanced variant is the simple one plus a prediction loop | `attendance.controller.js` — both getters |
@@ -407,6 +409,27 @@ Recorded, deliberately **not fixed** under INF-252. Each needs its own issue.
 `checkIn` shows the codebase already knows the right shape — it tracks `transactionFinished` and only rolls back when the transaction is still open. Two of its three sibling mutations were never updated to match.
 
 Both are pinned by tests that assert the current, broken outcome, so a fix makes them fail deliberately.
+
+### F35 / F36 — the OpenAPI audit
+
+Two audits were run against `docs/openapi.yaml`. They reached opposite conclusions, and the difference is the point.
+
+**Structural alignment: clean.** 62 mounted operations, 50 documented, **zero documented-but-not-mounted**. All 12 undocumented operations appear on the deliberate exclusion list already enforced by `openApiMountedRoutesContract.test.js` — debug, test and internal-ops endpoints are kept out of the public contract on purpose. Nothing to fix.
+
+**Contract alignment: not clean.** Both admin list endpoints describe a response shape the runtime does not produce.
+
+| | Documented | Actual |
+|---|---|---|
+| `GET /api/users` — query | `page`, `limit`, `search`, `role_id`, `division_id` | `search`, `sortBy`, `sortOrder` |
+| `GET /api/users` — body | `data: { users, pagination }` | `data: [ … ]`, no pagination, plus `message` |
+| `GET /api/attendance` — query | `page`, `limit`, `search`, `date`, `user_id` | `page`, `limit`, `search` |
+| `GET /api/attendance` — body | `data: { attendances, pagination }` | `data: [ … ]`, `pagination` as a **sibling** |
+
+A client written literally against this spec reads `response.data.users` and gets `undefined`.
+
+Note also that the spec describes the two endpoints **identically**, while the runtime behaves differently — attendance paginates, users does not (F20). Phase 2's list-query foundation has to pick one shape, and the spec currently matches neither.
+
+**Not fixed here, deliberately.** Choosing between correcting the document and adding pagination to the runtime is a contract decision, and [INF-250](https://linear.app/infinite-track-palu/issue/INF-250/cross-repo-define-scalable-user-directory-search-filter-sort-and) exists to make it. `tests/openApiRuntimeDriftContract.test.js` pins the mismatch so it cannot drift further or be closed by accident.
 
 ### F24 — the delete asymmetry
 

--- a/tests/openApiRuntimeDriftContract.test.js
+++ b/tests/openApiRuntimeDriftContract.test.js
@@ -1,0 +1,141 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Pins the drift between docs/openapi.yaml and verified runtime behavior
+ * (INF-252 Phase 0, follow-up audit).
+ *
+ * The structural audit is clean: 62 mounted operations, 50 documented, and
+ * every undocumented one appears on the deliberate exclusion list that
+ * openApiMountedRoutesContract.test.js already enforces. No phantom paths.
+ *
+ * The *contract* audit is not clean. Both list endpoints document a response
+ * shape the runtime does not produce, and both document query parameters the
+ * controllers ignore. A client written literally against the spec would read
+ * `response.data.users` and get undefined.
+ *
+ * These assertions describe the mismatch as it stands today. They are
+ * characterization, not approval -- see F35 and F36 in
+ * docs/architecture/api-contract-inventory.md. Whichever way INF-250 resolves
+ * the user-directory contract, this file has to be updated deliberately.
+ */
+
+const spec = readFileSync(path.join(process.cwd(), 'docs', 'openapi.yaml'), 'utf8');
+
+/** Returns the raw YAML block for one path+method, without a YAML parser. */
+const operationBlock = (apiPath, method) => {
+  const lines = spec.split(/\r?\n/);
+  const start = lines.findIndex((l) => l.trim() === `${apiPath}:` && l.startsWith('  /'));
+  if (start === -1) return '';
+
+  const out = [];
+  let inMethod = false;
+  for (let i = start + 1; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (/^ {2}\//.test(line)) break;
+    if (new RegExp(`^ {4}${method}:\\s*$`).test(line)) {
+      inMethod = true;
+      continue;
+    }
+    if (inMethod && /^ {4}\w+:\s*$/.test(line)) break;
+    if (inMethod) out.push(line);
+  }
+  return out.join('\n');
+};
+
+describe('GET /api/users — documented contract versus runtime', () => {
+  const block = operationBlock('/api/users', 'get');
+
+  it('is documented at all', () => {
+    expect(block).not.toHaveLength(0);
+  });
+
+  /**
+   * F35. usersPayloadContract.test.js pins the runtime as accepting
+   * search, sortBy and sortOrder, with no pagination whatsoever (F20).
+   */
+  it.each([['page'], ['limit'], ['role_id'], ['division_id']])(
+    'documents a "%s" query parameter the controller ignores',
+    (param) => {
+      expect(block).toContain(`name: ${param}`);
+    }
+  );
+
+  it('does not document sortBy or sortOrder, which the controller does read', () => {
+    expect(block).not.toContain('name: sortBy');
+    expect(block).not.toContain('name: sortOrder');
+  });
+
+  it('describes search as covering email, though the controller searches nip_nim', () => {
+    expect(block).toMatch(/Search by name or email/);
+  });
+
+  /**
+   * The runtime answers { success, data: [...], message }. The spec describes
+   * data as an object wrapping `users` and `pagination`.
+   */
+  it('documents data as an object wrapping users and pagination', () => {
+    expect(block).toContain('users:');
+    expect(block).toContain('pagination:');
+  });
+
+  it('does not document the message field the controller always returns', () => {
+    expect(block).not.toContain('message:');
+  });
+});
+
+describe('GET /api/attendance — documented contract versus runtime', () => {
+  const block = operationBlock('/api/attendance', 'get');
+
+  it('is documented at all', () => {
+    expect(block).not.toHaveLength(0);
+  });
+
+  /**
+   * F36. attendanceReadsContract.test.js pins the runtime as accepting
+   * search, page and limit only.
+   */
+  it.each([['date'], ['user_id']])(
+    'documents a "%s" filter the controller ignores',
+    (param) => {
+      expect(block).toContain(`name: ${param}`);
+    }
+  );
+
+  it('documents page and limit, which this controller genuinely honours', () => {
+    expect(block).toContain('name: page');
+    expect(block).toContain('name: limit');
+  });
+
+  it('describes search as covering email, though the controller searches nip_nim', () => {
+    expect(block).toMatch(/Search by user name or email/);
+  });
+
+  /**
+   * The runtime answers { success, message, data: [...], pagination: {...} }
+   * with pagination a SIBLING of data. The spec nests both inside data.
+   */
+  it('nests attendances and pagination inside data, unlike the runtime', () => {
+    expect(block).toContain('attendances:');
+    expect(block).toContain('pagination:');
+  });
+});
+
+describe('the two list endpoints disagree with each other', () => {
+  /**
+   * Worth stating on its own: the runtime shapes differ between the two
+   * admin lists -- attendance paginates, users does not (F20) -- while the
+   * spec describes them identically. Phase 2's list-query foundation has to
+   * pick one, and the spec currently matches neither.
+   */
+  it('are documented with the same envelope despite behaving differently', () => {
+    const users = operationBlock('/api/users', 'get');
+    const attendance = operationBlock('/api/attendance', 'get');
+
+    for (const block of [users, attendance]) {
+      expect(block).toContain('pagination:');
+      expect(block).toContain('name: page');
+      expect(block).toContain('name: limit');
+    }
+  });
+});


### PR DESCRIPTION
Follow-up audit for [INF-252](https://linear.app/infinite-track-palu/issue/INF-252/backendarchitecture-adopt-modular-mvc-per-feature-with-safe). **Tests and documentation only — zero production code changes, and `docs/openapi.yaml` is deliberately left untouched.**

Phase 0b made this audit possible: with all 60 endpoints characterized, the documented contract can finally be compared against verified behavior rather than against assumptions.

## Two audits, opposite conclusions

**Structural alignment: clean.** 62 mounted operations, 50 documented, **zero documented-but-not-mounted**. All 12 undocumented operations appear on the deliberate exclusion list that `openApiMountedRoutesContract.test.js` already enforces — debug, test and internal-ops endpoints are kept out of the public contract on purpose. Nothing to fix.

> I first counted **21** undocumented operations. That was wrong: the spec writes path params as `{id}` while the router writes `:id`, so nine entries were the same endpoint in two notations. Normalising brought it to 12 — all of them already on the exclusion list. Reporting 21 would have manufactured a defect that does not exist.

**Contract alignment: not clean.**

| | Documented | Actual |
|---|---|---|
| `GET /api/users` — query | `page`, `limit`, `search`, `role_id`, `division_id` | `search`, `sortBy`, `sortOrder` |
| `GET /api/users` — body | `data: { users, pagination }` | `data: [ … ]`, no pagination, plus `message` |
| `GET /api/attendance` — query | `page`, `limit`, `search`, `date`, `user_id` | `page`, `limit`, `search` |
| `GET /api/attendance` — body | `data: { attendances, pagination }` | `data: [ … ]`, `pagination` as a **sibling** |

**A client written literally against this spec reads `response.data.users` and gets `undefined`.**

Four documented filters do not exist. `search` is described in both places as covering *email*; the controllers search `nip_nim`. And the spec describes the two endpoints **identically** while the runtime behaves differently — attendance paginates, users does not (F20).

## Why the spec is not fixed in this PR

Choosing between *correcting the document* and *adding pagination to the runtime* is a contract decision with cross-repo consequences, and [INF-250](https://linear.app/infinite-track-palu/issue/INF-250/cross-repo-define-scalable-user-directory-search-filter-sort-and) exists precisely to make it. Editing the spec here would pre-empt that decision, and Phase 2's list-query foundation has to pick one shape anyway — the spec currently matches neither.

So the mismatch is **pinned instead**: `tests/openApiRuntimeDriftContract.test.js` asserts the drift as it stands, so it cannot widen unnoticed or be closed by accident. Whichever way INF-250 resolves, that file has to be updated deliberately.

## Worth checking on the client side

If Web FE or Android integrated against this spec, they may already be compensating for it in ways nobody wrote down — or silently receiving `undefined` and rendering empty lists. That is worth confirming before INF-250 changes anything.

## Verification

```
npm run lint    clean
npm test        112 suites / 971 tests passing  (955 on develop + 16)
git diff --stat develop..HEAD -- src/ docs/openapi.yaml    (no output)
```

## Review focus

1. Should the spec be corrected to match the runtime now, or wait for INF-250 to decide the target contract?
2. Are the four phantom filters (`role_id`, `division_id`, `date`, `user_id`) aspirational — features someone intended — or leftovers?

🤖 Generated with [Claude Code](https://claude.com/claude-code)