### PR TITLE
test(INF-252): pin searchHelper, find a latent composition defect

### DIFF
--- a/docs/architecture/api-contract-inventory.md
+++ b/docs/architecture/api-contract-inventory.md
@@ -375,6 +375,8 @@ Recorded, deliberately **not fixed** under INF-252. Each needs its own issue.
 | F15 | Nine `console.log` calls sit in the `checkOut` final-state mutation path, printing raw attendance rows. They bypass the winston logger used everywhere else, so they carry no request ID and no structured format | `src/controllers/attendance.controller.js:1503-1508,1525-1529` |
 | **F16** | **The `EARLY` check-in status is unreachable.** The working-hours gate returns 400 when `currentTimeMinutes < checkinStartMinutes`, and the classifier below tests that identical condition to assign `status_id: 4` / `EARLY`. Nothing can satisfy the second test after passing the first, so `status_id 4` can never be produced by check-in | `attendance.controller.js:757` vs `:918-921` |
 | F18 | `debugGeoapifyApi` is exported from `wfa.controller.js` but imported nowhere and mounted on no route — roughly 127 lines of dead code in a 586-line controller. It also calls Geoapify directly, so it duplicates the integration logic that Phase 4 is meant to consolidate | `src/controllers/wfa.controller.js:459-586` |
+| **F37** | **`applySearch` silently discards earlier predicates — latent.** It decides whether to preserve existing conditions with `Object.keys(queryOptions.where).length > 0`, but stores its own predicate under the **symbol** key `Op.or`, and `Object.keys` does not enumerate symbols. A second call therefore concludes the where clause is empty and **replaces** it. **Not triggered today**: both call sites invoke it exactly once per query, and `applyMultipleSearch` is unused. It becomes live the moment anything composes two search predicates — which is precisely what Phase 2's query object does | `src/utils/searchHelper.js:38-59` |
+| F38 | `applyMultipleSearch` is exported from `searchHelper.js` and used nowhere in `src/`. It is also the only caller pattern that would trigger F37 | `src/utils/searchHelper.js:71-91` |
 | **F35** | **`GET /api/users` is documented almost entirely wrong.** OpenAPI declares `page`, `limit`, `role_id` and `division_id` query parameters — the controller reads **none** of them. It omits `sortBy` and `sortOrder`, which the controller does read. It describes `search` as covering "name or email"; the controller searches `full_name` and `nip_nim`. It documents `data` as an object wrapping `users` and `pagination`; the runtime returns `data` as a **flat array** with no pagination, plus an undocumented `message` | `docs/openapi.yaml` vs `user.controller.js` |
 | **F36** | **`GET /api/attendance` documents filters that do not exist and the wrong envelope.** `date` and `user_id` are declared and ignored. `search` is again described as covering email. `data` is documented as an object wrapping `attendances` and `pagination`; the runtime returns `data` as a **flat array** with `pagination` as its **sibling** | `docs/openapi.yaml` vs `attendance.controller.js` |
 | F34 | **Four routes carry no validation middleware at all**, so their Validation axis is `n/a` rather than a gap: `POST /api/auth/refresh`, `POST /api/auth/logout`, `GET /api/attendance/history`, and `POST /api/attendance/test-weighted-prediction`. Sibling routes in the same files do have validators — `today-locations` and `geofence-evidence` both do — so this is inconsistency, not a deliberate policy. `/history` in particular reads query parameters with nothing validating them | `auth.routes.js:11-12`, `attendance.routes.js:68,115` |
@@ -409,6 +411,26 @@ Recorded, deliberately **not fixed** under INF-252. Each needs its own issue.
 `checkIn` shows the codebase already knows the right shape — it tracks `transactionFinished` and only rolls back when the transaction is still open. Two of its three sibling mutations were never updated to match.
 
 Both are pinned by tests that assert the current, broken outcome, so a fix makes them fail deliberately.
+
+### F37 — the trap Phase 2 walks into
+
+`src/utils/searchHelper.js` is the shared search primitive behind both admin lists. **Eleven test files mock it. None tested it** until `tests/searchHelperContract.test.js`.
+
+Writing that file surfaced a defect worse than the two already recorded:
+
+```js
+if (queryOptions.where[Op.and]) { /* append */ }
+else if (Object.keys(queryOptions.where).length > 0) { /* wrap in AND */ }
+else { queryOptions.where = { [Op.or]: searchConditions }; }   // ← replaces
+```
+
+The predicate it writes lives under `Op.or`, a **symbol**. `Object.keys` skips symbols. So on a second call the middle branch sees an apparently empty `where` and falls through to the last one, overwriting the first predicate entirely.
+
+**Severity: latent, not active.** Both production call sites — `attendance.controller.js:1682` and `summaryReport.service.js:473` — invoke `applySearch` exactly once per query, and `applyMultipleSearch`, the only pattern that would call it twice, is unused (F38).
+
+It matters because **Phase 2 composes queries**. An allowlisted query object that layers a search predicate onto an existing filter is exactly the second call this function mishandles. Pinned now so the foundation is not built on top of it.
+
+Also pinned in the same file: the mutation (F2) and the unescaped LIKE wildcards (F3), including that a search for `%` becomes `LIKE '%%%'` and matches everything.
 
 ### F35 / F36 — the OpenAPI audit
 

--- a/tests/searchHelperContract.test.js
+++ b/tests/searchHelperContract.test.js
@@ -1,0 +1,224 @@
+import { Op } from 'sequelize';
+
+import { applySearch, applyMultipleSearch } from '../src/utils/searchHelper.js';
+
+/**
+ * Characterization coverage for the shared search primitive
+ * (INF-252, Phase 2 groundwork).
+ *
+ * `applySearch` builds the search predicate for both admin lists --
+ * getAllAttendances and, indirectly, anything else that adopts it. Eleven test
+ * files mock this module. **None test it.** It is the least-covered piece of
+ * shared code in the repository, and Phase 2 replaces it with an allowlisted
+ * query object.
+ *
+ * Two recorded findings are pinned here as executable evidence rather than
+ * prose: it mutates its argument (F2), and it does not escape LIKE wildcards
+ * (F3).
+ */
+
+/** Reads the Op.or / Op.and arrays that are stored under symbol keys. */
+const symbolValue = (obj, sym) => obj?.[sym];
+
+describe('applySearch guard clauses', () => {
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['empty string', ''],
+    ['whitespace only', '   '],
+    ['a non-string', 42]
+  ])('returns the options untouched for %s', (_name, term) => {
+    const options = { where: { deleted_at: null } };
+
+    const result = applySearch(options, term, ['full_name']);
+
+    expect(result).toBe(options);
+    expect(result.where).toEqual({ deleted_at: null });
+  });
+
+  it.each([
+    ['undefined fields', undefined],
+    ['an empty array', []],
+    ['a non-array', 'full_name']
+  ])('returns the options untouched for %s', (_name, fields) => {
+    const options = { where: { deleted_at: null } };
+
+    const result = applySearch(options, 'nadia', fields);
+
+    expect(result.where).toEqual({ deleted_at: null });
+  });
+});
+
+describe('applySearch predicate construction', () => {
+  it('builds an OR of LIKE clauses across every field', () => {
+    const options = {};
+
+    applySearch(options, 'nadia', ['full_name', 'nip_nim']);
+
+    const or = symbolValue(options.where, Op.or);
+    expect(or).toHaveLength(2);
+    expect(symbolValue(or[0].full_name, Op.like)).toBe('%nadia%');
+    expect(symbolValue(or[1].nip_nim, Op.like)).toBe('%nadia%');
+  });
+
+  it('trims the term before wrapping it', () => {
+    const options = {};
+
+    applySearch(options, '  nadia  ', ['full_name']);
+
+    const or = symbolValue(options.where, Op.or);
+    expect(symbolValue(or[0].full_name, Op.like)).toBe('%nadia%');
+  });
+
+  it('creates the where clause when none exists', () => {
+    const options = {};
+
+    applySearch(options, 'nadia', ['full_name']);
+
+    expect(options.where).toBeDefined();
+  });
+
+  it('wraps pre-existing conditions in an AND alongside the search', () => {
+    const options = { where: { deleted_at: null } };
+
+    applySearch(options, 'nadia', ['full_name']);
+
+    const and = symbolValue(options.where, Op.and);
+    expect(and).toHaveLength(2);
+    expect(and[0]).toEqual({ deleted_at: null });
+    expect(symbolValue(and[1], Op.or)).toHaveLength(1);
+  });
+
+  it('appends to an existing AND rather than nesting a second one', () => {
+    const options = { where: { [Op.and]: [{ user_id: 7 }] } };
+
+    applySearch(options, 'nadia', ['full_name']);
+
+    const and = symbolValue(options.where, Op.and);
+    expect(and).toHaveLength(2);
+    expect(and[0]).toEqual({ user_id: 7 });
+  });
+
+  it('supports the $association.field$ syntax the attendance list relies on', () => {
+    const options = {};
+
+    applySearch(options, 'nadia', ['$user.full_name$', '$user.nip_nim$']);
+
+    const or = symbolValue(options.where, Op.or);
+    expect(Object.keys(or[0])[0]).toBe('$user.full_name$');
+  });
+});
+
+describe('applySearch known defects', () => {
+  /**
+   * F2. The function returns the same object it was given and edits it in
+   * place. A caller cannot build a query, branch, and discard one path --
+   * every call permanently changes the options it was handed. Phase 2's query
+   * object should return a new value instead.
+   */
+  it('mutates the caller options in place instead of returning a new object', () => {
+    const options = { where: { deleted_at: null }, limit: 10 };
+    const before = options.where;
+
+    const result = applySearch(options, 'nadia', ['full_name']);
+
+    expect(result).toBe(options);
+    expect(options.where).not.toBe(before);
+    expect(options.where).not.toEqual({ deleted_at: null });
+  });
+
+  /**
+   * F3. The term is interpolated straight into `%...%` with no escaping of
+   * the LIKE metacharacters. This is not SQL injection -- Sequelize still
+   * binds the value -- but the search behaves in ways a user cannot predict.
+   */
+  it.each([
+    ['percent', '100%', '%100%%'],
+    ['underscore', 'a_b', '%a_b%'],
+    ['both', '50%_off', '%50%_off%']
+  ])('does not escape the LIKE wildcard in a %s search', (_name, term, expected) => {
+    const options = {};
+
+    applySearch(options, term, ['full_name']);
+
+    const or = symbolValue(options.where, Op.or);
+    expect(symbolValue(or[0].full_name, Op.like)).toBe(expected);
+  });
+
+  it('turns a lone percent sign into a match-everything query', () => {
+    const options = {};
+
+    applySearch(options, '%', ['full_name']);
+
+    const or = symbolValue(options.where, Op.or);
+    // '%%%' matches every row rather than rows containing a percent sign.
+    expect(symbolValue(or[0].full_name, Op.like)).toBe('%%%');
+  });
+});
+
+describe('applyMultipleSearch', () => {
+  it('returns the options untouched when either argument is not an object', () => {
+    const options = { where: {} };
+
+    expect(applyMultipleSearch(options, null, {})).toBe(options);
+    expect(applyMultipleSearch(options, {}, null)).toBe(options);
+  });
+
+  it('applies a single mapped parameter', () => {
+    const options = {};
+
+    applyMultipleSearch(options, { name: 'nadia' }, { name: ['full_name'] });
+
+    const or = symbolValue(options.where, Op.or);
+    expect(or).toHaveLength(1);
+    expect(symbolValue(or[0].full_name, Op.like)).toBe('%nadia%');
+  });
+
+  /**
+   * F37, characterized not fixed.
+   *
+   * applySearch decides whether to preserve existing conditions with
+   * `Object.keys(queryOptions.where).length > 0`. Its own predicate is stored
+   * under the SYMBOL key Op.or, and Object.keys does not enumerate symbols.
+   *
+   * So on the second call the branch concludes the where clause is empty and
+   * REPLACES it. Searching two fields through applyMultipleSearch silently
+   * keeps only the last one.
+   */
+  it('silently discards all but the last search term', () => {
+    const options = {};
+
+    applyMultipleSearch(
+      options,
+      { name: 'nadia', code: 'A123' },
+      { name: ['full_name'], code: ['nip_nim'] }
+    );
+
+    // No AND was built, and the first predicate is gone.
+    expect(symbolValue(options.where, Op.and)).toBeUndefined();
+
+    const or = symbolValue(options.where, Op.or);
+    expect(or).toHaveLength(1);
+    expect(Object.keys(or[0])[0]).toBe('nip_nim');
+    expect(symbolValue(or[0].nip_nim, Op.like)).toBe('%A123%');
+  });
+
+  it('loses the first term even when applySearch is called directly twice', () => {
+    const options = {};
+
+    applySearch(options, 'nadia', ['full_name']);
+    applySearch(options, 'A123', ['nip_nim']);
+
+    const or = symbolValue(options.where, Op.or);
+    expect(or).toHaveLength(1);
+    expect(Object.keys(or[0])[0]).toBe('nip_nim');
+  });
+
+  it('skips a parameter with no matching field mapping', () => {
+    const options = {};
+
+    applyMultipleSearch(options, { unmapped: 'nadia' }, { name: ['full_name'] });
+
+    expect(options.where).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Phase 2 groundwork for [INF-252](https://linear.app/infinite-track-palu/issue/INF-252/backendarchitecture-adopt-modular-mvc-per-feature-with-safe). **Tests and documentation only — zero production code changes.**

## The gap

`src/utils/searchHelper.js` is the shared search primitive behind both admin lists. **Eleven test files mock it. None tested it.** It was the least-covered piece of shared code in the repository — and Phase 2 replaces it with an allowlisted query object.

## F37 — found by writing the test

```js
if (queryOptions.where[Op.and]) { /* append */ }
else if (Object.keys(queryOptions.where).length > 0) { /* wrap in AND */ }
else { queryOptions.where = { [Op.or]: searchConditions }; }   // ← replaces
```

The predicate it writes lives under `Op.or` — a **symbol**. `Object.keys` does not enumerate symbols. So on a second call the middle branch sees an apparently empty `where`, falls through to the last one, and **overwrites the first predicate entirely**.

```js
applySearch(options, 'nadia', ['full_name']);
applySearch(options, 'A123', ['nip_nim']);
// only nip_nim survives
```

**Severity: latent, not active.** Both production call sites — `attendance.controller.js:1682` and `summaryReport.service.js:473` — invoke `applySearch` exactly once per query, and `applyMultipleSearch`, the only pattern that would call it twice, is **unused anywhere in `src/`** (F38).

I want to be precise about that rather than inflate it: nothing is broken in production today.

**It matters because Phase 2 composes queries.** Layering a search predicate onto an existing filter is exactly the second call this function mishandles. Building the query foundation on top of it unexamined is how a latent defect becomes an active one.

## Also pinned

**F2 — it mutates its argument.** Returns the same reference and edits in place, so a caller cannot build a query, branch, and discard a path.

**F3 — LIKE metacharacters are not escaped.** `100%` becomes `LIKE '%100%%'`; a lone `%` becomes `LIKE '%%%'` and matches every row. Not SQL injection — Sequelize still binds the value — but the search behaves in ways a user cannot predict.

## What the 24 tests cover

Guard clauses for empty, blank, non-string and non-array inputs; the OR-of-LIKE construction; term trimming; AND-wrapping of pre-existing conditions; appending to an existing AND; the `$association.field$` syntax the attendance list depends on; and `applyMultipleSearch`.

## Verification

```
npm run lint    clean
npm test        113 suites / 1006 tests passing  (982 on develop + 24)
git diff --stat develop..HEAD -- src/    (no output)
```

## Review focus

1. Is `applyMultipleSearch` worth keeping at all? It is unused and is the only path that triggers F37.
2. Should F2 and F37 be fixed now, or does Phase 2 replace this module wholesale — making a fix here throwaway work?

🤖 Generated with [Claude Code](https://claude.com/claude-code)