### PR TITLE
feat(INF-256): harden the merged INF-252 foundations

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -32,6 +32,15 @@ module.exports = {
 							{
 								group: ['**/models', '**/models/*'],
 								message: 'Controllers must not import models. Go through a service.'
+							},
+							{
+								// config/database.js exports the configured Sequelize instance,
+								// which is how legacy controllers obtain transactions. Without
+								// this the "controllers must not touch the ORM" guarantee has a
+								// hole wide enough to drive a transaction through.
+								group: ['**/config/database', '**/config/database.js'],
+								message:
+									'Controllers must not reach the ORM through the database config. Transactions belong to the service.'
 							}
 						]
 					}

--- a/docs/architecture/target-modular-mvc.md
+++ b/docs/architecture/target-modular-mvc.md
@@ -128,9 +128,11 @@ No shims. No parallel `/v2` prefixes. At no point do two live implementations of
 
 | Rule | Enforcement |
 |---|---|
-| Controllers must not touch the ORM | `src/modules/*/*.controller.js` may not import `sequelize` or `**/models` |
+| Controllers must not touch the ORM | `src/modules/*/*.controller.js` may not import `sequelize`, `**/models`, or `**/config/database` |
 | Services must not know about HTTP | `src/modules/*/*.service.js` may not import `express`; `req`/`res`/`next` are denied identifiers |
 | Repositories must not answer HTTP | `src/modules/*/*.repository.js` may not import `express` |
+
+`**/config/database` is on the controller list deliberately. It exports the configured Sequelize instance, and it is how the attendance, booking and auth controllers obtain transactions today. Without it the "controllers must not touch the ORM" guarantee had a hole a migrated controller could open transactions through while `npm run lint` stayed green — worse than no rule, because it invites trust. Services are still allowed to import it: transaction boundaries belong to them.
 
 A violation fails `npm run lint`. The rules do not apply to legacy folders, so they can land before any migration and never block unrelated work.
 

--- a/src/shared/errors/AppError.js
+++ b/src/shared/errors/AppError.js
@@ -23,32 +23,46 @@ export class AppError extends Error {
   }
 }
 
+/**
+ * Every subclass accepts an optional `{ code }` override.
+ *
+ * Existing endpoints already expose codes more specific than the subclass
+ * default -- Users returns E_VALIDATION_NIP_EXISTS and
+ * E_VALIDATION_EMAIL_EXISTS. Migrating those paths without an override would
+ * silently rewrite a client-visible code, so the override exists to keep the
+ * taxonomy usable without changing a contract on the way in.
+ *
+ * The status is deliberately NOT overridable: it is what defines the subclass.
+ * Construct AppError directly when a different status is needed.
+ */
+const resolveCode = (defaultCode, options) => options?.code ?? defaultCode;
+
 export class ValidationError extends AppError {
-  constructor(message, details) {
-    super(message, { code: 'E_VALIDATION', status: 400, details });
+  constructor(message, details, options) {
+    super(message, { code: resolveCode('E_VALIDATION', options), status: 400, details });
   }
 }
 
 export class UnauthorizedError extends AppError {
-  constructor(message, details) {
-    super(message, { code: 'E_UNAUTHORIZED', status: 401, details });
+  constructor(message, details, options) {
+    super(message, { code: resolveCode('E_UNAUTHORIZED', options), status: 401, details });
   }
 }
 
 export class ForbiddenError extends AppError {
-  constructor(message, details) {
-    super(message, { code: 'E_FORBIDDEN', status: 403, details });
+  constructor(message, details, options) {
+    super(message, { code: resolveCode('E_FORBIDDEN', options), status: 403, details });
   }
 }
 
 export class NotFoundError extends AppError {
-  constructor(message, details) {
-    super(message, { code: 'E_NOT_FOUND', status: 404, details });
+  constructor(message, details, options) {
+    super(message, { code: resolveCode('E_NOT_FOUND', options), status: 404, details });
   }
 }
 
 export class ConflictError extends AppError {
-  constructor(message, details) {
-    super(message, { code: 'E_CONFLICT', status: 409, details });
+  constructor(message, details, options) {
+    super(message, { code: resolveCode('E_CONFLICT', options), status: 409, details });
   }
 }

--- a/tests/architectureLayerRules.test.js
+++ b/tests/architectureLayerRules.test.js
@@ -23,6 +23,30 @@ describe('modular MVC layer rules', () => {
     expect(messages.some((m) => m.ruleId === 'no-restricted-imports')).toBe(true);
   });
 
+  /**
+   * INF-256. The rule advertises "controllers must not touch the ORM", but
+   * src/config/database.js exports the configured Sequelize instance -- which
+   * is exactly how the attendance, booking and auth controllers obtain
+   * transactions today. Without this pattern a migrated controller could open
+   * transactions and run raw queries while `npm run lint` stayed green, which
+   * is worse than having no rule because it invites trust.
+   */
+  it('rejects database-config imports inside a module controller', async () => {
+    const messages = await lintAs(
+      'src/modules/users/user.controller.js',
+      "import sequelize from '../../config/database.js';\nexport const listUsers = () => sequelize;\n"
+    );
+    expect(messages.some((m) => m.ruleId === 'no-restricted-imports')).toBe(true);
+  });
+
+  it('still allows a module service to reach the database config for transactions', async () => {
+    const messages = await lintAs(
+      'src/modules/users/user.service.js',
+      "import sequelize from '../../config/database.js';\nexport const listUsers = () => sequelize;\n"
+    );
+    expect(messages.some((m) => m.ruleId === 'no-restricted-imports')).toBe(false);
+  });
+
   it('rejects express imports inside a module service', async () => {
     const messages = await lintAs(
       'src/modules/users/user.service.js',

--- a/tests/sharedAppError.test.js
+++ b/tests/sharedAppError.test.js
@@ -51,3 +51,61 @@ describe('AppError taxonomy', () => {
     expect(new ValidationError('invalid', details).details).toBe(details);
   });
 });
+
+/**
+ * INF-256. Users already exposes E_VALIDATION_NIP_EXISTS and
+ * E_VALIDATION_EMAIL_EXISTS. Migrating those paths to ValidationError without
+ * an override would silently rewrite a client-visible code to E_VALIDATION --
+ * a contract change with no test to catch it, since nothing asserts those
+ * codes today.
+ */
+describe('endpoint-specific code overrides', () => {
+  it('keeps the subclass default when no override is given', () => {
+    expect(new ValidationError('invalid').code).toBe('E_VALIDATION');
+  });
+
+  it('accepts a more specific code without changing the status', () => {
+    const err = new ValidationError('NIP/NIM sudah digunakan', undefined, {
+      code: 'E_VALIDATION_NIP_EXISTS'
+    });
+
+    expect(err.code).toBe('E_VALIDATION_NIP_EXISTS');
+    expect(err.status).toBe(400);
+    expect(err).toBeInstanceOf(ValidationError);
+  });
+
+  it('carries details and an override together', () => {
+    const details = [{ field: 'email', issue: 'taken' }];
+    const err = new ValidationError('Email sudah digunakan', details, {
+      code: 'E_VALIDATION_EMAIL_EXISTS'
+    });
+
+    expect(err.code).toBe('E_VALIDATION_EMAIL_EXISTS');
+    expect(err.details).toBe(details);
+  });
+
+  it.each([
+    [UnauthorizedError, 401, 'E_SESSION_EXPIRED'],
+    [ForbiddenError, 403, 'E_ROLE_FORBIDDEN'],
+    [NotFoundError, 404, 'E_USER_NOT_FOUND'],
+    [ConflictError, 409, 'E_ALREADY_CHECKED_IN']
+  ])('applies to every subclass, keeping status %#', (Klass, status, code) => {
+    const err = new Klass('message', undefined, { code });
+
+    expect(err.code).toBe(code);
+    expect(err.status).toBe(status);
+  });
+
+  it('ignores an empty options object', () => {
+    expect(new NotFoundError('nope', undefined, {}).code).toBe('E_NOT_FOUND');
+  });
+
+  /**
+   * The status is what defines the subclass, so it is deliberately NOT
+   * overridable. Use AppError directly if a different status is needed.
+   */
+  it('does not let the status be overridden', () => {
+    const err = new NotFoundError('nope', undefined, { code: 'E_X', status: 500 });
+    expect(err.status).toBe(404);
+  });
+});


### PR DESCRIPTION
Closes [INF-256](https://linear.app/infinite-track-palu/issue/INF-256/backend-harden-the-merged-inf-252-foundations-error-code-override-and). Two gaps in code already merged by #97 and #98, both found in review of #96.

This is the first PR in the INF-252 effort to change production behavior rather than only pin it. Both changes are small, both are backed by tests written first, and neither alters anything already written.

## 1. `AppError` subclasses accept an optional `{ code }` override

Users already exposes `E_VALIDATION_NIP_EXISTS` and `E_VALIDATION_EMAIL_EXISTS`. Migrating those paths to `ValidationError` without an override would **silently rewrite a client-visible code** to `E_VALIDATION` — a contract change with nothing to catch it, since no test asserts those codes today.

```js
new ValidationError('NIP/NIM sudah digunakan', undefined, { code: 'E_VALIDATION_NIP_EXISTS' })
```

The default is unchanged, so existing call sites behave identically.

**The status is deliberately not overridable** — it is what defines the subclass. Construct `AppError` directly when a different status is needed. A test pins that the status survives an attempt to override it, so the escape hatch cannot widen into a way of bypassing the taxonomy.

## 2. The layer rule now blocks `**/config/database` from module controllers

`src/config/database.js` exports the configured Sequelize instance — and it is exactly how the attendance, booking and auth controllers obtain transactions today.

The rule advertised *"controllers must not touch the ORM"* while leaving a hole a migrated controller could open transactions through with `npm run lint` still green. **That is worse than having no rule, because it invites trust.**

Services remain free to import it: transaction boundaries belong to them. A test pins that too, so the rule cannot be tightened past its intent by accident.

## Why now rather than during Phase 3

Both are prerequisites for the migration being correct, not cleanups after it. The override has to exist *before* the first Users endpoint moves, or that move quietly changes an error code. The lint hole has to close *before* the first module controller is written, or the guarantee is false from the first file.

## Verification

```
npm run lint    clean
npm test        112 suites / 982 tests passing  (971 on develop + 11)
```

Diff: 118 insertions across 5 files — 82 of them tests, 34 the `AppError` change, and 4 the documentation that describes the enforced rules.

## Review focus

1. Is code-only the right override surface, or should `details` handling change too?
2. Should `**/config/database` also be blocked from module **repositories**? They own persistence, so arguably they need it — but they receive transaction options rather than creating them, which suggests not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for assigning endpoint-specific error codes while preserving each error’s standard HTTP status.
  - Error details continue to be supported alongside custom codes, with default codes retained when no override is provided.

- **Bug Fixes**
  - Prevented attempts to override an error’s HTTP status through custom options.

- **Documentation**
  - Clarified application architecture rules around database access and layer responsibilities.

- **Tests**
  - Added coverage for custom error codes, status protection, and database access restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->