### PR TITLE
test(INF-252): pin geofence and work-hour arithmetic, find F42

### DIFF
--- a/docs/architecture/api-contract-inventory.md
+++ b/docs/architecture/api-contract-inventory.md
@@ -375,6 +375,8 @@ Recorded, deliberately **not fixed** under INF-252. Each needs its own issue.
 | F15 | Nine `console.log` calls sit in the `checkOut` final-state mutation path, printing raw attendance rows. They bypass the winston logger used everywhere else, so they carry no request ID and no structured format | `src/controllers/attendance.controller.js:1503-1508,1525-1529` |
 | **F16** | **The `EARLY` check-in status is unreachable.** The working-hours gate returns 400 when `currentTimeMinutes < checkinStartMinutes`, and the classifier below tests that identical condition to assign `status_id: 4` / `EARLY`. Nothing can satisfy the second test after passing the first, so `status_id 4` can never be produced by check-in | `attendance.controller.js:757` vs `:918-921` |
 | F18 | `debugGeoapifyApi` is exported from `wfa.controller.js` but imported nowhere and mounted on no route — roughly 127 lines of dead code in a 586-line controller. It also calls Geoapify directly, so it duplicates the integration logic that Phase 4 is meant to consolidate | `src/controllers/wfa.controller.js:459-586` |
+| **F42** | **The two Jakarta helpers in `geofence.js` have contradictory contracts.** `getJakartaTime()` returns a Date whose **local getters** hold Jakarta wall-clock values; `toJakartaTime(d)` returns one whose **UTC reading** does. A caller must know which it holds. `minutesSinceMidnightWIB` in `autoCheckout.job.js` calls `toJakartaTime(d).getHours()` — mixing the two — so it is correct only on a **UTC** host, and therefore wrong in production, which sets `TZ=Asia/Jakarta`. **Needs verification:** whether the downstream FAHP prediction is materially affected, since all historical values shift by the same constant | `src/utils/geofence.js:11-53`, `src/jobs/autoCheckout.job.js:173-175` |
+| F43 | `formatUTCToJakartaTime` performs **no conversion** despite its name. It reads the local getters and assumes Sequelize already returned WIB values | `src/utils/geofence.js:61-79` |
 | **F41** | **The missed-checkout flagger's deadline depends on the server's timezone.** `autoCheckout.job.js` computes "now in Jakarta" as `new Date(new Date().toLocaleString('en-US', { timeZone: 'Asia/Jakarta' }))`. The first call produces a Jakarta wall-clock string; the second re-parses it as **machine-local** time, displacing the instant by `jakartaOffset − machineOffset`. It is correct in production **only because `server.js` sets `TZ=Asia/Jakarta`**. On a container with the usual UTC default the job believes it is 7 hours later than it is, and would close every open attendance session around 11:30 Jakarta time | `src/jobs/autoCheckout.job.js` — `runMissedCheckoutFlagger` |
 | F40 | The flagger's per-record error handler logs `attendance.attendance_id`. The model's primary key is `id_attendance`, so a failed record is reported as `undefined` — the one log line that should identify which row failed identifies nothing | `src/jobs/autoCheckout.job.js` — `runMissedCheckoutFlagger` catch block |
 | **F39** | **The two paginated list surfaces use different key names for the same concepts.** `GET /api/attendance` returns `total_records` and `records_per_page`; `GET /api/summary/reports` returns `total_items` and `items_per_page`. A client consuming both must handle both spellings. `GET /api/users` has no pagination at all (F20), so the codebase has three list surfaces and three contracts | `attendance.controller.js` — `getAllAttendances`; `summaryReport.service.js:405-412` |
@@ -414,6 +416,25 @@ Recorded, deliberately **not fixed** under INF-252. Each needs its own issue.
 `checkIn` shows the codebase already knows the right shape — it tracks `transactionFinished` and only rolls back when the transaction is still open. Two of its three sibling mutations were never updated to match.
 
 Both are pinned by tests that assert the current, broken outcome, so a fix makes them fail deliberately.
+
+### F42 — the timezone family has a common root
+
+`src/utils/geofence.js` and `src/utils/workHourFormatter.js` are the two computational cores of attendance: the first decides whether a check-in is allowed at all, the second decides the hours recorded.
+
+**Each was mocked by seventeen test files and imported for real by none.** Every attendance test asserts behavior downstream of these functions while replacing them with stubs, so nothing verified the arithmetic they all depend on — until `tests/geofenceWorkHourContract.test.js` (38 tests).
+
+The Haversine distance and the work-hour arithmetic turn out to be sound. The Jakarta helpers do not agree with each other:
+
+| Helper | Correct reading | Wrong reading |
+|---|---|---|
+| `getJakartaTime()` | local getters (`.getHours()`) | `.getTime()`, `.toISOString()` |
+| `toJakartaTime(d)` | `.toISOString()` | local getters |
+
+A caller has to know which contract it is holding, and nothing in the signatures says so. `minutesSinceMidnightWIB` in `autoCheckout.job.js` mixes them — `toJakartaTime(d).getHours()` — which is correct only on a UTC host.
+
+**This is the common root of F17, F41 and F42.** Three separate defects, all from hand-rolled timezone conversion around helpers whose contracts were never written down or tested. Phase 2's `shared/` layer is the place to settle on one representation.
+
+`formatUTCToJakartaTime` is a fourth instance: despite the name it performs **no conversion at all**, assuming Sequelize already returned WIB (F43).
 
 ### F41 — a scheduled mutation that is correct only by accident
 

--- a/tests/geofenceWorkHourContract.test.js
+++ b/tests/geofenceWorkHourContract.test.js
@@ -1,0 +1,267 @@
+import {
+  calculateDistance,
+  isWithinRadius,
+  getJakartaTime,
+  getJakartaDateString,
+  toJakartaTime,
+  formatUTCToJakartaTime
+} from '../src/utils/geofence.js';
+import {
+  formatWorkHour,
+  parseWorkHour,
+  calculateWorkHour
+} from '../src/utils/workHourFormatter.js';
+
+/**
+ * Characterization coverage for the two computational cores of attendance
+ * (INF-252, Phase 0 follow-up).
+ *
+ * `geofence.js` decides whether a check-in is allowed at all.
+ * `workHourFormatter.js` decides the hours that get recorded.
+ *
+ * Both are mocked by **seventeen** test files each and were imported for real
+ * by none. Every attendance test in the suite asserts behavior downstream of
+ * these functions while replacing them with stubs, so nothing verified the
+ * arithmetic they all depend on.
+ *
+ * They also hold the Jakarta helpers whose absence caused F17 and F41 --
+ * making it worth asking whether the helpers themselves are correct. One is
+ * not: see F42.
+ */
+
+/** Host offset in minutes, east-positive. */
+const HOST_OFFSET_MIN = -new Date('2026-07-28T12:00:00Z').getTimezoneOffset();
+const JAKARTA_OFFSET_MIN = 7 * 60;
+
+/** Jakarta wall-clock parts for an instant, via Intl — correct on any host. */
+const jakartaParts = (instant) => {
+  const fmt = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Asia/Jakarta',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false
+  });
+  const parts = Object.fromEntries(fmt.formatToParts(instant).map((p) => [p.type, p.value]));
+  return parts;
+};
+
+describe('calculateDistance', () => {
+  const OFFICE = [-0.8917, 119.8707]; // Palu
+
+  it('returns zero for identical coordinates', () => {
+    expect(calculateDistance(...OFFICE, ...OFFICE)).toBe(0);
+  });
+
+  it('matches the known length of one degree of latitude', () => {
+    const metres = calculateDistance(0, 0, 1, 0);
+    // Mean-radius Haversine gives ~111.195 km per degree of latitude.
+    expect(metres).toBeGreaterThan(111_100);
+    expect(metres).toBeLessThan(111_300);
+  });
+
+  it('is symmetric', () => {
+    const there = calculateDistance(-0.89, 119.87, -0.90, 119.88);
+    const back = calculateDistance(-0.90, 119.88, -0.89, 119.87);
+    expect(there).toBeCloseTo(back, 9);
+  });
+
+  it('resolves distances at geofence scale', () => {
+    // ~0.0009 degrees of latitude is roughly 100 m.
+    const metres = calculateDistance(-0.8917, 119.8707, -0.8908, 119.8707);
+    expect(metres).toBeGreaterThan(90);
+    expect(metres).toBeLessThan(110);
+  });
+
+  it('handles antipodal-ish separation without NaN', () => {
+    expect(Number.isFinite(calculateDistance(-89, -179, 89, 179))).toBe(true);
+  });
+});
+
+describe('isWithinRadius', () => {
+  it('accepts a point inside the radius', () => {
+    expect(isWithinRadius(-0.8917, 119.8707, -0.8917, 119.8707, 100)).toBe(true);
+  });
+
+  it('rejects a point outside the radius', () => {
+    expect(isWithinRadius(0, 0, 1, 0, 100)).toBe(false);
+  });
+
+  /**
+   * The comparison is `distance <= radius`, so a point exactly on the
+   * boundary is inside. Worth pinning: a strict `<` would silently exclude
+   * anyone standing on the perimeter.
+   */
+  it('treats the boundary itself as inside', () => {
+    const exact = calculateDistance(0, 0, 1, 0);
+    expect(isWithinRadius(0, 0, 1, 0, exact)).toBe(true);
+  });
+});
+
+describe('Jakarta time helpers', () => {
+  it('getJakartaTime exposes Jakarta wall-clock values through local getters', () => {
+    const parts = jakartaParts(new Date());
+    const jakarta = getJakartaTime();
+
+    expect(jakarta.getFullYear()).toBe(Number(parts.year));
+    expect(jakarta.getMonth() + 1).toBe(Number(parts.month));
+    expect(jakarta.getDate()).toBe(Number(parts.day));
+    expect(jakarta.getHours()).toBe(Number(parts.hour));
+  });
+
+  it('getJakartaDateString agrees with getJakartaTime', () => {
+    const parts = jakartaParts(new Date());
+    expect(getJakartaDateString()).toBe(`${parts.year}-${parts.month}-${parts.day}`);
+  });
+
+  it('toJakartaTime returns null for a missing date', () => {
+    expect(toJakartaTime(null)).toBeNull();
+    expect(toJakartaTime(undefined)).toBeNull();
+  });
+
+  it('toJakartaTime shifts the epoch forward by exactly seven hours', () => {
+    const instant = new Date('2026-07-28T03:00:00Z');
+    expect(toJakartaTime(instant).getTime() - instant.getTime()).toBe(7 * 60 * 60 * 1000);
+  });
+
+  /**
+   * F42, characterized not fixed.
+   *
+   * The two helpers in this file disagree about what a "Jakarta time" is.
+   *
+   *   getJakartaTime()  -> local GETTERS are Jakarta; the epoch is wrong
+   *   toJakartaTime(d)  -> the UTC reading is Jakarta; local getters are wrong
+   *
+   * A caller must know which one it holds. `minutesSinceMidnightWIB` in
+   * autoCheckout.job.js calls `toJakartaTime(d).getHours()`, mixing the two
+   * contracts -- correct only when the host runs in UTC, and therefore wrong
+   * in production, which sets TZ=Asia/Jakarta.
+   */
+  it('toJakartaTime local getters are Jakarta only when the host runs in UTC', () => {
+    const instant = new Date('2026-07-28T03:00:00Z'); // 10:00 Jakarta
+    const readAsLocalHour = toJakartaTime(instant).getHours();
+
+    const expectedIfHostIsUtc = 10;
+    expect(readAsLocalHour === expectedIfHostIsUtc).toBe(HOST_OFFSET_MIN === 0);
+  });
+
+  it('toJakartaTime read as UTC is always the Jakarta wall clock', () => {
+    const instant = new Date('2026-07-28T03:00:00Z');
+    expect(toJakartaTime(instant).toISOString().substring(11, 16)).toBe('10:00');
+  });
+
+  it('the two helpers disagree by exactly the host offset', () => {
+    // getJakartaTime is meant to be read with local getters; toJakartaTime
+    // with UTC getters. Reading both locally shows how far apart they are --
+    // and the gap is the host offset, which is why mixing them produces the
+    // F17 / F41 / F42 family.
+    const instant = new Date();
+    const viaLocalGetters = toJakartaTime(instant).getHours();
+    const trueJakartaHour = Number(jakartaParts(instant).hour);
+
+    const gapHours = (viaLocalGetters - trueJakartaHour + 24) % 24;
+    expect(gapHours).toBe(((HOST_OFFSET_MIN - JAKARTA_OFFSET_MIN) / 60 + 24 + 7) % 24);
+  });
+});
+
+describe('formatUTCToJakartaTime', () => {
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['an unparseable string', 'not-a-date']
+  ])('returns 00:00 for %s', (_name, input) => {
+    expect(formatUTCToJakartaTime(input)).toBe('00:00');
+  });
+
+  it('pads hours and minutes to two digits', () => {
+    const d = new Date(2026, 6, 28, 9, 5, 0); // local 09:05
+    expect(formatUTCToJakartaTime(d)).toBe('09:05');
+  });
+
+  it('reads the local clock rather than converting, despite its name', () => {
+    // The function assumes Sequelize already returned WIB values, so it does
+    // no conversion at all -- it formats whatever the local getters say.
+    const d = new Date(2026, 6, 28, 17, 42, 0);
+    expect(formatUTCToJakartaTime(d)).toBe('17:42');
+  });
+});
+
+describe('formatWorkHour', () => {
+  it.each([
+    ['zero', 0],
+    ['null', null],
+    ['undefined', undefined],
+    ['a negative value', -3]
+  ])('returns 00:00 for %s', (_name, input) => {
+    expect(formatWorkHour(input)).toBe('00:00');
+  });
+
+  it('splits a fractional hour into minutes', () => {
+    expect(formatWorkHour(8.5)).toBe('08:30');
+    expect(formatWorkHour(1.25)).toBe('01:15');
+  });
+
+  it('pads a single-digit hour', () => {
+    expect(formatWorkHour(9)).toBe('09:00');
+  });
+
+  it('carries into the next hour when rounding reaches sixty minutes', () => {
+    // 7.999 -> 59.94 minutes -> rounds to 60 -> must become 08:00, not 07:60.
+    expect(formatWorkHour(7.999)).toBe('08:00');
+  });
+});
+
+describe('parseWorkHour', () => {
+  it('is the inverse of formatWorkHour for whole minutes', () => {
+    expect(parseWorkHour('08:30')).toBe(8.5);
+  });
+
+  it.each([
+    ['null', null],
+    ['a non-string', 830],
+    ['a malformed string', 'eight thirty']
+  ])('returns 0 for %s', (_name, input) => {
+    expect(parseWorkHour(input)).toBe(0);
+  });
+});
+
+describe('calculateWorkHour', () => {
+  const at = (hhmm) => new Date(`2026-07-28T${hhmm}:00+07:00`);
+
+  it.each([
+    ['no time_in', null, at('17:00')],
+    ['no time_out', at('09:00'), null]
+  ])('returns 0 with %s', (_name, tIn, tOut) => {
+    expect(calculateWorkHour(tIn, tOut)).toBe(0);
+  });
+
+  it('never returns a negative duration', () => {
+    expect(calculateWorkHour(at('17:00'), at('09:00'))).toBe(0);
+  });
+
+  it('computes a normal working day', () => {
+    expect(calculateWorkHour(at('09:00'), at('17:30'))).toBe(8.5);
+  });
+
+  it('rounds long durations to two decimals', () => {
+    const tIn = new Date('2026-07-28T09:00:00Z');
+    const tOut = new Date('2026-07-28T17:20:00Z'); // 8h20m = 8.3333
+    expect(calculateWorkHour(tIn, tOut)).toBe(8.33);
+  });
+
+  /**
+   * Sub-hour durations use minute precision, and anything under a full
+   * minute is discarded rather than rounded up.
+   */
+  it('discards a session shorter than one minute', () => {
+    const tIn = new Date('2026-07-28T09:00:00Z');
+    expect(calculateWorkHour(tIn, new Date('2026-07-28T09:00:30Z'))).toBe(0);
+  });
+
+  it('keeps minute precision below one hour', () => {
+    const tIn = new Date('2026-07-28T09:00:00Z');
+    expect(calculateWorkHour(tIn, new Date('2026-07-28T09:30:00Z'))).toBe(0.5);
+  });
+});


### PR DESCRIPTION
Phase 2 groundwork for [INF-252](https://linear.app/infinite-track-palu/issue/INF-252/backendarchitecture-adopt-modular-mvc-per-feature-with-safe). **Tests and documentation only — zero production code changes.**

## The gap, found by measuring rather than guessing

A coverage sweep of `src/utils`, `src/services`, `src/middlewares` and `src/jobs` showed 28 of 37 modules exercised by some test. Two of the nine that were not are the **computational cores of attendance**:

| Module | Decides | Mocked by | Imported for real by |
|---|---|---|---|
| `geofence.js` | whether a check-in is allowed at all | **17 test files** | **none** |
| `workHourFormatter.js` | the hours recorded | **17 test files** | **none** |

Every attendance test in the suite asserts behavior *downstream* of these functions while replacing them with stubs. Nothing verified the arithmetic all of it rests on.

> My first sweep reported 31 untested modules. That was wrong — it only matched static `from '../src/…'` imports, while most tests use dynamic `await import(…)` because ESM mocking requires it. Correcting the detection brought it to 9.

## The good news

The Haversine distance and the work-hour arithmetic are **sound**. 38 tests now pin them: zero distance, one degree of latitude against its known length, symmetry, geofence-scale resolution, the inclusive radius boundary, the sixty-minute rounding carry, the sub-minute discard, and the non-negative guarantee.

## F42 — the two Jakarta helpers contradict each other

| Helper | Correct reading | Wrong reading |
|---|---|---|
| `getJakartaTime()` | local getters — `.getHours()` | `.getTime()`, `.toISOString()` |
| `toJakartaTime(d)` | `.toISOString()` | local getters |

**A caller has to know which contract it is holding, and nothing in the signatures says so.**

`minutesSinceMidnightWIB` in `autoCheckout.job.js` mixes them — `toJakartaTime(d).getHours()` — making it correct only on a **UTC** host, and therefore wrong in production, which sets `TZ=Asia/Jakarta`.

**Needs verification:** whether the downstream FAHP prediction is materially affected. Every historical value shifts by the same constant, so it depends on what the consumer compares against — and that is locked-theory territory I did not want to assert about.

**F43** — `formatUTCToJakartaTime` performs **no conversion at all** despite its name; it reads local getters and assumes Sequelize already returned WIB.

## The pattern this completes

F17, F41, F42 and F43 are not four independent bugs. They are one root: **hand-rolled timezone conversion around helpers whose contracts were never written down or tested.** Phase 2's `shared/` layer is where a single representation should be settled on — and now the current behavior is pinned, so that change is visible rather than silent.

## Host independence

The Jakarta assertions compare against `Intl`-formatted parts and express the host dependence as arithmetic, so the suite behaves identically on any machine. That is a deliberate lesson from F41, where a naive test would have passed or failed depending on where it ran.

## Verification

```
npm run lint    clean
npm test        115 suites / 1058 tests passing  (1020 on develop + 38)
git diff --stat develop..HEAD -- src/    (no output)
```

## Review focus

1. F42 — should `toJakartaTime` be removed in favour of `getJakartaTime`, or given a name that states its contract?
2. Is the FAHP prediction actually degraded by `minutesSinceMidnightWIB` being offset, or does the shift cancel downstream?

🤖 Generated with [Claude Code](https://claude.com/claude-code)