### PR TITLE
ci(inf-252): land the Phase 0c integration job behind a baseline gate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,20 @@ DB_SSL=false
 DB_SSL_REJECT_UNAUTHORIZED=true
 DB_ROOT_PASSWORD=rootpassword
 
+# Integration Test Database (INF-252 Phase 0c)
+# Read only by tests/integration/*, never by the running application. These are
+# deliberately separate from DB_* so that pointing the suite at a database can
+# never be a one-variable mistake away from pointing it at a real one.
+# The suite defaults to exactly these values, so a local disposable container on
+# 3307 needs only TEST_DB_PORT overridden. Use a throwaway database: the suite
+# runs against a schema restored from db/baseline/schema.sql, and migrations are
+# applied to it.
+TEST_DB_HOST=127.0.0.1
+TEST_DB_PORT=3306
+TEST_DB_USER=root
+TEST_DB_PASS=root
+TEST_DB_NAME=infinite_track_test
+
 # JWT Configuration
 # JWT_SECRET is functionally required anywhere auth sign/verify flows are exercised.
 JWT_SECRET=your_super_secret_jwt_key

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,3 +15,87 @@ jobs:
           CLOUDINARY_CLOUD_NAME: test_cloud
           CLOUDINARY_API_KEY: test_key
           CLOUDINARY_API_SECRET: test_secret
+
+  # INF-252 Phase 0c / INF-254.
+  #
+  # The integration suite needs a real MySQL schema, and this repository
+  # cannot build one: src/models/migrations/ patches a schema that already
+  # exists rather than creating it (finding F13). The schema therefore has to
+  # arrive as a committed baseline dump.
+  #
+  # Until db/baseline/schema.sql exists, the integration job must not run —
+  # it would fail every build for everyone. This gate decides that in a job
+  # of its own so the MySQL service container is never started while the
+  # dump is absent.
+  baseline-gate:
+    runs-on: ubuntu-latest
+    outputs:
+      present: ${{ steps.check.outputs.present }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: check
+        run: |
+          if [ -f db/baseline/schema.sql ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Integration tests skipped::db/baseline/schema.sql is absent, so there is no schema to test against. See db/baseline/README.md and INF-254. This is expected until the baseline dump is committed."
+          fi
+
+  integration:
+    needs: baseline-gate
+    if: needs.baseline-gate.outputs.present == 'true'
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: infinite_track_test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -proot"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - run: npm ci
+
+      # The dump carries table structure plus the sequelizemeta rows. Both
+      # matter: none of the migrations guard against changes that already
+      # exist, so an empty ledger makes the next step re-run all of them and
+      # fail on a duplicate column (finding F48).
+      - name: Apply the baseline schema
+        run: mysql -h 127.0.0.1 -P 3306 -uroot -proot infinite_track_test < db/baseline/schema.sql
+
+      # Migrations then patch that baseline forward, exactly as they do in
+      # every other environment.
+      - name: Run migrations
+        run: npm run migrate
+        env:
+          NODE_ENV: test
+          DB_HOST: 127.0.0.1
+          DB_PORT: 3306
+          DB_USER: root
+          DB_PASS: root
+          DB_NAME: infinite_track_test
+          CLOUDINARY_CLOUD_NAME: test_cloud
+          CLOUDINARY_API_KEY: test_key
+          CLOUDINARY_API_SECRET: test_secret
+
+      - name: Run integration tests
+        run: npm run test:integration
+        env:
+          TEST_DB_HOST: 127.0.0.1
+          TEST_DB_PORT: 3306
+          TEST_DB_USER: root
+          TEST_DB_PASS: root
+          TEST_DB_NAME: infinite_track_test
+          CLOUDINARY_CLOUD_NAME: test_cloud
+          CLOUDINARY_API_KEY: test_key
+          CLOUDINARY_API_SECRET: test_secret


### PR DESCRIPTION
Phase 0c was blocked twice over: on a production schema dump only a human
can produce, **and** on me to wire CI once it lands. This removes the
second half. **The dump becomes the only remaining dependency.**

## How it works

The integration job is committed in full, but gated:

- **`baseline-gate`** — checks for `db/baseline/schema.sql`, outputs a boolean
- **`integration`** — `needs: baseline-gate`, `if: ... == 'true'`

A separate gate job rather than an `if` on the steps, deliberately: a
step-level condition would still start the MySQL service container on every
push and then skip. This way the container is **never** created while the
dump is absent.

**When the dump lands, the job turns itself on. No further PR from me.**

The skip is loud — `::notice` puts the reason and the issue reference in the
run summary. A test that quietly does not run is worse than one that fails.

## Impact

| File | Change |
|---|---|
| `.github/workflows/ci.yml` | Adds two jobs. The existing `build` job is **byte-for-byte unchanged**, still 5 steps |
| `.env.example` | Adds the `TEST_DB_*` block |

`TEST_DB_*` is read only by `tests/integration/*`, never by the running
application, and is kept separate from `DB_*` on purpose: pointing the suite
at a database should never be one variable away from pointing it at a real
one.

The apply-schema step carries a comment explaining why the dump must include
the `sequelizemeta` rows — none of the migrations guard against changes that
already exist, so an empty ledger re-runs all of them and dies on a duplicate
column (**F48**).

## Verification

- `ci.yml` parses; jobs `build` / `baseline-gate` / `integration`; `build` still 5 steps
- Gate logic executed **both ways**: absent → `present=false` + notice; present → `present=true`
- `npm run lint` — clean
- `npm test` — **1149 passed, 119 suites**

## Not verified

**The integration job has never executed on GitHub**, because the gate
correctly prevents it. Its first real run happens when the dump lands.
Marked **Needs Verification** until then.

## Risk

Low while the dump is absent — the job cannot run at all. Once it lands the
job becomes required, and a dump that does not match production will fail it.
That is the intended failure, not a regression.

**DOCS/ADR UPDATE REQUIRED** — touches the env contract and CI. ADR-009 is
still `Proposed`; this does not change that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)