### PR TITLE
docs(inf-254): record the end-to-end baseline rehearsal

### DIFF
--- a/db/baseline/README.md
+++ b/db/baseline/README.md
@@ -117,6 +117,21 @@ All three steps must succeed. If `npm run migrate` still fails, the dump is miss
 
 > Port 3307 is used deliberately: 3306 is usually taken by a local MySQL, and pointing this at a real development database would run migrations against it.
 
+## The procedure has been rehearsed end to end
+
+Run on 2026-07-27 against a disposable MySQL 8.0 container, using a schema built from the Sequelize models as a stand-in for the production dump:
+
+| Step | Result |
+|---|---|
+| Restore a complete schema | 17 tables |
+| `sequelizemeta` present, carrying all 9 migration names | 9 rows |
+| `npm run migrate` | ✓ **Migrations completed successfully** |
+| `npm run test:integration` | ✓ **4 tests passed** |
+
+**Everything downstream of the dump works.** The integration harness, the `test` environment key, the migrate step and the suite have all now run green together. The one thing the rehearsal could not stand in for is the dump's *provenance* — whether the committed schema matches production.
+
+One nuance the rehearsal exposed, which matters only if you build a schema some other way: **`sequelizemeta` is not a Sequelize model.** `sync()` does not create it; `sequelize-cli` does, on first migrate. A production dump carries both its structure and — with the second command above — its rows, so this is not a concern for the documented path.
+
 ## Once the dump exists
 
 Two things follow, neither of which should land before it:


### PR DESCRIPTION
Follows #123, which corrected the baseline procedure. That PR proved the
*migrate* step. This one runs the whole thing.

## What was rehearsed

Against a disposable MySQL 8.0 container on port 3307, with a
model-derived schema standing in for the production dump:

| Step | Result |
|---|---|
| Restore a complete schema | 17 tables |
| `sequelizemeta` carrying all 9 migration names | 9 rows |
| `npm run migrate` | **completed successfully** |
| `npm run test:integration` | **4 passed** |

`test:integration` had never passed before this. The harness, the `test`
environment key added in the F12 fix, the migrate step and the suite have
now all run green together.

## What it did not prove

The dump's **provenance** — whether a committed `schema.sql` matches
production. A rehearsal cannot stand in for that, and INF-254 stays open
until a real dump exists.

## The nuance it exposed

The first attempt failed, and the reason is worth recording:
**`sequelizemeta` is not a Sequelize model.** `sync()` does not create it;
`sequelize-cli` does, on first migrate. So every ledger INSERT went to a
table that did not exist, the ledger stayed empty, and migrate died on
`Duplicate column name 'storage_provider'` — reproducing F48 from a second
direction without meaning to.

This affects only someone building a schema by a route other than the
documented one. A production dump carries both the ledger's structure and
its rows. But it is precisely the trap that ate the first attempt, so the
README now names it.

## Verification

Container torn down, scratch script deleted, working tree clean.

Docs only — no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)