### PR TITLE
docs(inf-252): align pagination migration with INF-262

### DIFF
--- a/docs/architecture/api-contract-inventory.md
+++ b/docs/architecture/api-contract-inventory.md
@@ -77,7 +77,7 @@ The body form is what mobile clients use. Recording only the cookie would let an
 
 **Migration target.** INF-263 is Phase B: Web FE always sends pagination. Phase C later makes pagination the backend default and removes the full-array path in a separate contract PR.
 
-**Payloads pinned 2026-07-26** by `tests/usersPayloadContract.test.js` (16 tests): the 15-field mapped user shape shared by list and detail, string-to-number coercion of the location numerics, `null` for every absent association, the `'Work From Home'` category default, the `deleted_at: null` filter, the search predicate covering `full_name` and `nip_nim` only, and the delete semantics.
+**Historical payloads pinned 2026-07-26** by `tests/usersPayloadContract.test.js` (16 tests): the 15-field mapped user shape shared by list and detail, string-to-number coercion of the location numerics, `null` for every absent association, the `'Work From Home'` category default, the `deleted_at: null` filter, the then-current search predicate covering `full_name` and `nip_nim` only, and the delete semantics. The list projection and search claims are superseded below: INF-251/INF-261 split the projections, and INF-262 added `email` to the current three-field search.
 
 `createUser` and `updateUser` remain `route-only`: both run DigitalOcean Spaces uploads and transaction orchestration, and deserve their own slice.
 
@@ -133,7 +133,7 @@ Before it, five of six Users endpoints had zero behavioral coverage; the only `/
 - the create-payload rules, including that **`latitude` and `longitude` are required and may not be 0** — the required-WFH-location rule that INF-251 depends on;
 - update treats every field as optional, and its 400 envelope is `{ success: false, code: 'E_VALIDATION', message, errors[] }`.
 
-**Still open for Users:** `route-only` above means the middleware chain and routing are pinned but the **controller's own response body is not** — pagination metadata, the mapped user shape, and 404 handling for a missing `:id` remain uncovered. Closing that requires model-level mocking rather than controller mocking, and is the remaining Phase 0b work for this module.
+**Historical coverage gap — closed by subsequent characterization.** The earlier `route-only` limitation is no longer current: the controller response body, including pagination metadata, the mapped user shape, and 404 handling for a missing `:id`, is now pinned. There is no remaining Phase 0b work for the Users module.
 
 ## 3. `/api/attendance` — 23 endpoints
 

--- a/docs/architecture/api-contract-inventory.md
+++ b/docs/architecture/api-contract-inventory.md
@@ -75,7 +75,7 @@ The body form is what mobile clients use. Recording only the cookie would let an
 
 **Request-shape correction.** An earlier version of this table recorded `GET /api/users` as accepting `page` and `limit`. At the time it did not; since INF-262 it does (opt-in pagination plus the INF-250 filter matrix: `role`, `program`, `division`, `position`, `location_status`). Without `page`/`limit` it still returns every non-deleted user in one response — see F20 (closed).
 
-**Migration target.** INF-263 is Phase B: Web FE always sends pagination. Phase C later makes pagination the backend default and removes the full-array path in a separate contract PR.
+**Migration target.** INF-263 is Phase B: every Web FE directory request sends both `page` and `limit`, then renders the server pagination metadata without a second client-side pagination layer. Phase C later makes pagination the backend default and removes the full-array path in a separate contract PR.
 
 **Historical payloads pinned 2026-07-26** by `tests/usersPayloadContract.test.js` (16 tests): the 15-field mapped user shape shared by list and detail, string-to-number coercion of the location numerics, `null` for every absent association, the `'Work From Home'` category default, the `deleted_at: null` filter, the then-current search predicate covering `full_name` and `nip_nim` only, and the delete semantics. The list projection and search claims are superseded below: INF-251/INF-261 split the projections, and INF-262 added `email` to the current three-field search.
 

--- a/docs/architecture/api-contract-inventory.md
+++ b/docs/architecture/api-contract-inventory.md
@@ -66,7 +66,7 @@ The body form is what mobile clients use. Recording only the cookie would let an
 
 | Method | Path | Roles | Request | Error codes | Happy | RBAC | Validation |
 |---|---|---|---|---|---|---|---|
-| GET | `/api/users` | Admin, Management | query: `search`, `sortBy`, `sortOrder` — **no pagination** | 401, 403 | covered | covered | n/a |
+| GET | `/api/users` | Admin, Management | query: `page`, `limit`, `search`, `role`, `program`, `division`, `position`, `location_status`, `sortBy`, `sortOrder`; pagination opt-in in Phase A | 400, 401, 403 | covered | covered | covered |
 | GET | `/api/users/:id` | Admin, Management | param: id | 401, 403, 404 `E_NOT_FOUND`, **409 `E_USER_LOCATION_INTEGRITY`** | covered | covered | n/a |
 | POST | `/api/users` | Admin, Management | multipart + body | 400 `E_UPLOAD`/`E_VALIDATION_EMAIL_EXISTS`/`E_VALIDATION_NIP_EXISTS`, 401, 403 | covered | covered | covered |
 | POST | `/api/users/:id/photo` | Admin, Management | multipart `face_photo` | 400, 404, `E_UPLOAD` | covered | covered | covered |
@@ -74,6 +74,8 @@ The body form is what mobile clients use. Recording only the cookie would let an
 | DELETE | `/api/users/:id` | Admin | param: id | 401, 403, 404 (no code) | covered | covered | n/a |
 
 **Request-shape correction.** An earlier version of this table recorded `GET /api/users` as accepting `page` and `limit`. At the time it did not; since INF-262 it does (opt-in pagination plus the INF-250 filter matrix: `role`, `program`, `division`, `position`, `location_status`). Without `page`/`limit` it still returns every non-deleted user in one response — see F20 (closed).
+
+**Migration target.** INF-263 is Phase B: Web FE always sends pagination. Phase C later makes pagination the backend default and removes the full-array path in a separate contract PR.
 
 **Payloads pinned 2026-07-26** by `tests/usersPayloadContract.test.js` (16 tests): the 15-field mapped user shape shared by list and detail, string-to-number coercion of the location numerics, `null` for every absent association, the `'Work From Home'` category default, the `deleted_at: null` filter, the search predicate covering `full_name` and `nip_nim` only, and the delete semantics.
 
@@ -323,7 +325,7 @@ Baseline as measured on 2026-07-26, before any Phase 0b work:
 
 **The Users module is fully characterized.** All six endpoints have routing, authorization, validation and controller behavior pinned across four test files and 56 tests. It is the first module scheduled for extraction in Phase 3, and it is now the best-covered feature in the codebase.
 
-Characterizing it produced eight findings — F8, F19, F20, F21, F22, F23, F25 and F27 — none of them fixed, all recorded.
+Characterizing it produced eight findings — F8, F19, F20, F21, F22, F23, F25 and F27. F20 is closed by INF-262; F49, recorded later during characterization, is also closed by INF-262. The remaining Users findings stay open unless their own entries say otherwise.
 
 **The authorization axis is now closed for the entire API.** Every one of the 60 route-file endpoints has its middleware chain pinned: `/api/users` by `usersRouteContract`, `/api/attendance` by `attendanceRouteContract`, `/api/bookings` by `bookingsReadinessContract`, and the remaining seven route files by `routeAuthorizationMatrix`.
 
@@ -429,7 +431,7 @@ Recorded, deliberately **not fixed** under INF-252. Each needs its own issue.
 | **F39** | **The paginated list surfaces use different key names for the same concepts.** `GET /api/attendance` returns `total_records` and `records_per_page`; `GET /api/summary/reports` returns `total_items` and `items_per_page`. Since INF-262, `GET /api/users` uses the INF-250 **canonical** spelling — `page`, `limit`, `total`, `totalPages` — which the other two surfaces are expected to migrate to (separate scope). Until then a client consuming all three must handle three spellings | `attendance.controller.js` — `getAllAttendances`; `summaryReport.service.js:405-412`; `user.controller.js` — `getAllUsers` |
 | **F37** | **`applySearch` silently discards earlier predicates — latent.** It decides whether to preserve existing conditions with `Object.keys(queryOptions.where).length > 0`, but stores its own predicate under the **symbol** key `Op.or`, and `Object.keys` does not enumerate symbols. A second call therefore concludes the where clause is empty and **replaces** it. **Not triggered today**: both call sites invoke it exactly once per query, and `applyMultipleSearch` is unused. It becomes live the moment anything composes two search predicates — which is precisely what Phase 2's query object does | `src/utils/searchHelper.js:38-59` |
 | F38 | `applyMultipleSearch` is exported from `searchHelper.js` and used nowhere in `src/`. It is also the only caller pattern that would trigger F37 | `src/utils/searchHelper.js:71-91` |
-| **F35** | **`GET /api/users` is documented almost entirely wrong.** OpenAPI declares `page`, `limit`, `role_id` and `division_id` query parameters — the controller reads **none** of them. It omits `sortBy` and `sortOrder`, which the controller does read. It describes `search` as covering "name or email"; the controller searches `full_name` and `nip_nim`. It documents `data` as an object wrapping `users` and `pagination`; the runtime returns `data` as a **flat array** with no pagination, plus an undocumented `message` | `docs/openapi.yaml` vs `user.controller.js` |
+| **F35** | **Users half CLOSED by INF-251/INF-261/INF-262.** OpenAPI now documents the slim projection and the full Phase A query/pagination matrix. The historical mismatch is preserved below; F36 remains the attendance-only open half | `docs/openapi.yaml`; `user.controller.js` |
 | **F36** | **`GET /api/attendance` documents filters that do not exist and the wrong envelope.** `date` and `user_id` are declared and ignored. `search` is again described as covering email. `data` is documented as an object wrapping `attendances` and `pagination`; the runtime returns `data` as a **flat array** with `pagination` as its **sibling** | `docs/openapi.yaml` vs `attendance.controller.js` |
 | F34 | **Four routes carry no validation middleware at all**, so their Validation axis is `n/a` rather than a gap: `POST /api/auth/refresh`, `POST /api/auth/logout`, `GET /api/attendance/history`, and `POST /api/attendance/test-weighted-prediction`. Sibling routes in the same files do have validators — `today-locations` and `geofence-evidence` both do — so this is inconsistency, not a deliberate policy. `/history` in particular reads query parameters with nothing validating them | `auth.routes.js:11-12`, `attendance.routes.js:68,115` |
 | **F33** | **`getEnhancedAutoCheckoutSettings` is an N+1.** It loads the open sessions in one query, then loops over them issuing a further `Attendance.findAll` per session for that user's month of history. N open sessions cost N+1 queries. This is the concrete instance of what INF-252 Phase 8 calls *"audit N+1 and indexes based on actual queries"* | `attendance.controller.js` — `getEnhancedAutoCheckoutSettings` |
@@ -543,6 +545,8 @@ Two audits were run against `docs/openapi.yaml`. They reached opposite conclusio
 
 **Contract alignment: originally not clean.** Both admin list endpoints described a response shape the runtime does not produce.
 
+**Historical snapshot — before INF-251/INF-261/INF-262:**
+
 | | Documented (at audit time) | Actual |
 |---|---|---|
 | `GET /api/users` — query | `page`, `limit`, `search`, `role_id`, `division_id` | `search`, `sortBy`, `sortOrder` |
@@ -552,7 +556,14 @@ Two audits were run against `docs/openapi.yaml`. They reached opposite conclusio
 
 A client written literally against that spec reads `response.data.users` and gets `undefined`.
 
-**F35 (users half) — RESOLVED by INF-251/INF-261.** `docs/openapi.yaml` now documents the real `GET /api/users` runtime: query `search`/`sortBy`/`sortOrder`, envelope `{ success, data: [UserListItem], message }`, and the deliberately slim list projection (no `phone`, no raw coordinates, `location_status` readiness flag). `tests/openApiRuntimeDriftContract.test.js` now asserts the users spec stays aligned.
+**Current snapshot — `develop` at `df5a491`:**
+
+| Surface | OpenAPI | Runtime |
+|---|---|---|
+| `GET /api/users` — query | Phase A: `page`, `limit`, `search`, `role`, `program`, `division`, `position`, `location_status`, `sortBy`, `sortOrder` | same |
+| `GET /api/users` — body | Phase A paginated mode: flat `data` plus sibling `pagination`; legacy mode: flat `data` without pagination | same |
+
+**F35 (users half) — RESOLVED by INF-251/INF-261/INF-262.** `docs/openapi.yaml` now documents the real `GET /api/users` Phase A runtime: opt-in pagination, filters (`role`, `program`, `division`, `position`, `location_status`), three-field search (`full_name`, `nip_nim`, `email`), and allowlisted sorting. It also documents the deliberately slim list projection (no `phone`, no raw coordinates, `location_status` readiness flag). `tests/openApiRuntimeDriftContract.test.js` now asserts the users spec stays aligned.
 
 **F36 (attendance half) — still open, deliberately.** Choosing between correcting the document and changing the runtime remains a contract decision for [INF-250](https://linear.app/infinite-track-palu/issue/INF-250/cross-repo-define-scalable-user-directory-search-filter-sort-and). The attendance mismatch stays pinned in `tests/openApiRuntimeDriftContract.test.js` so it cannot drift further or be closed by accident. The two list runtimes now both paginate but spell their envelopes differently (users uses the INF-250 canonical `page/limit/total/totalPages`, attendance still uses `total_records`/`records_per_page` — F39); migrating attendance to the canonical spelling is follow-up scope.
 

--- a/docs/architecture/target-modular-mvc.md
+++ b/docs/architecture/target-modular-mvc.md
@@ -96,6 +96,30 @@ Owns list and report queries: associations, selected attributes, search, filter,
 - Uses a **strict allowlist per endpoint**. A client-supplied sort field that is not on the list is rejected, not passed through.
 - Shared code supplies the mechanism; each feature owns its public query contract.
 
+#### Worked example — Users directory
+
+```text
+user.routes.js
+  -> user.validation.js
+  -> user.controller.js
+  -> user.service.js
+  -> user.query.js
+  -> Sequelize models
+  -> user.mapper.js
+  -> HTTP response
+```
+
+1. Validation owns scalar shape, ranges, enums, and the sort allowlist.
+2. Controller contains no Sequelize concepts.
+3. Service owns integrity-warning orchestration.
+4. Query owns associations, predicates, ordering, pagination, and both Phase A fetch paths.
+5. Mapper owns the stable slim response item.
+6. Feature-specific fields and joins remain in Users.
+7. Shared pagination/search mechanisms require two real consumers.
+8. Phase C is not part of the extraction.
+
+The Phase 2 Users migration follows the binding [post-INF-262 list-query design](../superpowers/specs/2026-07-27-inf-252-list-query-post-inf262-design.md): retain the Phase A `findAll` compatibility path and `findAndCountAll` paginated path while INF-263 supplies Phase B client evidence. A separate Phase C contract PR may remove compatibility only after that evidence exists.
+
 ### Validation
 
 Transport validation only — params, query shape, body types and ranges. Business validation stays in the service or a policy.

--- a/docs/superpowers/plans/2026-07-27-inf-252-pagination-migration-docs.md
+++ b/docs/superpowers/plans/2026-07-27-inf-252-pagination-migration-docs.md
@@ -1,0 +1,441 @@
+# INF-252 Pagination Migration Documentation Refresh Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace stale pre-INF-262 migration guidance with an explicit Phase A/B/C pagination lifecycle and Modular MVC ownership map without changing runtime behavior.
+
+**Architecture:** Preserve the old Phase 2 list-query design as historical evidence and add a superseding post-INF-262 design as the migration source of truth. Update the Users migration plan, target architecture, and API inventory to distinguish current compatibility behavior from the approved always-paginated target while leaving OpenAPI aligned with the current runtime.
+
+**Tech Stack:** Markdown architecture documents, OpenAPI YAML as a read-only runtime-contract reference, Git, ripgrep, ESLint, Jest.
+
+## Global Constraints
+
+- Baseline is `develop` at merge commit `df5a491` from PR #129.
+- This delivery changes documentation only; it must not modify runtime, routes, response shapes, database, Docker, or Linear state.
+- Phase A is current: pagination is opt-in and omission of `page`/`limit` preserves the full-array response.
+- Phase B is INF-263: Web FE always sends pagination and consumes server metadata without a second client-side pagination layer.
+- Phase C is target: backend always paginates with defaults `page=1`, `limit=20`, and maximum `limit=100`.
+- Phase C requires a separate backend contract issue and PR after INF-263 deployment evidence exists.
+- OpenAPI continues to describe Phase A until the Phase C runtime change lands.
+- The canonical pagination object is `{ page, limit, total, totalPages }`, as a sibling of `data`.
+- ADR-009 remains `Proposed`; this delivery must not imply acceptance.
+- Attendance and summary-report pagination unification remains out of scope.
+- Preserve the historical body of the superseded Phase 2 design.
+
+---
+
+## File responsibility map
+
+| File | Responsibility after this plan |
+|---|---|
+| `docs/superpowers/specs/2026-07-27-inf-252-list-query-post-inf262-design.md` | Binding post-INF-262 list-query and Users extraction design |
+| `docs/superpowers/specs/2026-07-27-inf-252-phase2-list-query-design.md` | Historical pre-INF-262 decision record with a superseded banner |
+| `docs/superpowers/plans/2026-07-27-inf-252-phase2-users-module.md` | Executable module-migration sequence based on the live Phase A contract |
+| `docs/architecture/target-modular-mvc.md` | Stable architecture rules and worked Users directory ownership example |
+| `docs/architecture/api-contract-inventory.md` | Current contract and findings truth at `df5a491` |
+| `docs/openapi.yaml` | Unmodified live Phase A API description |
+
+---
+
+### Task 1: Establish the superseding post-INF-262 design
+
+**Files:**
+- Create: `docs/superpowers/specs/2026-07-27-inf-252-list-query-post-inf262-design.md`
+- Modify: `docs/superpowers/specs/2026-07-27-inf-252-phase2-list-query-design.md:1-7`
+- Reference: `docs/superpowers/specs/2026-07-27-inf-252-pagination-migration-docs-design.md`
+
+**Interfaces:**
+- Consumes: Approved Phase A/B/C lifecycle and ownership boundaries from the binding documentation-refresh design.
+- Produces: One linkable source of truth used by the Users plan and target architecture.
+
+- [ ] **Step 1: Confirm the stale design still presents INF-250 decisions as unresolved**
+
+Run:
+
+```powershell
+rg -n 'Pagination \| \*\*none\*\*|Decisions required before implementation|D1 —|D2 —|D3 —|blocked on two decisions' docs/superpowers/specs/2026-07-27-inf-252-phase2-list-query-design.md
+```
+
+Expected: matches show the pre-INF-262 state and unresolved D1/D2/D3 sections.
+
+- [ ] **Step 2: Create the replacement design with resolved decisions**
+
+Create `docs/superpowers/specs/2026-07-27-inf-252-list-query-post-inf262-design.md` with these exact top-level sections:
+
+```markdown
+# INF-252 Phase 2 — List Query Foundation after INF-262
+
+**Status:** Approved migration source of truth
+**Supersedes:** [2026-07-27-inf-252-phase2-list-query-design.md](2026-07-27-inf-252-phase2-list-query-design.md)
+**Baseline:** `develop` at `df5a491`
+
+## 1. Resolved decisions
+## 2. Current contract — Phase A
+## 3. Client migration — Phase B
+## 4. Target contract — Phase C
+## 5. Modular MVC ownership
+## 6. Shared list-query boundary
+## 7. Extraction invariants
+## 8. Verification gates
+## 9. Risks
+## 10. Out of scope
+```
+
+The resolved-decision table must contain:
+
+```markdown
+| Former decision | Resolution |
+|---|---|
+| D1 — pagination envelope | Users uses the canonical `{ page, limit, total, totalPages }` object as a sibling of `data`; attendance and reports migrate separately |
+| D2 — paginate users | Yes; opt-in in Phase A, always paginated only after INF-263 in Phase C |
+| D3 — search fields | Per-endpoint allowlist; Users searches `full_name`, `nip_nim`, and `email` |
+```
+
+The ownership section must map `user.validation.js`, `user.controller.js`, `user.service.js`, `user.query.js`, and `user.mapper.js` exactly as specified in the approved design. It must state that extraction preserves both the Phase A `findAll` compatibility path and the paginated `findAndCountAll` path.
+
+- [ ] **Step 3: Mark the old design as historical without rewriting its body**
+
+Change its metadata to:
+
+```markdown
+**Status:** Superseded — historical pre-INF-262 decision record
+**Superseded by:** [2026-07-27-inf-252-list-query-post-inf262-design.md](2026-07-27-inf-252-list-query-post-inf262-design.md)
+```
+
+Add this note immediately before the first horizontal rule:
+
+```markdown
+> Historical boundary: the facts and recommendations below describe the repository before INF-250 was decided and INF-262 landed in PR #129. Do not use this document to implement the Users query extraction.
+```
+
+Do not modify sections 1 through 8.
+
+- [ ] **Step 4: Verify the replacement and supersession relationship**
+
+Run:
+
+```powershell
+rg -n 'Approved migration source of truth|Phase A|Phase B|Phase C|user\.query\.js|findAndCountAll|findAll' docs/superpowers/specs/2026-07-27-inf-252-list-query-post-inf262-design.md
+rg -n 'Status:.*Superseded|Superseded by:|Historical boundary:' docs/superpowers/specs/2026-07-27-inf-252-phase2-list-query-design.md
+```
+
+Expected: the replacement contains all lifecycle and ownership markers; the old design contains all three historical markers.
+
+- [ ] **Step 5: Commit the superseding design**
+
+```powershell
+git add docs/superpowers/specs/2026-07-27-inf-252-list-query-post-inf262-design.md docs/superpowers/specs/2026-07-27-inf-252-phase2-list-query-design.md
+git diff --cached --check
+git commit -m "docs(inf-252): supersede pre-INF262 list query design"
+```
+
+Expected: one documentation-only commit with no files outside `docs/superpowers/specs/`.
+
+---
+
+### Task 2: Align the Users migration plan and target architecture
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-07-27-inf-252-phase2-users-module.md:3-150`
+- Modify: `docs/architecture/target-modular-mvc.md:92-176`
+- Reference: `docs/superpowers/specs/2026-07-27-inf-252-list-query-post-inf262-design.md`
+
+**Interfaces:**
+- Consumes: Phase A/B/C terminology and ownership rules from Task 1.
+- Produces: Migration instructions that preserve current behavior and a worked architecture example future modules can follow.
+
+- [ ] **Step 1: Record the stale Users-plan assumptions before editing**
+
+Run:
+
+```powershell
+rg -n 'Op\.or.*full_name.*nip_nim|move a `LIKE` search|sort allowlist \(F49\)|Slice 3' docs/superpowers/plans/2026-07-27-inf-252-phase2-users-module.md
+```
+
+Expected: matches show the pre-INF-262 two-field query description and the INF-251/INF-261-only amendment.
+
+- [ ] **Step 2: Add the binding post-INF-262 design to the Users plan**
+
+Below the existing binding-spec metadata, add:
+
+```markdown
+**Binding list-query design:** [2026-07-27-inf-252-list-query-post-inf262-design.md](../specs/2026-07-27-inf-252-list-query-post-inf262-design.md)
+```
+
+Add a new section after the INF-251/INF-261 amendment:
+
+```markdown
+### Amended 2026-07-27 — INF-250 / INF-262 landed in PR #129
+
+Slice 3 now extracts the Phase A dual-mode contract. It does not introduce Phase C.
+```
+
+The section must enumerate:
+
+- pagination trigger, defaults, cap, count, and empty-page behavior;
+- three search fields and wildcard escaping;
+- five filters;
+- five sort fields and deterministic validation;
+- `location_status` integrity semantics;
+- `UserListItem` projection boundary;
+- Phase B dependency on INF-263;
+- Phase C as a separate contract PR.
+
+- [ ] **Step 3: Replace the stale Slice 3 responsibility paragraph**
+
+Replace the paragraph beginning `**Slice 3** carries the real risk` with:
+
+```markdown
+**Slice 3** carries the highest read-path risk. It moves the complete Phase A query matrix into `user.query.js`: the `findAll` compatibility path; the `findAndCountAll` paginated path; pagination defaults and cap; escaped three-field search; five filters; allowlisted sorting; left-joined WFH location integrity; `distinct: true`; and `subQuery: false`. `user.validation.js` owns transport validation, `user.service.js` owns integrity warnings, and `user.mapper.js` owns the slim list projection. The extraction must preserve both response modes exactly.
+```
+
+Update the verification section to require these existing tests by name:
+
+```markdown
+- `tests/usersListPaginationContract.test.js`
+- `tests/usersListQueryValidationContract.test.js`
+- `tests/usersListSortContract.test.js`
+- `tests/usersPayloadContract.test.js`
+- `tests/openApiRuntimeDriftContract.test.js`
+```
+
+- [ ] **Step 4: Add the worked Users directory example to target architecture**
+
+After `### Query object`, add `#### Worked example — Users directory` containing:
+
+```text
+user.routes.js
+  -> user.validation.js
+  -> user.controller.js
+  -> user.service.js
+  -> user.query.js
+  -> Sequelize models
+  -> user.mapper.js
+  -> HTTP response
+```
+
+State these invariants:
+
+1. Validation owns scalar shape, ranges, enums, and the sort allowlist.
+2. Controller contains no Sequelize concepts.
+3. Service owns integrity-warning orchestration.
+4. Query owns associations, predicates, ordering, pagination, and both Phase A fetch paths.
+5. Mapper owns the stable slim response item.
+6. Feature-specific fields and joins remain in Users.
+7. Shared pagination/search mechanisms require two real consumers.
+8. Phase C is not part of the extraction.
+
+Add a Phase 2 migration-order note linking to the post-INF-262 design.
+
+- [ ] **Step 5: Verify migration ownership and lifecycle terms**
+
+Run:
+
+```powershell
+rg -n 'INF-250 / INF-262|Phase A|Phase B|Phase C|three-field|five filters|findAll|findAndCountAll|usersListPaginationContract' docs/superpowers/plans/2026-07-27-inf-252-phase2-users-module.md
+rg -n 'Worked example — Users directory|user\.validation\.js|user\.query\.js|integrity-warning|Phase C|two real consumers' docs/architecture/target-modular-mvc.md
+```
+
+Expected: both files name the complete ownership split and distinguish extraction from the later breaking contract change.
+
+- [ ] **Step 6: Commit the migration guidance**
+
+```powershell
+git add docs/superpowers/plans/2026-07-27-inf-252-phase2-users-module.md docs/architecture/target-modular-mvc.md
+git diff --cached --check
+git commit -m "docs(inf-252): align users migration with pagination contract"
+```
+
+Expected: one commit modifying only the Users plan and target architecture.
+
+---
+
+### Task 3: Reconcile the API contract inventory
+
+**Files:**
+- Modify: `docs/architecture/api-contract-inventory.md:65-134`
+- Modify: `docs/architecture/api-contract-inventory.md:304-326`
+- Modify: `docs/architecture/api-contract-inventory.md:396-557`
+- Reference: `docs/openapi.yaml:2810-2905`
+
+**Interfaces:**
+- Consumes: Current Phase A facts from PR #129 and the lifecycle terminology from Task 1.
+- Produces: A non-contradictory current-state inventory while leaving attendance/reporting findings open.
+
+- [ ] **Step 1: Prove the inventory currently contradicts itself**
+
+Run:
+
+```powershell
+rg -n 'query: `search`, `sortBy`, `sortOrder` — \*\*no pagination\*\*|none of them fixed|documented almost entirely wrong|data: \[ … \], no pagination|query `search`/`sortBy`/`sortOrder`' docs/architecture/api-contract-inventory.md
+```
+
+Expected: stale statements appear alongside later F20/F49 closure text.
+
+- [ ] **Step 2: Correct the `/api/users` endpoint table**
+
+Replace the list row with:
+
+```markdown
+| GET | `/api/users` | Admin, Management | query: `page`, `limit`, `search`, `role`, `program`, `division`, `position`, `location_status`, `sortBy`, `sortOrder`; pagination opt-in in Phase A | 400, 401, 403 | covered | covered | covered |
+```
+
+Keep the request-shape correction, but append:
+
+```markdown
+**Migration target.** INF-263 is Phase B: Web FE always sends pagination. Phase C later makes pagination the backend default and removes the full-array path in a separate contract PR.
+```
+
+- [ ] **Step 3: Reconcile historical progress and findings text**
+
+Change the sentence saying all eight Users findings remain unfixed so it explicitly records:
+
+```markdown
+F20 is closed by INF-262; F49, recorded later during characterization, is also closed by INF-262. The remaining Users findings stay open unless their own entries say otherwise.
+```
+
+Update the F35 row in the active inconsistency table to:
+
+```markdown
+| **F35** | **Users half CLOSED by INF-251/INF-261/INF-262.** OpenAPI now documents the slim projection and the full Phase A query/pagination matrix. The historical mismatch is preserved below; F36 remains the attendance-only open half | `docs/openapi.yaml`; `user.controller.js` |
+```
+
+Replace the historical F35/F36 comparison table Users rows with current Phase A values:
+
+```markdown
+| `GET /api/users` — query | Phase A: `page`, `limit`, `search`, `role`, `program`, `division`, `position`, `location_status`, `sortBy`, `sortOrder` | same |
+| `GET /api/users` — body | Phase A paginated mode: flat `data` plus sibling `pagination`; legacy mode: flat `data` without pagination | same |
+```
+
+Change the F35 resolution paragraph to credit INF-262 and name pagination, filters, three-field search, and allowlisted sorting. Do not change the F36 attendance finding or F39.
+
+- [ ] **Step 4: Verify stale active claims are gone and open findings remain**
+
+Run:
+
+```powershell
+$file = 'docs/architecture/api-contract-inventory.md'
+if (Select-String -Path $file -Pattern 'query: `search`, `sortBy`, `sortOrder` — \*\*no pagination\*\*|none of them fixed|data: \[ … \], no pagination') { exit 1 }
+rg -n 'pagination opt-in in Phase A|Migration target|F20 is closed|Users half CLOSED|INF-251/INF-261/INF-262|F39|F36.*still open' $file
+```
+
+Expected: the first command exits successfully with no stale matches; the second shows corrected Users facts while F39 and F36 remain open.
+
+- [ ] **Step 5: Confirm OpenAPI was not changed**
+
+Run:
+
+```powershell
+git diff --exit-code refs/remotes/origin/develop -- docs/openapi.yaml
+```
+
+Expected: exit `0` and no output.
+
+- [ ] **Step 6: Commit the inventory reconciliation**
+
+```powershell
+git add docs/architecture/api-contract-inventory.md
+git diff --cached --check
+git commit -m "docs(inf-252): reconcile users contract inventory"
+```
+
+Expected: one commit modifying only the API contract inventory.
+
+---
+
+### Task 4: Run final documentation and repository gates
+
+**Files:**
+- Verify: all files changed by Tasks 1 through 3
+- Verify unchanged: `docs/openapi.yaml`
+- Verify unchanged: `src/**`, `tests/**`, `docker-compose.yml`, `.github/workflows/**`
+
+**Interfaces:**
+- Consumes: All documentation changes from Tasks 1 through 3.
+- Produces: Evidence that the documentation is internally consistent and did not alter runtime surfaces.
+
+- [ ] **Step 1: Scan active migration docs for stale claims**
+
+Run:
+
+```powershell
+$active = @(
+  'docs/superpowers/specs/2026-07-27-inf-252-list-query-post-inf262-design.md',
+  'docs/superpowers/plans/2026-07-27-inf-252-phase2-users-module.md',
+  'docs/architecture/target-modular-mvc.md',
+  'docs/architecture/api-contract-inventory.md'
+)
+$stale = Select-String -Path $active -Pattern 'Pagination \| \*\*none\*\*|blocked on two decisions|does `/api/users` gain pagination|searches `full_name` and `nip_nim` only|no pagination on `GET /api/users` \| \*\*unchanged'
+if ($stale) { $stale; exit 1 }
+```
+
+Expected: exit `0` with no stale matches in active documents. The historical superseded file is intentionally excluded.
+
+- [ ] **Step 2: Scan for placeholders and whitespace errors**
+
+Run:
+
+```powershell
+$patterns = @(
+  ('T' + 'BD'),
+  ('T' + 'ODO'),
+  ('FIX' + 'ME'),
+  ('implement' + ' later'),
+  ('fill in' + ' details')
+)
+$targets = @(
+  'docs/superpowers/specs/2026-07-27-inf-252-list-query-post-inf262-design.md',
+  'docs/superpowers/plans/2026-07-27-inf-252-phase2-users-module.md',
+  'docs/architecture/target-modular-mvc.md',
+  'docs/architecture/api-contract-inventory.md'
+)
+$placeholders = Select-String -Path $targets -Pattern $patterns
+if ($placeholders) { $placeholders; exit 1 }
+git diff --check refs/remotes/origin/develop...HEAD
+```
+
+Expected: no placeholders and no whitespace errors.
+
+- [ ] **Step 3: Verify the diff is documentation-only**
+
+Run:
+
+```powershell
+$changed = git diff --name-only refs/remotes/origin/develop...HEAD
+$invalid = $changed | Where-Object { $_ -notmatch '^docs/' }
+$changed
+if ($invalid) { Write-Error "Non-doc files changed: $($invalid -join ', ')"; exit 1 }
+```
+
+Expected: every changed path begins with `docs/`.
+
+- [ ] **Step 4: Run lint**
+
+Run:
+
+```powershell
+npm run lint
+```
+
+Expected: exit `0`, no ESLint errors.
+
+- [ ] **Step 5: Run the full test suite**
+
+Run:
+
+```powershell
+npm test
+```
+
+Expected: all suites and tests pass, including `openApiRuntimeDriftContract.test.js` and `findingsRegisterGuard.test.js`.
+
+- [ ] **Step 6: Verify repository status and commit history**
+
+Run:
+
+```powershell
+git status --short --branch
+git log --oneline refs/remotes/origin/develop..HEAD
+```
+
+Expected: clean worktree; commits are documentation-only and include the approved design, superseding design, migration guidance, and inventory reconciliation.

--- a/docs/superpowers/plans/2026-07-27-inf-252-pagination-migration-docs.md
+++ b/docs/superpowers/plans/2026-07-27-inf-252-pagination-migration-docs.md
@@ -300,9 +300,19 @@ Update the F35 row in the active inconsistency table to:
 | **F35** | **Users half CLOSED by INF-251/INF-261/INF-262.** OpenAPI now documents the slim projection and the full Phase A query/pagination matrix. The historical mismatch is preserved below; F36 remains the attendance-only open half | `docs/openapi.yaml`; `user.controller.js` |
 ```
 
-Replace the historical F35/F36 comparison table Users rows with current Phase A values:
+Preserve the existing F35/F36 comparison table and label it:
 
 ```markdown
+**Historical snapshot — before INF-251/INF-261/INF-262:**
+```
+
+Then add a separate current-state table:
+
+```markdown
+**Current snapshot — `develop` at `df5a491`:**
+
+| Surface | OpenAPI | Runtime |
+|---|---|---|
 | `GET /api/users` — query | Phase A: `page`, `limit`, `search`, `role`, `program`, `division`, `position`, `location_status`, `sortBy`, `sortOrder` | same |
 | `GET /api/users` — body | Phase A paginated mode: flat `data` plus sibling `pagination`; legacy mode: flat `data` without pagination | same |
 ```
@@ -315,11 +325,11 @@ Run:
 
 ```powershell
 $file = 'docs/architecture/api-contract-inventory.md'
-if (Select-String -Path $file -Pattern 'query: `search`, `sortBy`, `sortOrder` — \*\*no pagination\*\*|none of them fixed|data: \[ … \], no pagination') { exit 1 }
-rg -n 'pagination opt-in in Phase A|Migration target|F20 is closed|Users half CLOSED|INF-251/INF-261/INF-262|F39|F36.*still open' $file
+if (Select-String -Path $file -Pattern 'query: `search`, `sortBy`, `sortOrder` — \*\*no pagination\*\*|none of them fixed') { exit 1 }
+rg -n 'pagination opt-in in Phase A|Migration target|F20 is closed|Users half CLOSED|Historical snapshot|Current snapshot|INF-251/INF-261/INF-262|F39|F36.*still open' $file
 ```
 
-Expected: the first command exits successfully with no stale matches; the second shows corrected Users facts while F39 and F36 remain open.
+Expected: the first command exits successfully with no stale active claims; the second shows both labelled snapshots, corrected Users facts, and the still-open F39/F36 findings.
 
 - [ ] **Step 5: Confirm OpenAPI was not changed**
 

--- a/docs/superpowers/plans/2026-07-27-inf-252-phase2-users-module.md
+++ b/docs/superpowers/plans/2026-07-27-inf-252-phase2-users-module.md
@@ -103,13 +103,13 @@ Six endpoints, six PRs, in this order. **Each PR introduces exactly one new laye
 
 Slice 3 now extracts the Phase A dual-mode contract. It does not introduce Phase C.
 
-- Pagination is triggered when either `page` or `limit` is supplied; defaults are `page=1` and `limit=20`, the cap is `limit=100`, the paginated path counts the complete result set, and pages beyond the last page return `200` with empty `data` and accurate totals.
+- Pagination is triggered when either `page` or `limit` is supplied; defaults are `page=1` and `limit=20`, the cap is `limit=100`, the paginated path counts the complete result set, pages beyond the last page return `200` with empty `data` and accurate totals, and the canonical `{ page, limit, total, totalPages }` object remains a sibling of `data`.
 - Search covers `full_name`, `nip_nim`, and `email`; `%` and `_` are escaped so they remain literal search characters.
 - Filters are `role`, `program`, `division`, `position`, and `location_status`.
 - Sorting is allowlisted to `full_name`, `email`, `nip_nim`, `created_at`, and `updated_at`; malformed or unsupported query values receive deterministic `400 E_VALIDATION` responses.
 - `location_status=integrity_error` remains a visible recovery state for active users with invalid WFH location integrity; it is not collapsed into a normal not-configured state.
 - `UserListItem` is the slim list projection boundary and does not reintroduce phone numbers or raw coordinates.
-- Phase B depends on INF-263 moving the Web FE to the server-driven directory contract and verifying that migration.
+- Phase B depends on INF-263 moving the Web FE to the server-driven directory contract: every directory request sends both `page` and `limit`, and the client renders server pagination metadata without a second client-side pagination layer. That migration must be verified.
 - Phase C is a separate contract PR, after Phase B evidence, to remove the compatibility branch and make `GET /api/users` always paginated.
 
 ---

--- a/docs/superpowers/plans/2026-07-27-inf-252-phase2-users-module.md
+++ b/docs/superpowers/plans/2026-07-27-inf-252-phase2-users-module.md
@@ -2,6 +2,7 @@
 
 **Issue:** [INF-252](https://linear.app/infinite-track-palu/issue/INF-252)
 **Binding spec:** [2026-07-26-inf-252-modular-mvc-design.md](../specs/2026-07-26-inf-252-modular-mvc-design.md)
+**Binding list-query design:** [2026-07-27-inf-252-list-query-post-inf262-design.md](../specs/2026-07-27-inf-252-list-query-post-inf262-design.md)
 **Status:** plan only. **Execution is gated — see the gate below.**
 
 The spec details execution for Phase 0 and Phase 1 and leaves Phases 2–8 as a single arrow on a dependency diagram. This plan converts the first of them into executable steps, and picks the module order for everything after it.
@@ -64,7 +65,7 @@ Six endpoints, six PRs, in this order. **Each PR introduces exactly one new laye
 
 **Slice 2** is the simplest mutation. `User` is `paranoid: true` with `deletedAt: 'deleted_at'`, so `destroy()` is a genuine soft delete and the repository must not quietly become a hard delete.
 
-**Slice 3** carries the real risk: `Op.or` over `full_name` and `nip_nim` with `Op.like`, plus includes. Spec §3.3 requires a strict per-endpoint attribute allowlist. **This is why the gate exists.**
+**Slice 3** carries the highest read-path risk. It moves the complete Phase A query matrix into `user.query.js`: the `findAll` compatibility path; the `findAndCountAll` paginated path; pagination defaults and cap; escaped three-field search; five filters; allowlisted sorting; left-joined WFH location integrity; `distinct: true`; and `subQuery: false`. `user.validation.js` owns transport validation, `user.service.js` owns integrity warnings, and `user.mapper.js` owns the slim list projection. The extraction must preserve both response modes exactly.
 
 **Slice 4** writes `User` and `Location` with **no transaction** — the legacy behaviour, pinned by `usersUpdateContract.test.js`. The extraction preserves it. Adding a transaction here would be a behaviour change and belongs to its own issue.
 
@@ -97,6 +98,19 @@ Six endpoints, six PRs, in this order. **Each PR introduces exactly one new laye
 **The undecided item is unchanged.** `getProfile` and `updateProfile` survived this PR, so spec §3.5.4 still has no answer for the legacy file after slice 6.
 
 **One number moved:** the repository now has **10** migrations, not 9 (`20260727000000-allow-null-location-description.cjs`). The baseline procedure states its ledger check relatively — "must match the number of migration files" — so `db/baseline/README.md` needs no edit, but a dump produced now must carry 10 `sequelizemeta` rows.
+
+### Amended 2026-07-27 — INF-250 / INF-262 landed in PR #129
+
+Slice 3 now extracts the Phase A dual-mode contract. It does not introduce Phase C.
+
+- Pagination is triggered when either `page` or `limit` is supplied; defaults are `page=1` and `limit=20`, the cap is `limit=100`, the paginated path counts the complete result set, and pages beyond the last page return `200` with empty `data` and accurate totals.
+- Search covers `full_name`, `nip_nim`, and `email`; `%` and `_` are escaped so they remain literal search characters.
+- Filters are `role`, `program`, `division`, `position`, and `location_status`.
+- Sorting is allowlisted to `full_name`, `email`, `nip_nim`, `created_at`, and `updated_at`; malformed or unsupported query values receive deterministic `400 E_VALIDATION` responses.
+- `location_status=integrity_error` remains a visible recovery state for active users with invalid WFH location integrity; it is not collapsed into a normal not-configured state.
+- `UserListItem` is the slim list projection boundary and does not reintroduce phone numbers or raw coordinates.
+- Phase B depends on INF-263 moving the Web FE to the server-driven directory contract and verifying that migration.
+- Phase C is a separate contract PR, after Phase B evidence, to remove the compatibility branch and make `GET /api/users` always paginated.
 
 ---
 
@@ -140,6 +154,14 @@ npm run test:integration   # once Phase 0c is green — mandatory from slice 3 o
 ```
 
 A slice is done when all three pass, the legacy function is gone, and the diff shows no edits under `tests/`.
+
+Slice 3 must also retain these existing contract tests without edits:
+
+- `tests/usersListPaginationContract.test.js`
+- `tests/usersListQueryValidationContract.test.js`
+- `tests/usersListSortContract.test.js`
+- `tests/usersPayloadContract.test.js`
+- `tests/openApiRuntimeDriftContract.test.js`
 
 ---
 

--- a/docs/superpowers/specs/2026-07-27-inf-252-list-query-post-inf262-design.md
+++ b/docs/superpowers/specs/2026-07-27-inf-252-list-query-post-inf262-design.md
@@ -1,0 +1,139 @@
+# INF-252 Phase 2 — List Query Foundation after INF-262
+
+**Status:** Approved migration source of truth
+**Supersedes:** [2026-07-27-inf-252-phase2-list-query-design.md](2026-07-27-inf-252-phase2-list-query-design.md)
+**Baseline:** `develop` at `df5a491`
+
+## 1. Resolved decisions
+
+| Former decision | Resolution |
+|---|---|
+| D1 — pagination envelope | Users uses the canonical `{ page, limit, total, totalPages }` object as a sibling of `data`; attendance and reports migrate separately |
+| D2 — paginate users | Yes; opt-in in Phase A, always paginated only after INF-263 in Phase C |
+| D3 — search fields | Per-endpoint allowlist; Users searches `full_name`, `nip_nim`, and `email` |
+
+## 2. Current contract — Phase A
+
+Phase A is the live compatibility contract at `df5a491`. `GET /api/users` preserves the legacy full-array response when both `page` and `limit` are omitted. Supplying either parameter enables pagination, with `page=1`, `limit=20`, and maximum `limit=100`.
+
+Paginated responses keep `data` and the canonical pagination object as siblings:
+
+```json
+{
+  "success": true,
+  "data": [],
+  "pagination": {
+    "page": 1,
+    "limit": 20,
+    "total": 0,
+    "totalPages": 0
+  },
+  "message": "Users fetched successfully"
+}
+```
+
+Users search `full_name`, `nip_nim`, and `email`, with literal handling for `%` and `_`. Filters are `role`, `program`, `division`, `position`, and `location_status`; sort fields are restricted to `full_name`, `email`, `nip_nim`, `created_at`, and `updated_at`. Invalid query values return deterministic `400 E_VALIDATION`; pages past the last page return `200` with empty `data` and accurate totals.
+
+## 3. Client migration — Phase B
+
+INF-263 moves the Web FE to the server-driven directory contract. Every directory request sends `page` and `limit`; search, filters, and sorting go to the backend; URL state represents the directory query; and the client renders server pagination metadata without a second hidden pagination layer. Verification requires data spanning at least two pages.
+
+Phase B must be verified before the Phase A compatibility path can be removed.
+
+## 4. Target contract — Phase C
+
+After INF-263 is deployed and verified, a separate backend contract-change issue and PR will make `GET /api/users` always paginated. Omitting parameters will use `page=1` and `limit=20`; the legacy full-array branch will be removed; the canonical envelope and maximum `limit=100` remain. That delivery updates OpenAPI, contract tests, shared context, release notes, and client compatibility evidence together.
+
+Phase C is approved target architecture, not current runtime.
+
+## 5. Modular MVC ownership
+
+```text
+user.routes.js
+  -> user.validation.js
+  -> user.controller.js
+  -> user.service.js
+  -> user.query.js
+  -> Sequelize models
+  -> user.mapper.js
+  -> user.controller.js response
+```
+
+### `user.routes.js`
+
+- Wires authentication, role guards, query validation, and the controller.
+- Does not interpret pagination, filters, or sort values.
+
+### `user.validation.js`
+
+- Owns transport validation and normalization for all documented query parameters.
+- Rejects arrays and malformed scalar values.
+- Enforces integer bounds, enums, and the sort allowlist.
+- Produces the same `400 E_VALIDATION` contract as Phase A.
+
+### `user.controller.js`
+
+- Reads validated query input.
+- Calls one service operation.
+- Returns the response envelope supplied by the use case.
+- Contains no Sequelize operators, includes, sorting map, count logic, or integrity scanning.
+
+### `user.service.js`
+
+- Orchestrates the directory use case.
+- Calls the query object and mapper.
+- Owns the warning for active users whose `location_status` is `integrity_error`.
+- Does not know about Express request or response objects.
+
+### `user.query.js`
+
+- Owns the `where` clause, associations, selected attributes, search predicates, filters, sort mapping, `findAll` compatibility path, and `findAndCountAll` paginated path.
+- Preserves `distinct: true` and `subQuery: false` while the association topology remains compatible with those choices.
+- Returns query results and count data; it does not construct HTTP responses.
+- Uses per-endpoint allowlists. No client-provided column name reaches Sequelize directly.
+
+### `user.mapper.js`
+
+- Produces the stable slim `UserListItem`.
+- Does not reintroduce phone numbers or raw coordinates.
+- Preserves `location_status` semantics.
+
+Extraction preserves both the Phase A `findAll` compatibility path and the paginated `findAndCountAll` path.
+
+## 6. Shared list-query boundary
+
+Shared code may own scalar pagination parsing, escaped LIKE construction, and canonical pagination metadata only when the ADR-009 two-consumer rule is satisfied. The Users module owns its public field lists and feature-specific association graph. The extraction must not create a global query specification containing user-specific fields.
+
+## 7. Extraction invariants
+
+- Preserve the public Phase A response shapes and status codes.
+- Preserve deterministic validation, including rejection of malformed array-shaped query values.
+- Preserve successful empty pages and accurate totals.
+- Preserve `location_status=integrity_error` as a visible recovery state, not a normal not-configured state.
+- Do not introduce Phase C as an accidental side effect of moving files.
+- Do not remove the full-array compatibility path until Phase B evidence exists and a separate Phase C contract PR is approved.
+
+## 8. Verification gates
+
+- Verify the extraction preserves both Phase A paths and all documented query validation.
+- Verify a paginated request returns the canonical sibling `pagination` object with accurate totals, including an empty page beyond the last page.
+- Verify search, filters, sort allowlists, and literal `%` and `_` handling.
+- Verify INF-263 client compatibility evidence before any Phase C contract change.
+- Run `npm run lint`, `npm test`, and `git diff --check` for a migration delivery.
+
+## 9. Risks
+
+| Risk | Mitigation |
+|---|---|
+| Phase C is mistaken for current runtime | Keep Phase A explicitly current and label Phase C as target |
+| Extraction removes compatibility | Preserve both query paths and require INF-263 evidence before Phase C |
+| Shared query code absorbs feature policy | Apply the two-consumer rule and keep Users fields and joins feature-owned |
+| Attendance or reports are treated as resolved | Migrate those contracts separately |
+
+## 10. Out of scope
+
+- Changing `GET /api/users` runtime behavior.
+- Implementing INF-263.
+- Migrating controller code into `src/modules/users/`.
+- Unifying attendance or summary-report pagination.
+- Changing authentication, role authorization, database schema, Docker, deployment, or Linear issue states.

--- a/docs/superpowers/specs/2026-07-27-inf-252-pagination-migration-docs-design.md
+++ b/docs/superpowers/specs/2026-07-27-inf-252-pagination-migration-docs-design.md
@@ -1,0 +1,260 @@
+# INF-252 Pagination Migration Documentation Refresh: Design Spec
+
+**Linear:** [INF-252](https://linear.app/infinite-track-palu/issue/INF-252/backendarchitecture-adopt-modular-mvc-per-feature-with-safe), [INF-250](https://linear.app/infinite-track-palu/issue/INF-250/cross-repo-define-scalable-user-directory-search-filter-sort-and), [INF-262](https://linear.app/infinite-track-palu/issue/INF-262/backend-implement-server-driven-get-users-directory-query-inf-250), [INF-263](https://linear.app/infinite-track-palu/issue/INF-263/web-fe-consume-server-driven-user-directory-pagination-search-filter)
+**Date:** 2026-07-27
+**Status:** Approved design
+**Baseline:** `develop` at merge commit `df5a491` (PR #129)
+**Scope:** Documentation alignment only. No runtime, route, response, database, Docker, or Linear-state changes.
+
+---
+
+## 1. Problem
+
+PR #129 implemented the INF-250 contract for `GET /api/users`, but the migration documentation still describes the pre-INF-262 architecture:
+
+- the Phase 2 list-query spec says the user directory has no pagination;
+- it treats the pagination envelope and the decision to paginate users as unresolved;
+- the Users-module migration plan describes moving the older two-field search and unvalidated sorting implementation;
+- the target Modular MVC document explains query-object ownership generically but does not show how the live user-directory contract maps into that ownership;
+- the API contract inventory contains a stale endpoint-table row even though later sections correctly record INF-262.
+
+This creates a migration hazard. An implementer following the old design could preserve or recreate the wrong contract while extracting `getAllUsers` into the Users module.
+
+## 2. Decision
+
+Use a **superseding-document strategy**:
+
+1. Preserve the original Phase 2 list-query design as historical evidence.
+2. Mark it explicitly as superseded by a new post-INF-262 design.
+3. Make the new design the source of truth for migrating the user-directory query into Modular MVC.
+4. Keep OpenAPI truthful to the current Phase A runtime until a later runtime PR implements Phase C.
+5. Record current, transitional, and target states separately so future intent cannot be mistaken for live behavior.
+
+The old document is not silently rewritten because it records the facts and trade-offs that led to INF-250. The new document resolves those decisions using the evidence from INF-250, INF-262, and PR #129.
+
+## 3. Contract lifecycle
+
+### Phase A — current backend compatibility mode
+
+This is the live contract at `df5a491`:
+
+- `GET /api/users` without `page` and `limit` preserves the legacy full-array response.
+- Supplying either `page` or `limit` enables server pagination.
+- Defaults in paginated mode are `page=1` and `limit=20`.
+- The maximum `limit` is `100`.
+- Paginated responses use:
+
+```json
+{
+  "success": true,
+  "data": [],
+  "pagination": {
+    "page": 1,
+    "limit": 20,
+    "total": 0,
+    "totalPages": 0
+  },
+  "message": "Users fetched successfully"
+}
+```
+
+- Search covers `full_name`, `nip_nim`, and `email`, with literal handling for `%` and `_`.
+- Filters are `role`, `program`, `division`, `position`, and `location_status`.
+- Sort fields are restricted to `full_name`, `email`, `nip_nim`, `created_at`, and `updated_at`.
+- Invalid query values return deterministic `400 E_VALIDATION`.
+- A page beyond the last page returns `200`, an empty `data` array, and accurate totals.
+
+Phase A is intentionally transitional. It is not the target state for a scalable directory.
+
+### Phase B — Web FE cutover
+
+INF-263 moves the Web FE to the server-driven contract:
+
+- every directory request sends `page` and `limit`;
+- search, filters, and sorting are sent to the backend;
+- URL state represents the directory query;
+- the client renders the server-provided pagination metadata;
+- the client does not apply a second hidden pagination layer;
+- verification uses a dataset spanning at least two pages.
+
+Phase B must be verified before removing the compatibility path.
+
+### Phase C — target backend contract
+
+After INF-263 is deployed and verified, a separate backend contract-change issue and PR will:
+
+- make `GET /api/users` always paginated;
+- apply `page=1` and `limit=20` when the client omits them;
+- remove the legacy full-array response branch;
+- retain the canonical envelope and maximum `limit=100`;
+- update OpenAPI, contract tests, shared context, release notes, and client compatibility evidence in the same delivery cycle.
+
+Phase C is approved target architecture, not current runtime. Documentation must label it accordingly.
+
+## 4. Target Modular MVC ownership
+
+The migration preserves the public Phase A contract first. It must not introduce Phase C as an accidental side effect of moving files.
+
+```text
+user.routes.js
+  -> user.validation.js
+  -> user.controller.js
+  -> user.service.js
+  -> user.query.js
+  -> Sequelize models
+  -> user.mapper.js
+  -> user.controller.js response
+```
+
+### `user.routes.js`
+
+- Wires authentication, role guards, query validation, and the controller.
+- Does not interpret pagination, filters, or sort values.
+
+### `user.validation.js`
+
+- Owns transport validation and normalization for all documented query parameters.
+- Rejects arrays and malformed scalar values.
+- Enforces integer bounds, enums, and the sort allowlist.
+- Produces the same `400 E_VALIDATION` contract as Phase A.
+
+### `user.controller.js`
+
+- Reads validated query input.
+- Calls one service operation.
+- Returns the response envelope supplied by the use case.
+- Contains no Sequelize operators, includes, sorting map, count logic, or integrity scanning.
+
+### `user.service.js`
+
+- Orchestrates the directory use case.
+- Calls the query object and mapper.
+- Owns the warning for active users whose `location_status` is `integrity_error`.
+- Does not know about Express request or response objects.
+
+### `user.query.js`
+
+- Owns the `where` clause, associations, selected attributes, search predicates, filters, sort mapping, `findAll` compatibility path, and `findAndCountAll` paginated path.
+- Preserves `distinct: true` and `subQuery: false` while the association topology remains compatible with those choices.
+- Returns query results and count data; it does not construct HTTP responses.
+- Uses per-endpoint allowlists. No client-provided column name reaches Sequelize directly.
+
+### `user.mapper.js`
+
+- Produces the stable slim `UserListItem`.
+- Does not reintroduce phone numbers or raw coordinates.
+- Preserves `location_status` semantics.
+
+### Shared query primitives
+
+Shared code may own mechanisms such as scalar pagination parsing, escaped LIKE construction, and canonical pagination metadata only when the ADR-009 two-consumer rule is satisfied. The Users module owns its public field lists and feature-specific association graph.
+
+The architecture migration must not create a global query specification containing user-specific fields.
+
+## 5. Documentation changes
+
+### Create
+
+`docs/superpowers/specs/2026-07-27-inf-252-list-query-post-inf262-design.md`
+
+- Becomes the binding post-INF-262 design for the list-query foundation and Users-module extraction.
+- Records the Phase A/B/C lifecycle.
+- Resolves the old D1/D2/D3 decisions with the accepted INF-250 contract.
+- Defines feature and shared ownership boundaries.
+
+### Modify
+
+`docs/superpowers/specs/2026-07-27-inf-252-phase2-list-query-design.md`
+
+- Add a prominent `Superseded` status and link to the replacement.
+- Preserve the historical body.
+
+`docs/superpowers/plans/2026-07-27-inf-252-phase2-users-module.md`
+
+- Add a post-INF-262 amendment.
+- Replace stale Slice 3 assumptions with the live query matrix.
+- State that extraction preserves Phase A and that Phase C requires a separate contract PR.
+- Map query, validation, service, and mapper responsibilities.
+
+`docs/architecture/target-modular-mvc.md`
+
+- Add the user-directory list flow as the worked query-object example.
+- Show the boundary between feature-owned contract and shared mechanism.
+- Add the Phase A preservation rule and Phase C non-goal for extraction.
+
+`docs/architecture/api-contract-inventory.md`
+
+- Correct the stale `/api/users` endpoint row.
+- Reconcile stale findings text with the already-recorded INF-262 closure.
+- Keep unrelated attendance and summary pagination inconsistencies open.
+
+`docs/openapi.yaml`
+
+- No semantic change in this documentation refresh.
+- It continues to describe Phase A because OpenAPI represents live runtime, not future architecture.
+- It changes only in the later Phase C runtime delivery.
+
+`docs/adr/ADR-009-modular-mvc-per-feature.md`
+
+- Keep `Status: Proposed`.
+- Add no acceptance claim.
+- The refreshed docs may link to ADR-009, but only the decider can accept it.
+
+## 6. Source-of-truth rules
+
+The refreshed documents use these labels:
+
+- **Current:** verified in the live repository/runtime at `df5a491`.
+- **Transitional:** approved and implemented for compatibility, but scheduled for removal.
+- **Target:** approved future contract that is not yet live.
+- **Historical:** accurate record of an earlier decision point, superseded for implementation.
+
+When documents conflict:
+
+1. runtime and code establish current behavior;
+2. OpenAPI describes the current public contract;
+3. the new post-INF-262 design controls migration structure and target state;
+4. the old Phase 2 design remains historical only.
+
+## 7. Error and compatibility handling
+
+- The architecture extraction must preserve Phase A status codes and response shapes.
+- Validation remains deterministic and rejects malformed array-shaped query values.
+- Empty pages remain successful responses.
+- `location_status=integrity_error` remains a visible recovery state, not a normal “not configured” state.
+- Phase C cannot be merged until INF-263 compatibility evidence exists.
+- Removing the full-array path without that evidence is a breaking contract change.
+
+## 8. Verification
+
+The documentation refresh is complete when:
+
+1. no active migration document says `/api/users` lacks pagination;
+2. no active migration document treats INF-250 pagination decisions as unresolved;
+3. every future-state statement is labelled Phase C or target;
+4. OpenAPI remains aligned with Phase A runtime;
+5. the inventory table and findings register agree;
+6. links between historical, current, and superseding documents resolve;
+7. `npm run lint` passes;
+8. `npm test` passes, including OpenAPI drift and findings-register guards;
+9. `git diff --check` reports no whitespace errors.
+
+## 9. Risks
+
+| Risk | Mitigation |
+|---|---|
+| Future Phase C is mistaken for current runtime | Keep OpenAPI on Phase A and label every Phase C statement as target |
+| Migration silently removes legacy compatibility | State that extraction is behavior-preserving and Phase C needs a separate issue/PR |
+| Historical evidence is lost | Preserve the old design body and add only a superseded banner |
+| Shared query code absorbs feature policy | Document the two-consumer rule and keep field lists/joins inside Users |
+| Attendance or reporting pagination is accidentally declared resolved | Keep F39 and unrelated endpoint contracts explicitly out of scope |
+| ADR acceptance is implied without authority | Keep ADR-009 `Proposed` |
+
+## 10. Out of scope
+
+- Changing `GET /api/users` runtime behavior.
+- Implementing INF-263.
+- Migrating controller code into `src/modules/users/`.
+- Unifying attendance or summary-report pagination.
+- Changing authentication, role authorization, database schema, Docker, or deployment.
+- Updating Linear issue states.

--- a/docs/superpowers/specs/2026-07-27-inf-252-phase2-list-query-design.md
+++ b/docs/superpowers/specs/2026-07-27-inf-252-phase2-list-query-design.md
@@ -2,8 +2,11 @@
 
 **Linear:** [INF-252](https://linear.app/infinite-track-palu/issue/INF-252/backendarchitecture-adopt-modular-mvc-per-feature-with-safe), [INF-250](https://linear.app/infinite-track-palu/issue/INF-250/cross-repo-define-scalable-user-directory-search-filter-sort-and)
 **Date:** 2026-07-27
-**Status:** Proposed — **blocked on two decisions and one artifact**
+**Status:** Superseded — historical pre-INF-262 decision record
+**Superseded by:** [2026-07-27-inf-252-list-query-post-inf262-design.md](2026-07-27-inf-252-list-query-post-inf262-design.md)
 **Scope:** the shared list-query foundation only. No module extraction; that is Phase 3 onwards.
+
+> Historical boundary: the facts and recommendations below describe the repository before INF-250 was decided and INF-262 landed in PR #129. Do not use this document to implement the Users query extraction.
 
 ---
 


### PR DESCRIPTION
## Summary

- supersede the pre-INF-262 `GET /users` list-query design while preserving it as historical context
- document the verified Phase A server-driven query and pagination contract from PR #129
- update the INF-252 Users migration plan, target modular MVC guidance, and API contract inventory
- make the Phase B Web FE handoff explicit: send both `page` and `limit` on every request and do not apply a second client-side pagination layer

## Why

The migration documentation still described the older pagination design after PR #129 merged. That created competing contract descriptions around query parameters, pagination defaults, envelope shape, and client ownership. This PR reconciles the docs with the implemented and tested `df5a491` contract so the later architecture migration has one evidence-backed source of truth.

## Impact

Documentation only. No runtime, OpenAPI, test, Docker, workflow, or database behavior changes.

## Verified contract

- pagination is opt-in during Phase A when `page` or `limit` is present
- defaults are `page=1` and `limit=20`, with maximum `limit=100`
- paginated responses use a sibling `pagination` object containing `page`, `limit`, `total`, and `totalPages`
- GET filters/pagination remain query parameters, never a request body
- Phase B Web FE becomes fully server-driven and sends both pagination parameters

## Validation

- `npm run lint`
- `npm test` — 126/126 suites, 1,211/1,211 tests passed
- `git diff --check`
- final cross-task review: no Critical, Important, or Minor findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated `/api/users` contract documentation with optional pagination, filtering, sorting, search, response metadata, and validation/error behavior.
  - Added a current-versus-historical API contract snapshot and marked outdated list-query guidance as superseded.
  - Documented the Phase A/B/C pagination lifecycle and compatibility rules.
  - Added a worked Users directory example showing responsibilities across the modular MVC layers.
  - Expanded migration checklists and verification requirements for preserving existing response shapes and contract tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->