### PR TITLE
docs(inf-252): plan Phase 2 — the users module

### DIFF
--- a/docs/superpowers/plans/2026-07-27-inf-252-phase2-users-module.md
+++ b/docs/superpowers/plans/2026-07-27-inf-252-phase2-users-module.md
@@ -1,0 +1,126 @@
+# INF-252 Phase 2 — the `users` module
+
+**Issue:** [INF-252](https://linear.app/infinite-track-palu/issue/INF-252)
+**Binding spec:** [2026-07-26-inf-252-modular-mvc-design.md](../specs/2026-07-26-inf-252-modular-mvc-design.md)
+**Status:** plan only. **Execution is gated — see the gate below.**
+
+The spec details execution for Phase 0 and Phase 1 and leaves Phases 2–8 as a single arrow on a dependency diagram. This plan converts the first of them into executable steps, and picks the module order for everything after it.
+
+---
+
+## The gate
+
+Spec §4.4, decision D4, is unambiguous:
+
+> No extraction begins until 0b, 0c, and Phase 1 have all merged.
+
+| Track | Status |
+|---|---|
+| Phase 0a — architecture documents | ✅ merged |
+| Phase 0b — characterization backfill, 37 endpoints | ✅ merged, **zero coverage gaps remain** |
+| Phase 1 — typed error foundation | ✅ merged |
+| **Phase 0c — CI MySQL integration harness** | ❌ **blocked on `db/baseline/schema.sql`** |
+
+**Phase 0c is the only outstanding gate, and it is blocked on a production schema dump that only a human with database access can produce** (procedure: [db/baseline/README.md](../../../db/baseline/README.md), decision: [INF-254](https://linear.app/infinite-track-palu/issue/INF-254)).
+
+This is not bureaucracy. Slice 3 below moves a `LIKE`-based search query into a query object. Every existing test mocks Sequelize, so **no test in the repository today can tell a correct query from a broken one.** Phase 0c exists specifically to cover that slice. Executing Phase 2 before it lands means moving SQL with no way to detect a regression.
+
+**Do not start slice 1 until Phase 0c is green.**
+
+---
+
+## Module order for Phases 2–8
+
+Chosen by risk, ascending. Each module is a phase.
+
+| Phase | Module | LOC | Endpoints | Why here |
+|---|---|---|---|---|
+| **2** | `users` | 831 | 6 | Smallest well-characterized feature. One transaction, no jobs, no geofence, no FAHP, no cross-module callers |
+| 3 | `auth` | 997 | — | Session/token contract. High risk, but self-contained and heavily tested |
+| 4 | `bookings` (owns `/api/bookings` **and** `/api/wfa`) | 980 + 586 | — | Two route prefixes, one module per spec §3.1. Approval semantics are backend-authoritative |
+| 5 | `attendance` | 2291 | — | **Last of the large modules.** Final-state authority, three background jobs write to it, FAHP reads it |
+| 6 | the small ones — `referenceData`, `settings`, `summary`, `discipline`, `analysis` | 981 total | — | Cheap once the patterns are proven. Not worth spending the pattern-establishing budget on |
+
+`attendance` is deliberately not last-but-one. It is the only module whose state is mutated by something other than an HTTP request, so it should migrate when the pattern is least likely to still be changing.
+
+---
+
+## Phase 2 slices
+
+Six endpoints, six PRs, in this order. **Each PR introduces exactly one new layer concept**, so a failure identifies the layer that caused it.
+
+| # | Endpoint | Introduces | Legacy fn deleted |
+|---|---|---|---|
+| 1 | `GET /api/users/:id` | module skeleton, `user.mapper.js`, `user.service.js`, `user.controller.js` | `getUserById` |
+| 2 | `DELETE /api/users/:id` | `user.repository.js` | `deleteUser` |
+| 3 | `GET /api/users` | `user.query.js` — **the slice Phase 0c protects** | `getAllUsers` |
+| 4 | `PATCH /api/users/:id` | cross-entity write (User + Location), uniqueness policy | `updateUser` |
+| 5 | `POST /api/users/:id/photo` | external adapter boundary (Cloudinary) | `uploadUserPhoto` |
+| 6 | `POST /api/users` | transaction boundary owned by the service | `createUser` |
+
+### Why this order
+
+**Slice 1** is a pure read. It establishes the directory, the mapper, and the route-file cutover mechanic with the least possible surface. Note it uses `User.findOne`, not `findByPk` — pinned by `usersPayloadContract.test.js`, and the mapper must preserve that.
+
+**Slice 2** is the simplest mutation. `User` is `paranoid: true` with `deletedAt: 'deleted_at'`, so `destroy()` is a genuine soft delete and the repository must not quietly become a hard delete.
+
+**Slice 3** carries the real risk: `Op.or` over `full_name` and `nip_nim` with `Op.like`, plus includes. Spec §3.3 requires a strict per-endpoint attribute allowlist. **This is why the gate exists.**
+
+**Slice 4** writes `User` and `Location` with **no transaction** — the legacy behaviour, pinned by `usersUpdateContract.test.js`. The extraction preserves it. Adding a transaction here would be a behaviour change and belongs to its own issue.
+
+**Slice 5** is the only Cloudinary caller in this module, and it uses a dynamic `import()` inside a helper. It also performs multiple writes without a transaction. The adapter boundary is the point of the slice; the missing transaction moves unchanged.
+
+**Slice 6** is last because `createUser` is the only function that owns a transaction, and spec §3.3 puts transaction ownership in the service. By the time it runs, mapper, repository, query object, and policy code all exist and it is the only new thing being proven.
+
+---
+
+## The rule every slice obeys
+
+**Extraction is behaviour-preserving. Known defects move with the code.**
+
+The Phase 0b tests are the oracle. A correct slice makes `usersRouteContract`, `usersPayloadContract`, `usersCreateContract`, and `usersUpdateContract` pass **with zero edits to the test files**.
+
+> If a slice requires editing a characterization test, it is not an extraction. It is a behaviour change wearing an extraction's clothes, and it needs its own issue.
+
+Recorded findings that touch this module — F8, F19 among them — stay as they are. Fixes live in INF-253, INF-255, INF-257, INF-258.
+
+---
+
+## One thing this plan does not decide
+
+Spec §3.5 rule 4: *a legacy controller file is removed when its last function has moved.*
+
+`user.controller.js` exports **eight** functions; `users.routes.js` mounts **six**. The other two, `getProfile` and `updateProfile`, are unreachable — no route mounts them, nothing imports them (**F19**, pinned by `controllerExportReachability.test.js`). They contain all four F8 envelope deviations.
+
+They will never "move", because there is no endpoint to move them to. So after slice 6 the file still exists, holding only dead code, and rule 4 has no answer.
+
+**This needs a decision, not a default:**
+
+- **(a)** Delete them in slice 6 and shrink the F19 list in the same commit — the reachability test already requires that pairing.
+- **(b)** Leave the file, and close it out in a separate cleanup PR with its own issue.
+
+**(a)** is tidier and the test already supports it. **(b)** keeps slice 6 purely an extraction, which is the discipline every other slice follows. I lean **(b)**, narrowly — slice 6 is already the hardest one, and mixing a deletion into it weakens the "extraction only" rule at exactly the point it is under most pressure.
+
+Not decided here.
+
+---
+
+## Verification per slice
+
+```bash
+npm run lint          # the §3.4 layer contract now applies to src/modules/**
+npm test              # every Phase 0b contract test, unedited
+npm run test:integration   # once Phase 0c is green — mandatory from slice 3 on
+```
+
+A slice is done when all three pass, the legacy function is gone, and the diff shows no edits under `tests/`.
+
+---
+
+## Docs/ADR note
+
+**DOCS/ADR UPDATE REQUIRED** at the end of Phase 2, not per slice:
+
+- **ADR-009** is still `Proposed`. It should be `Accepted` before slice 1 — it is the document that makes the layer contract binding.
+- `docs/architecture/target-modular-mvc.md` gains the users module as the worked reference example.
+- `docs/openapi.yaml` should need **no change at all**. If a slice touches it, the slice changed the contract and is out of scope.


### PR DESCRIPTION
The spec details Phase 0 and Phase 1 and leaves Phases 2–8 as a single
arrow on a dependency diagram. This converts the first of them into
executable steps, and picks the module order for everything after it.

## Phase 0b is complete

Verified mechanically: **zero coverage gaps remain** in
`docs/architecture/api-contract-inventory.md`.

| Track | Status |
|---|---|
| Phase 0a — documents | ✅ merged |
| Phase 0b — 37 endpoints characterized | ✅ **zero gaps** |
| Phase 1 — typed errors | ✅ merged |
| Phase 0c — CI MySQL harness | ❌ blocked on `db/baseline/schema.sql` |

So **Phase 0c is the only outstanding D4 gate.** The plan says so at the
top rather than burying it, because slice 3 moves a `LIKE`-based search
into a query object and every test in the repository mocks Sequelize —
nothing here today can tell a correct query from a broken one. That is
precisely what Phase 0c covers.

## Module order

Ascending by risk: `users` → `auth` → `bookings`(+`wfa`) → `attendance` →
the small ones.

`attendance` is deliberately not last-but-one. It is the only module whose
state is mutated by something other than an HTTP request — three
background jobs write to it — so it should migrate when the pattern is
least likely to still be changing.

## Six slices, one new concept each

skeleton → repository → query object → cross-entity write → external
adapter → transaction.

The order is the diagnostic: when a slice fails, it says which layer did
it. Putting `POST /users` first — the only function owning a transaction —
would make PR #1 prove mapper, repository, service *and* transaction
boundary simultaneously, with no way to tell which one broke.

## Verified, not assumed

- `getUserById` uses `findOne`, not `findByPk` — the mapper must preserve it
- `User` is `paranoid: true` / `deletedAt: 'deleted_at'`, so `destroy()` is
  a real soft delete and the repository must not quietly harden it
- `updateUser` and `uploadUserPhoto` each write **two entities with no
  transaction** — checked line by line. That behaviour moves unchanged;
  adding a transaction would be a behaviour change, not an extraction
- `user.controller.js` exports **8** functions, `users.routes.js` mounts **6**

## The oracle

A correct slice makes the Phase 0b contract tests pass **with zero edits to
the test files**. If a slice needs to edit a characterization test, it is
not an extraction — it is a behaviour change wearing an extraction's
clothes, and it needs its own issue.

## One thing left undecided

`getProfile` and `updateProfile` are unreachable (**F19**), so they never
"move" and spec rule §3.5.4 — *remove the legacy file when its last
function has moved* — has no answer. Both options are written out with a
lean toward keeping slice 6 purely an extraction, but **not decided**.

Docs only — no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)