### PR TITLE
docs(inf-252): remap the users contract after INF-251/INF-261 (#125)

### DIFF
--- a/docs/architecture/api-contract-inventory.md
+++ b/docs/architecture/api-contract-inventory.md
@@ -67,7 +67,7 @@ The body form is what mobile clients use. Recording only the cookie would let an
 | Method | Path | Roles | Request | Error codes | Happy | RBAC | Validation |
 |---|---|---|---|---|---|---|---|
 | GET | `/api/users` | Admin, Management | query: `search`, `sortBy`, `sortOrder` — **no pagination** | 401, 403 | covered | covered | n/a |
-| GET | `/api/users/:id` | Admin, Management | param: id | 401, 403, 404 `E_NOT_FOUND` | covered | covered | n/a |
+| GET | `/api/users/:id` | Admin, Management | param: id | 401, 403, 404 `E_NOT_FOUND`, **409 `E_USER_LOCATION_INTEGRITY`** | covered | covered | n/a |
 | POST | `/api/users` | Admin, Management | multipart + body | 400 `E_UPLOAD`/`E_VALIDATION_EMAIL_EXISTS`/`E_VALIDATION_NIP_EXISTS`, 401, 403 | covered | covered | covered |
 | POST | `/api/users/:id/photo` | Admin, Management | multipart `face_photo` | 400, 404, `E_UPLOAD` | covered | covered | covered |
 | PATCH | `/api/users/:id` | Admin, Management | body, all fields optional; `email` is ignored | 400 (**no `code` field** — see F27), 404 | covered | covered | covered |
@@ -78,6 +78,56 @@ The body form is what mobile clients use. Recording only the cookie would let an
 **Payloads pinned 2026-07-26** by `tests/usersPayloadContract.test.js` (16 tests): the 15-field mapped user shape shared by list and detail, string-to-number coercion of the location numerics, `null` for every absent association, the `'Work From Home'` category default, the `deleted_at: null` filter, the search predicate covering `full_name` and `nip_nim` only, and the delete semantics.
 
 `createUser` and `updateUser` remain `route-only`: both run DigitalOcean Spaces uploads and transaction orchestration, and deserve their own slice.
+
+### Remapped 2026-07-27 — INF-251 / INF-261 (#125)
+
+**One claim above is superseded.** The payload note says the 15-field shape is *shared by list and detail*. It is not, as of `8b6f8f2`: the two projections were deliberately split, and that split is the single most important input to Phase 2 slice 3.
+
+| | `GET /api/users` (list) | `GET /api/users/:id` (detail) |
+|---|---|---|
+| Builder | `toUserListProjection` | `toUserDetailProjection` |
+| `phone` | **removed** | present |
+| `location` object | **removed** | present (lat/lng/radius/description) |
+| `location_status` | **new** — `configured` \| `integrity_error` | absent |
+| `created_at` / `updated_at` | **new** | **new** |
+
+**Why the split exists.** Before this change the list sent every user's home coordinates and phone number to anyone with directory access; restricting it in the UI was cosmetic, because the data was in the response. The list is now the low-sensitivity surface and the detail endpoint is where identifying data lives.
+
+**The missing-location semantics inverted.** The WFH association was an inner join (`required: true`), so an active user with no WFH location silently vanished from the list and returned 404 from detail. Now:
+
+- **list** — left join; the row stays visible and carries `location_status: 'integrity_error'`, plus a `logger.warn` naming the offending user ids
+- **detail** — **409 `E_USER_LOCATION_INTEGRITY`**, replacing the misleading 404. A user that exists is no longer reported as absent
+
+**Also in this change:** `locations.description` became nullable (migration `20260727000000-allow-null-location-description.cjs`, taking the repository from 9 migrations to **10**), and `createUser` stopped fabricating `'Default WFH Location'` for an empty description.
+
+**Coverage added** — four new files: `userListProjectionContract`, `userDetailProjectionContract`, `userCreateUpdateProjectionContract`, `userCreateValidationContract`. `usersPayloadContract` was amended, which is the correct signal: this was a behaviour change, not an extraction.
+
+#### What this does *not* resolve
+
+Re-verified against `8b6f8f2`, not assumed:
+
+| Finding | State |
+|---|---|
+| **F19** — `getProfile` / `updateProfile` unreachable | **unchanged.** Both still exported, still mounted by nothing |
+| **F8** — bare `{ message }` envelopes | **unchanged.** All four still inside those two unreachable exports |
+| **F20** — no pagination on `GET /api/users` | **unchanged.** Still returns every non-deleted user in one response. INF-250 scope |
+| **F25** — post-commit rollback in `createUser` | **unchanged.** Commit at `:648`; the refetch, mapping and response remain inside the same `try`, and the `catch` still deletes the Spaces object and rolls back unconditionally |
+| **F36** — attendance half of the OpenAPI drift | **unchanged**, deliberately. INF-250 |
+| `updateUser`, `uploadUserPhoto` — two-entity writes with no transaction | **unchanged.** Verified line by line: zero `transaction` references in either |
+
+#### F49 — the sort parameters reach `ORDER BY` with no allowlist
+
+`getAllUsers` reads `req.query.sortBy` and `req.query.sortOrder` and passes them straight into `order: [[sortBy, sortOrder.toUpperCase()]]`. Nothing validates either one — not the route (`users.routes.js` mounts no validator on `GET /`), not the controller, not a query object.
+
+**Confirmed, empirically:** Express parses `?sortOrder[]=x` into an array, and `[].toUpperCase` does not exist.
+
+```text
+GET /api/users?sortOrder[]=x  →  TypeError: sortOrder.toUpperCase is not a function  →  500
+```
+
+**Needs Verification:** `?sortBy=<not-a-column>` and `?sortBy[]=x` reach Sequelize's `order` clause unvalidated. Sequelize quotes identifiers, so this is **not** SQL injection, but the resulting SQL error almost certainly surfaces as a 500. Confirming that requires the integration harness (Phase 0c), which is why it is not asserted here.
+
+This is not new to #125 — the same two lines existed before it — but no finding recorded it, and the endpoint-level tests only pin that the parameters are *documented*, never that they are *validated*. Spec §3.3 already requires a strict per-endpoint allowlist for exactly this surface, so Phase 2 slice 3 is where it gets closed.
 
 **Updated 2026-07-26 — `tests/usersRouteContract.test.js` added (14 tests).**
 

--- a/docs/superpowers/plans/2026-07-27-inf-252-phase2-users-module.md
+++ b/docs/superpowers/plans/2026-07-27-inf-252-phase2-users-module.md
@@ -72,6 +72,32 @@ Six endpoints, six PRs, in this order. **Each PR introduces exactly one new laye
 
 **Slice 6** is last because `createUser` is the only function that owns a transaction, and spec §3.3 puts transaction ownership in the service. By the time it runs, mapper, repository, query object, and policy code all exist and it is the only new thing being proven.
 
+### Amended 2026-07-27 — INF-251 / INF-261 landed on develop (#125)
+
+`8b6f8f2` changed this module underneath the plan. The slice **order** survives unchanged; the **contents** of slices 1 and 3 do not.
+
+**Slice 3 is now the largest slice, not just the riskiest.** It was "move a `LIKE` search into a query object". It now also carries:
+
+1. **Two projections, not one.** `toUserListProjection` and `toUserDetailProjection` already exist as separate functions in the legacy controller. They map to two mappers, or one mapper with two named projections — the module decides, but the split is now a contract, not an implementation detail. The list deliberately omits `phone` and raw coordinates.
+2. **The `location_status` integrity flag**, plus the `logger.warn` that names offending user ids. That warn is a service-layer concern, not a mapper one.
+3. **The sort allowlist (F49).** `sortBy` and `sortOrder` reach `ORDER BY` unvalidated today; `?sortOrder[]=x` returns a 500. Spec §3.3 already requires a per-endpoint allowlist, so this closes inside the slice rather than becoming a separate issue.
+
+**Slice 1 gains an error branch.** `GET /api/users/:id` now returns **409 `E_USER_LOCATION_INTEGRITY`** where it used to return a misleading 404. That is a genuine use case for the typed-error taxonomy Phase 1 added — likely a `ConflictError` subclass with a `code` override, which is precisely why the override was added to `AppError`.
+
+**Re-verified against `8b6f8f2`** — every "verified, not assumed" claim above still holds:
+
+| Claim | State |
+|---|---|
+| `getUserById` uses `findOne`, not `findByPk` | ✅ still true |
+| `updateUser` and `uploadUserPhoto` write two entities with **no transaction** | ✅ still true — zero `transaction` references in either |
+| 8 exports, 6 mounted; `getProfile`/`updateProfile` unreachable (F19) | ✅ still true |
+| `User` is `paranoid: true` | ✅ still true |
+| **F25** — post-commit rollback in `createUser` | ✅ **still present**, untouched by #125 |
+
+**The undecided item is unchanged.** `getProfile` and `updateProfile` survived this PR, so spec §3.5.4 still has no answer for the legacy file after slice 6.
+
+**One number moved:** the repository now has **10** migrations, not 9 (`20260727000000-allow-null-location-description.cjs`). The baseline procedure states its ledger check relatively — "must match the number of migration files" — so `db/baseline/README.md` needs no edit, but a dump produced now must carry 10 `sequelizemeta` rows.
+
 ---
 
 ## The rule every slice obeys

--- a/tests/usersListSortContract.test.js
+++ b/tests/usersListSortContract.test.js
@@ -1,0 +1,131 @@
+import { jest } from '@jest/globals';
+
+/**
+ * Characterization coverage for the sort parameters of GET /api/users (F49).
+ *
+ * `getAllUsers` reads `sortBy` and `sortOrder` from the query string and passes
+ * both straight into `order: [[sortBy, sortOrder.toUpperCase()]]`. Nothing
+ * validates either one: the route mounts no validator on `GET /`, the
+ * controller checks nothing, and there is no query object yet.
+ *
+ * These tests pin the absence deliberately. Spec 3.3 requires a strict
+ * per-endpoint allowlist, so INF-252 Phase 2 slice 3 is where this closes --
+ * and when it does, the two "no allowlist" tests below must fail and be
+ * rewritten. That is the point of them.
+ */
+
+const buildRes = () => {
+  const res = {};
+  res.status = jest.fn(() => res);
+  res.json = jest.fn(() => res);
+  return res;
+};
+
+const loadController = async ({ findAll }) => {
+  jest.unstable_mockModule('../src/models/index.js', () => ({
+    User: { findAll },
+    Photo: {},
+    Role: {},
+    Program: {},
+    Position: {},
+    Division: {},
+    AttendanceCategory: {},
+    Location: {},
+    sequelize: {}
+  }));
+
+  jest.unstable_mockModule('../src/config/spaces.js', () => ({
+    buildUserProfilePhotoKey: jest.fn(),
+    uploadBufferToSpaces: jest.fn(),
+    deleteSpacesObject: jest.fn()
+  }));
+
+  jest.unstable_mockModule('../src/utils/logger.js', () => ({
+    default: { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+  }));
+
+  return import('../src/controllers/user.controller.js');
+};
+
+const orderFrom = (findAll) => findAll.mock.calls[0][0].order;
+
+describe('GET /users sort parameters (F49)', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it('defaults to created_at DESC when neither parameter is sent', async () => {
+    const findAll = jest.fn().mockResolvedValue([]);
+    const { getAllUsers } = await loadController({ findAll });
+
+    await getAllUsers({ query: {} }, buildRes(), jest.fn());
+
+    expect(orderFrom(findAll)).toEqual([['created_at', 'DESC']]);
+  });
+
+  it('uppercases the direction, so a lowercase value still works', async () => {
+    const findAll = jest.fn().mockResolvedValue([]);
+    const { getAllUsers } = await loadController({ findAll });
+
+    await getAllUsers({ query: { sortOrder: 'asc' } }, buildRes(), jest.fn());
+
+    expect(orderFrom(findAll)).toEqual([['created_at', 'ASC']]);
+  });
+
+  /**
+   * DEFECT, characterized not fixed. There is no column allowlist, so any
+   * string the caller supplies becomes an ORDER BY identifier. Sequelize
+   * quotes identifiers, so this is not SQL injection -- but an unknown column
+   * reaches the database and the resulting error surfaces as a 500. Confirming
+   * that end to end needs the Phase 0c integration harness; what is provable
+   * here is that nothing stops the value.
+   */
+  it('passes an arbitrary sortBy through with no allowlist', async () => {
+    const findAll = jest.fn().mockResolvedValue([]);
+    const { getAllUsers } = await loadController({ findAll });
+
+    await getAllUsers({ query: { sortBy: 'password' } }, buildRes(), jest.fn());
+
+    expect(orderFrom(findAll)).toEqual([['password', 'DESC']]);
+  });
+
+  /**
+   * DEFECT, characterized not fixed, and this half is fully provable.
+   *
+   * Express parses `?sortOrder[]=x` into an array, and arrays have no
+   * toUpperCase. The call throws before the query is ever built, the catch
+   * forwards it, and the caller receives a 500 for a request that is merely
+   * malformed. A validated parameter would be a 400.
+   */
+  it('throws on an array sortOrder, turning a malformed query into a 500', async () => {
+    const findAll = jest.fn().mockResolvedValue([]);
+    const { getAllUsers } = await loadController({ findAll });
+    const res = buildRes();
+    const next = jest.fn();
+
+    await getAllUsers({ query: { sortOrder: ['x'] } }, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    const [error] = next.mock.calls[0];
+    expect(error).toBeInstanceOf(TypeError);
+    expect(error.message).toMatch(/toUpperCase is not a function/);
+
+    // It fails before the query is built, and nothing is sent to the client.
+    expect(findAll).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The same shape one level up: an array sortBy survives all the way into the
+   * order clause, because only the direction is ever coerced.
+   */
+  it('lets an array sortBy reach the order clause intact', async () => {
+    const findAll = jest.fn().mockResolvedValue([]);
+    const { getAllUsers } = await loadController({ findAll });
+
+    await getAllUsers({ query: { sortBy: ['x'] } }, buildRes(), jest.fn());
+
+    expect(orderFrom(findAll)).toEqual([[['x'], 'DESC']]);
+  });
+});


### PR DESCRIPTION
`8b6f8f2` changed `GET /users` underneath the Phase 2 plan. This maps the
new reality into the architecture documents and records one defect the
original audit missed.

## One claim was superseded

The inventory said the 15-field shape was *"shared by list and detail"*.
That sharing is precisely what #125 removed.

| | list | detail |
|---|---|---|
| `phone`, `location` object | **removed** | present |
| `location_status` | **new** — `configured` \| `integrity_error` | absent |
| `created_at` / `updated_at` | **new** | **new** |
| missing WFH location | row stays visible, flagged | **409 `E_USER_LOCATION_INTEGRITY`** (was a misleading 404) |

Before this, the list sent every user's home coordinates and phone number
to anyone with directory access — restricting it in the UI was cosmetic.

## Re-verified, not assumed

The Phase 2 plan rests on these, so each was checked against `8b6f8f2`:

| Claim | State |
|---|---|
| `getUserById` uses `findOne` | ✅ holds |
| `updateUser` / `uploadUserPhoto` write two entities, **no transaction** | ✅ holds — zero `transaction` refs in either |
| 8 exports, 6 mounted (F19) | ✅ holds |
| `User` is `paranoid: true` | ✅ holds |
| **F25** post-commit rollback in `createUser` | ✅ **survived #125 untouched** |

F8, F20 and F36 are likewise unchanged. F35's users half was already
resolved by #125 itself.

## New finding — F49

`sortBy` and `sortOrder` reach `ORDER BY` with **no allowlist**. The route
mounts no validator on `GET /`; the controller checks nothing.

**Confirmed without a database:**

```text
GET /api/users?sortOrder[]=x  →  TypeError: sortOrder.toUpperCase is not a function  →  500
```

Express parses the bracket form into an array, and arrays have no
`toUpperCase`. A merely malformed query becomes a server error instead of
a 400.

**Needs Verification:** the `sortBy` half — an arbitrary string reaching the
order clause. Sequelize quotes identifiers so this is **not** SQL injection,
but confirming the SQL consequence needs the Phase 0c harness.

**Not new to #125** — the same two lines predate it. No finding had recorded
it, and the endpoint tests only pin that the parameters are *documented*,
never that they are *validated*.

`tests/usersListSortContract.test.js` pins all of it. The two "no allowlist"
tests are written to **fail** when slice 3 adds one. That is deliberate.

## Phase 2 plan amended, not rewritten

The slice **order** survives. Slice 3 is now the largest slice rather than
merely the riskiest — it carries two projections, the integrity flag, and
the sort allowlist. Slice 1 gains the 409, which is the first real consumer
of the Phase 1 error taxonomy.

Also: the repository now has **10** migrations, not 9. The baseline
procedure states its ledger check relatively, so `db/baseline/README.md`
needs no edit — but a dump produced now must carry 10 `sequelizemeta` rows.

## Verification

- `npm run lint` — clean
- `npm test` — **1178 passed, 124 suites**

Docs and tests only — no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)