### PR TITLE
feat(INF-270): add global WFA policy and reason catalogs

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -3335,7 +3335,7 @@ paths:
                   example: 2
                 request_other_reason:
                   type: string
-                  maxLength: 255
+                  maxLength: 500
                   nullable: true
                   example: 'Client incident response'
                 latitude:
@@ -3634,17 +3634,17 @@ paths:
                   data:
                     type: object
                     required:
-                      - radius_m
-                      - request_reasons
+                      - radius_meters
+                      - reasons
                     properties:
-                      radius_m:
+                      radius_meters:
                         type: integer
                         minimum: 1
                         example: 100
-                      request_reasons:
+                      reasons:
                         type: array
                         items:
-                          $ref: '#/components/schemas/WfaReason'
+                          $ref: '#/components/schemas/WfaPublicReason'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '500':
@@ -6843,7 +6843,7 @@ components:
 
     WfaReason:
       type: object
-      required: [id, label, is_other, is_active, sort_order]
+      required: [id, label, is_other, is_active, sort_order, created_at, updated_at]
       additionalProperties: false
       properties:
         id:
@@ -6861,6 +6861,30 @@ components:
         sort_order:
           type: integer
           example: 20
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    WfaPublicReason:
+      type: object
+      required: [id, label, is_other, sort_order]
+      additionalProperties: false
+      properties:
+        id:
+          type: integer
+          example: 2
+        label:
+          type: string
+          example: 'Client meeting'
+        is_other:
+          type: boolean
+          example: false
+        sort_order:
+          type: integer
+          example: 20
 
     WfaReasonCreateRequest:
       type: object
@@ -6870,7 +6894,7 @@ components:
         label:
           type: string
           minLength: 1
-          maxLength: 255
+          maxLength: 120
         is_other:
           type: boolean
           default: false
@@ -6891,7 +6915,7 @@ components:
         label:
           type: string
           minLength: 1
-          maxLength: 255
+          maxLength: 120
         is_active:
           type: boolean
         sort_order:
@@ -7371,7 +7395,11 @@ components:
                 type: boolean
                 example: true
               data:
-                $ref: '#/components/schemas/WfaReason'
+                type: object
+                required: [reason]
+                properties:
+                  reason:
+                    $ref: '#/components/schemas/WfaReason'
 
     BadRequest:
       description: Bad request - Invalid input data

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -3303,7 +3303,15 @@ paths:
       tags:
         - WFA Bookings
       summary: Create WFA booking
-      description: Create a new Work From Anywhere booking request
+      description: |
+        Create a pending Work From Anywhere booking request. The authenticated user, request radius,
+        suitability result, and initial status are owned by the backend. `schedule_date` must be a real
+        ISO calendar date. When the selected request reason has `is_other=true`, `request_other_reason`
+        is required; otherwise it must be omitted. Stable validation codes include
+        `INVALID_SCHEDULE_DATE`, `PAST_DATE_NOT_ALLOWED`, `SAME_DAY_NOT_ALLOWED`,
+        `WFA_REQUEST_REASON_REQUIRED`, `WFA_REQUEST_REASON_NOT_FOUND`,
+        `WFA_REQUEST_REASON_NOT_ACTIVE`, and `WFA_OTHER_REASON_REQUIRED`.
+        A same-user/same-date conflict returns `DUPLICATE_BOOKING`.
       requestBody:
         required: true
         content:
@@ -3312,13 +3320,24 @@ paths:
               type: object
               required:
                 - schedule_date
+                - request_reason_id
                 - latitude
                 - longitude
               properties:
                 schedule_date:
                   type: string
                   format: date
+                  pattern: '^\d{4}-\d{2}-\d{2}$'
                   example: '2026-04-29'
+                request_reason_id:
+                  type: integer
+                  minimum: 1
+                  example: 2
+                request_other_reason:
+                  type: string
+                  maxLength: 255
+                  nullable: true
+                  example: 'Client incident response'
                 latitude:
                   type: number
                   format: float
@@ -3327,9 +3346,6 @@ paths:
                   type: number
                   format: float
                   example: 106.816666
-                radius:
-                  type: number
-                  example: 100
                 description:
                   type: string
                   example: 'WFA smoke gate location'
@@ -3349,25 +3365,42 @@ paths:
                     example: true
                   message:
                     type: string
-                    example: 'Booking WFA berhasil diajukan dan menunggu persetujuan.'
+                    example: 'Booking WFA berhasil dibuat.'
                   data:
                     type: object
+                    required:
+                      - booking_id
+                      - schedule_date
+                      - status
+                      - request_reason
+                      - location
+                      - radius_snapshot
+                      - created_at
                     properties:
                       booking_id:
                         type: integer
                       schedule_date:
                         type: string
-                      location_id:
-                        type: integer
                       status:
                         type: string
                         example: pending
+                      request_reason:
+                        $ref: '#/components/schemas/WfaRequestReasonProjection'
+                      location:
+                        $ref: '#/components/schemas/WfaBookingLocation'
+                      radius_snapshot:
+                        type: integer
+                        minimum: 1
+                        example: 100
                       suitability_score:
                         type: number
                         nullable: true
                       suitability_label:
                         type: string
                         nullable: true
+                      created_at:
+                        type: string
+                        format: date-time
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -3484,7 +3517,11 @@ paths:
       tags:
         - WFA Bookings
       summary: Update booking status (Admin/Management only)
-      description: Approve or reject a WFA booking request
+      description: |
+        Approve or reject a WFA booking request. Rejection requires `rejection_reason_id`; when that
+        catalog item has `is_other=true`, `rejection_note` is required. Approval clears structured
+        rejection fields. Stable rejection codes are `REJECTION_REASON_REQUIRED`,
+        `REJECTION_REASON_NOT_FOUND`, `REJECTION_REASON_NOT_ACTIVE`, and `REJECTION_NOTE_REQUIRED`.
       parameters:
         - in: path
           name: id
@@ -3505,9 +3542,17 @@ paths:
                   type: string
                   enum: [approved, rejected]
                   example: 'approved'
-                admin_notes:
+                rejection_reason_id:
+                  type: integer
+                  minimum: 1
+                  nullable: true
+                  description: Required when status is rejected; must reference an active rejection reason.
+                rejection_note:
                   type: string
-                  example: 'Approved for client meeting'
+                  maxLength: 500
+                  nullable: true
+                  description: Required only when the selected rejection reason has is_other=true.
+                  example: 'The submitted location does not meet the current operational need.'
       responses:
         '200':
           description: Booking status updated successfully
@@ -3565,6 +3610,49 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
+
+  /api/wfa/request-config:
+    get:
+      tags:
+        - WFA System
+      summary: Get WFA request configuration
+      description: Return the backend-authoritative request radius and active request-reason catalog.
+      responses:
+        '200':
+          description: WFA request configuration retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - success
+                  - data
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: object
+                    required:
+                      - radius_m
+                      - request_reasons
+                    properties:
+                      radius_m:
+                        type: integer
+                        minimum: 1
+                        example: 100
+                      request_reasons:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/WfaReason'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          description: WFA configuration storage is missing or invalid (`WFA_CONFIG_UNAVAILABLE`).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WfaConfigUnavailableError'
 
   # WFA Recommendations
   /api/wfa/recommendations:
@@ -5041,6 +5129,118 @@ paths:
         '500':
           $ref: '#/components/responses/OperationalSettingsIntegrityError'
 
+  /api/settings/wfa/request-reasons:
+    get:
+      tags: [Settings]
+      summary: List all WFA request reasons (Admin/Management only)
+      responses:
+        '200':
+          $ref: '#/components/responses/WfaReasonCatalogResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+    post:
+      tags: [Settings]
+      summary: Create a WFA request reason (Admin/Management only)
+      description: Rejects invalid input with `E_VALIDATION` and the single-Other invariant with `WFA_REASON_CATALOG_CONFLICT`.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WfaReasonCreateRequest'
+      responses:
+        '201':
+          $ref: '#/components/responses/WfaReasonMutationResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /api/settings/wfa/request-reasons/{id}:
+    patch:
+      tags: [Settings]
+      summary: Update a WFA request reason (Admin/Management only)
+      description: Rejects invalid input with `E_VALIDATION` and the single-Other invariant with `WFA_REASON_CATALOG_CONFLICT`.
+      parameters:
+        - $ref: '#/components/parameters/WfaReasonId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WfaReasonUpdateRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/WfaReasonMutationResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/settings/wfa/rejection-reasons:
+    get:
+      tags: [Settings]
+      summary: List all WFA rejection reasons (Admin/Management only)
+      responses:
+        '200':
+          $ref: '#/components/responses/WfaReasonCatalogResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+    post:
+      tags: [Settings]
+      summary: Create a WFA rejection reason (Admin/Management only)
+      description: Rejects invalid input with `E_VALIDATION` and the single-Other invariant with `WFA_REASON_CATALOG_CONFLICT`.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WfaReasonCreateRequest'
+      responses:
+        '201':
+          $ref: '#/components/responses/WfaReasonMutationResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /api/settings/wfa/rejection-reasons/{id}:
+    patch:
+      tags: [Settings]
+      summary: Update a WFA rejection reason (Admin/Management only)
+      description: Rejects invalid input with `E_VALIDATION` and the single-Other invariant with `WFA_REASON_CATALOG_CONFLICT`.
+      parameters:
+        - $ref: '#/components/parameters/WfaReasonId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WfaReasonUpdateRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/WfaReasonMutationResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
   # Reference Data Endpoints
   /api/roles:
     get:
@@ -5185,6 +5385,16 @@ components:
       in: cookie
       name: token
       description: Access token stored in the HTTP-only `token` cookie for browser flows.
+
+  parameters:
+    WfaReasonId:
+      in: path
+      name: id
+      required: true
+      schema:
+        type: integer
+        minimum: 1
+      description: WFA reason catalog item ID.
 
   schemas:
     LoginRequest:
@@ -5771,6 +5981,11 @@ components:
         This schema intentionally exposes only the approved operational settings. It does not include arbitrary
         settings-table rows or analysis configuration such as `AHP_CR_THRESHOLD`.
       properties:
+        wfaRequestRadiusM:
+          type: integer
+          minimum: 1
+          example: 100
+          description: Backend-authoritative radius in meters for every newly submitted WFA request.
         geofenceRadiusDefaultM:
           type: integer
           minimum: 1
@@ -5797,6 +6012,7 @@ components:
           example: '17:00:00'
           description: Default fallback shift end time normalized to HH:mm:ss.
       required:
+        - wfaRequestRadiusM
         - geofenceRadiusDefaultM
         - autoCheckoutIdleMin
         - autoCheckoutTBufferMin
@@ -5812,6 +6028,10 @@ components:
         Only the approved operational settings may be sent. `defaultShiftEnd` accepts `HH:mm` or `HH:mm:ss` on input
         and is normalized to `HH:mm:ss` in the success response.
       properties:
+        wfaRequestRadiusM:
+          type: integer
+          minimum: 1
+          example: 150
         geofenceRadiusDefaultM:
           type: integer
           minimum: 1
@@ -6621,6 +6841,126 @@ components:
           example: 100
           description: 'Geofence radius in meters'
 
+    WfaReason:
+      type: object
+      required: [id, label, is_other, is_active, sort_order]
+      additionalProperties: false
+      properties:
+        id:
+          type: integer
+          example: 2
+        label:
+          type: string
+          example: 'Client meeting'
+        is_other:
+          type: boolean
+          example: false
+        is_active:
+          type: boolean
+          example: true
+        sort_order:
+          type: integer
+          example: 20
+
+    WfaReasonCreateRequest:
+      type: object
+      required: [label]
+      additionalProperties: false
+      properties:
+        label:
+          type: string
+          minLength: 1
+          maxLength: 255
+        is_other:
+          type: boolean
+          default: false
+        is_active:
+          type: boolean
+          default: true
+        sort_order:
+          type: integer
+          minimum: 0
+          default: 0
+
+    WfaReasonUpdateRequest:
+      type: object
+      minProperties: 1
+      additionalProperties: false
+      description: `is_other` is immutable; deactivate a catalog item with `is_active=false` instead of deleting it.
+      properties:
+        label:
+          type: string
+          minLength: 1
+          maxLength: 255
+        is_active:
+          type: boolean
+        sort_order:
+          type: integer
+          minimum: 0
+
+    WfaRequestReasonProjection:
+      type: object
+      required: [id, label, is_other, other_text]
+      properties:
+        id:
+          type: integer
+        label:
+          type: string
+        is_other:
+          type: boolean
+        other_text:
+          type: string
+          nullable: true
+
+    WfaRejectionReasonProjection:
+      type: object
+      nullable: true
+      required: [id, label, is_other, note]
+      properties:
+        id:
+          type: integer
+        label:
+          type: string
+        is_other:
+          type: boolean
+        note:
+          type: string
+          nullable: true
+
+    WfaBookingLocation:
+      type: object
+      required: [location_id, latitude, longitude, radius]
+      properties:
+        location_id:
+          type: integer
+        latitude:
+          type: number
+          format: float
+        longitude:
+          type: number
+          format: float
+        radius:
+          type: integer
+          minimum: 1
+        description:
+          type: string
+          nullable: true
+
+    WfaConfigUnavailableError:
+      type: object
+      required: [success, code, message]
+      additionalProperties: false
+      properties:
+        success:
+          type: boolean
+          example: false
+        code:
+          type: string
+          example: WFA_CONFIG_UNAVAILABLE
+        message:
+          type: string
+          example: 'WFA configuration is unavailable'
+
     Booking:
       type: object
       properties:
@@ -6630,13 +6970,20 @@ components:
         user_id:
           type: integer
           example: 1
-        date:
+        schedule_date:
           type: string
           format: date
-          example: '2025-07-10'
-        location_name:
-          type: string
-          example: 'Coffee Shop Downtown'
+          example: '2026-07-30'
+        request_reason:
+          $ref: '#/components/schemas/WfaRequestReasonProjection'
+        rejection_reason:
+          $ref: '#/components/schemas/WfaRejectionReasonProjection'
+        radius_snapshot:
+          type: integer
+          minimum: 1
+          example: 100
+        location:
+          $ref: '#/components/schemas/WfaBookingLocation'
         latitude:
           type: number
           format: float
@@ -6645,9 +6992,6 @@ components:
           type: number
           format: float
           example: 106.816666
-        reason:
-          type: string
-          example: 'Working on client presentation'
         notes:
           type: string
           nullable: true
@@ -6656,10 +7000,6 @@ components:
           type: string
           enum: [pending, approved, rejected]
           example: 'pending'
-        admin_notes:
-          type: string
-          nullable: true
-          example: 'Approved for client meeting'
         approved_by:
           type: integer
           nullable: true
@@ -6746,6 +7086,15 @@ components:
           format: date
           example: '2025-07-15'
           description: Scheduled WFA date
+        request_reason:
+          $ref: '#/components/schemas/WfaRequestReasonProjection'
+        rejection_reason:
+          $ref: '#/components/schemas/WfaRejectionReasonProjection'
+        radius_snapshot:
+          type: integer
+          minimum: 1
+          example: 100
+          description: Server-owned WFA request radius captured when the booking was submitted.
         status:
           type: string
           enum: [pending, approved, rejected]
@@ -6990,6 +7339,40 @@ components:
           example: false
 
   responses:
+    WfaReasonCatalogResponse:
+      description: WFA reason catalog retrieved successfully, including active and inactive entries.
+      content:
+        application/json:
+          schema:
+            type: object
+            required: [success, data]
+            properties:
+              success:
+                type: boolean
+                example: true
+              data:
+                type: object
+                required: [reasons]
+                properties:
+                  reasons:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/WfaReason'
+
+    WfaReasonMutationResponse:
+      description: WFA reason catalog item saved successfully.
+      content:
+        application/json:
+          schema:
+            type: object
+            required: [success, data]
+            properties:
+              success:
+                type: boolean
+                example: true
+              data:
+                $ref: '#/components/schemas/WfaReason'
+
     BadRequest:
       description: Bad request - Invalid input data
       content:

--- a/docs/superpowers/plans/2026-07-28-inf-270-wfa-policy-and-reason-catalogs.md
+++ b/docs/superpowers/plans/2026-07-28-inf-270-wfa-policy-and-reason-catalogs.md
@@ -1,0 +1,1498 @@
+# INF-270 Server-Authoritative WFA Policy and Reason Catalogs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the backend the authoritative owner of the global WFA radius, request reasons, rejection reasons, and booking reject semantics consumed by Android INF-265 and Management Web INF-271.
+
+**Architecture:** Preserve the repository's current layer-first Express architecture. Reuse the existing `settings` table and operational settings service for radius, add focused Sequelize reason catalogs, and keep booking mutations in the existing booking controller while delegating settings/reason lookup to a focused WFA settings service.
+
+**Tech Stack:** Node.js ESM, Express, express-validator, Sequelize 6, MySQL, Jest ESM, OpenAPI YAML.
+
+**Design spec:** `docs/superpowers/specs/2026-07-28-inf-270-wfa-policy-and-reason-catalogs-design.md`
+
+## Global Constraints
+
+- Preserve `Route → middleware/validator → Controller → focused existing-layer service/helper → Sequelize Model → MySQL`.
+- Do not add `src/modules`, repository, adapter, policy, mapper, base-controller, or v2 API layers.
+- `bookings` remains the WFA request and approval source of truth.
+- Do not use or redesign the legacy `wfa_requests` table.
+- Store the global radius in the existing `settings` table as `wfa.request.radius_m` and expose it as `wfaRequestRadiusM`.
+- All business date behavior uses `Asia/Jakarta`; canonical client date format is strict `YYYY-MM-DD`.
+- Android must not control radius, user identity, status, timestamps, or suitability.
+- Used reasons are deactivated; no hard-delete endpoint is added.
+- Leave the existing `bookings.rejection_reason` column untouched and stop new code from writing it.
+- Preserve existing auth-session validation, role guards, transactions, duplicate-booking rules, and nightly resolver semantics.
+- During the compatibility window, accept but ignore legacy `radius`, `suitability_score`, and `suitability_label` request fields.
+- Every task follows test-first development and ends in an independently reviewable commit.
+- Implementation branch starts from `develop`; final delivery is a PR into `develop`.
+
+---
+
+## File Structure Map
+
+### Create
+
+```text
+src/controllers/wfaSettings.controller.js
+src/services/wfaSettings.service.js
+src/middlewares/wfaSettings.validator.js
+src/models/wfaRequestReason.model.js
+src/models/wfaRejectionReason.model.js
+src/models/migrations/20260728010000-add-wfa-request-policy.cjs
+tests/wfaSettingsService.test.js
+tests/wfaSettingsRoutesContract.test.js
+tests/wfaRequestConfigContract.test.js
+tests/bookingWfaPolicyContract.test.js
+tests/bookingWfaRejectionContract.test.js
+tests/bookingWfaProjectionContract.test.js
+tests/openapiWfaPolicyContract.test.js
+```
+
+### Modify
+
+```text
+src/utils/settings.js
+src/services/operationalSettings.service.js
+src/middlewares/settings.validator.js
+src/routes/settings.routes.js
+src/routes/wfa.routes.js
+src/routes/booking.routes.js
+src/middlewares/validator.js
+src/controllers/booking.controller.js
+src/models/booking.model.js
+src/models/index.js
+docs/openapi.yaml
+tests/operationalSettings.test.js
+tests/settingsOperationalRoutesContract.test.js
+tests/bookingsReadinessContract.test.js
+tests/resolveWfaBookingsJobIdempotency.test.js
+```
+
+### Responsibilities
+
+- `wfaSettings.service.js`: typed settings/reason reads and CRUD-lite catalog operations.
+- `wfaSettings.controller.js`: HTTP response orchestration for request config and catalog endpoints.
+- `wfaSettings.validator.js`: catalog body/path validation only.
+- `booking.controller.js`: canonical create/approve/reject transaction orchestration.
+- `settings.js` and `operationalSettings.service.js`: canonical operational radius mapping and mutation.
+- reason models: relational catalog persistence.
+- migration: additive schema, defaults, indexes, and FKs without legacy data deletion.
+
+---
+
+### Task 1: Add the Global WFA Radius to Existing Operational Settings
+
+**Files:**
+- Modify: `src/utils/settings.js`
+- Modify: `src/services/operationalSettings.service.js`
+- Modify: `src/middlewares/settings.validator.js`
+- Modify: `tests/operationalSettings.test.js`
+- Modify: `tests/settingsOperationalRoutesContract.test.js`
+
+**Interfaces:**
+- Produces: `wfaRequestRadiusM: number` in operational settings reads and patches.
+- Produces: DB key `wfa.request.radius_m` with default `100`.
+- Consumes: existing `Settings` model and operational settings transaction flow.
+
+- [ ] **Step 1: Extend failing operational settings expectations**
+
+Update `tests/operationalSettings.test.js` so all full settings fixtures include:
+
+```js
+{ setting_key: 'wfa.request.radius_m', setting_value: '100' }
+```
+
+and expected typed objects include:
+
+```js
+wfaRequestRadiusM: 100
+```
+
+Add focused assertions:
+
+```js
+expect(OPERATIONAL_SETTING_KEYS.wfaRequestRadiusM).toBe('wfa.request.radius_m');
+expect(OPERATIONAL_SETTING_DEFAULTS.wfaRequestRadiusM).toBe(100);
+expect(OPERATIONAL_SETTING_INTEGER_FIELDS).toContain('wfaRequestRadiusM');
+expect(normalizeOperationalSettingValue('wfaRequestRadiusM', '150')).toBe(150);
+expect(normalizeOperationalSettingValue('wfaRequestRadiusM', 0)).toBeNull();
+```
+
+- [ ] **Step 2: Run focused settings tests and verify failure**
+
+Run:
+
+```bash
+npm test -- --runInBand tests/operationalSettings.test.js tests/settingsOperationalRoutesContract.test.js
+```
+
+Expected: FAIL because `wfaRequestRadiusM` is not yet registered.
+
+- [ ] **Step 3: Register the WFA radius in the existing settings map**
+
+Modify `src/utils/settings.js`:
+
+```js
+export const OPERATIONAL_SETTING_KEYS = {
+  geofenceRadiusDefaultM: 'attendance.geofence.radius_default_m',
+  autoCheckoutIdleMin: 'attendance.auto_checkout.idle_min',
+  autoCheckoutTBufferMin: 'attendance.auto_checkout.tbuffer_min',
+  lateCheckoutToleranceMin: 'attendance.auto_checkout.late_tolerance_min',
+  defaultShiftEnd: 'checkout.fallback_time',
+  wfaRequestRadiusM: 'wfa.request.radius_m'
+};
+
+export const OPERATIONAL_SETTING_DEFAULTS = {
+  geofenceRadiusDefaultM: 100,
+  autoCheckoutIdleMin: 10,
+  autoCheckoutTBufferMin: 30,
+  lateCheckoutToleranceMin: 15,
+  defaultShiftEnd: '17:00:00',
+  wfaRequestRadiusM: 100
+};
+
+export const OPERATIONAL_SETTING_INTEGER_FIELDS = Object.freeze([
+  'geofenceRadiusDefaultM',
+  'autoCheckoutIdleMin',
+  'autoCheckoutTBufferMin',
+  'lateCheckoutToleranceMin',
+  'wfaRequestRadiusM'
+]);
+```
+
+Do not add a separate settings access path.
+
+- [ ] **Step 4: Verify existing operational patch validation accepts the field**
+
+Add a route-contract assertion that this payload reaches the existing patch handler:
+
+```js
+{
+  wfaRequestRadiusM: 150
+}
+```
+
+and invalid values such as `0`, `-1`, and non-integers return `400`.
+
+Only modify `settings.validator.js` when its explicit allow-list does not already derive from `OPERATIONAL_SETTING_FIELDS`.
+
+- [ ] **Step 5: Run focused tests**
+
+Run:
+
+```bash
+npm test -- --runInBand tests/operationalSettings.test.js tests/settingsOperationalRoutesContract.test.js
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the settings contract**
+
+```bash
+git add src/utils/settings.js src/services/operationalSettings.service.js src/middlewares/settings.validator.js tests/operationalSettings.test.js tests/settingsOperationalRoutesContract.test.js
+git commit -m "feat: add global WFA radius setting"
+```
+
+---
+
+### Task 2: Add Reason Catalog Schema and Booking Columns
+
+**Files:**
+- Create: `src/models/migrations/20260728010000-add-wfa-request-policy.cjs`
+- Create: `src/models/wfaRequestReason.model.js`
+- Create: `src/models/wfaRejectionReason.model.js`
+- Modify: `src/models/booking.model.js`
+- Modify: `src/models/index.js`
+- Create: `tests/wfaSettingsService.test.js`
+
+**Interfaces:**
+- Produces: Sequelize models `WfaRequestReason` and `WfaRejectionReason`.
+- Produces: Booking associations `request_reason` and `rejection_reason_detail`.
+- Produces booking fields: `request_reason_id`, `request_other_reason`, `rejection_reason_id`, `rejection_note`, `radius_snapshot`.
+- Preserves: legacy `Booking.rejection_reason`.
+
+- [ ] **Step 1: Write failing model/export contract tests**
+
+Create `tests/wfaSettingsService.test.js` with an initial model-shape test using dynamic imports or source-contract assertions consistent with existing model tests:
+
+```js
+expect(models).toHaveProperty('WfaRequestReason');
+expect(models).toHaveProperty('WfaRejectionReason');
+expect(models.Booking.rawAttributes).toHaveProperty('request_reason_id');
+expect(models.Booking.rawAttributes).toHaveProperty('rejection_reason_id');
+expect(models.Booking.rawAttributes).toHaveProperty('radius_snapshot');
+expect(models.Booking.rawAttributes).toHaveProperty('rejection_reason');
+```
+
+Also assert association aliases:
+
+```js
+expect(models.Booking.associations).toHaveProperty('request_reason');
+expect(models.Booking.associations).toHaveProperty('rejection_reason_detail');
+```
+
+- [ ] **Step 2: Run the model test and verify failure**
+
+```bash
+npm test -- --runInBand tests/wfaSettingsService.test.js
+```
+
+Expected: FAIL because models and fields do not exist.
+
+- [ ] **Step 3: Implement the request reason model**
+
+Create `src/models/wfaRequestReason.model.js`:
+
+```js
+import { DataTypes } from 'sequelize';
+import sequelize from '../config/database.js';
+
+const WfaRequestReason = sequelize.define(
+  'WfaRequestReason',
+  {
+    id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
+    label: { type: DataTypes.STRING(120), allowNull: false },
+    is_active: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: true },
+    is_other: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false },
+    sort_order: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
+    created_at: { type: DataTypes.DATE, allowNull: false },
+    updated_at: { type: DataTypes.DATE, allowNull: false }
+  },
+  {
+    tableName: 'wfa_request_reasons',
+    timestamps: false
+  }
+);
+
+export default WfaRequestReason;
+```
+
+- [ ] **Step 4: Implement the rejection reason model**
+
+Create `src/models/wfaRejectionReason.model.js` with the same fields and table name `wfa_rejection_reasons`.
+
+- [ ] **Step 5: Add booking fields without removing the legacy field**
+
+Modify `src/models/booking.model.js`:
+
+```js
+request_reason_id: {
+  type: DataTypes.INTEGER,
+  allowNull: true,
+  references: { model: 'wfa_request_reasons', key: 'id' }
+},
+request_other_reason: {
+  type: DataTypes.TEXT,
+  allowNull: true
+},
+rejection_reason_id: {
+  type: DataTypes.INTEGER,
+  allowNull: true,
+  references: { model: 'wfa_rejection_reasons', key: 'id' }
+},
+rejection_note: {
+  type: DataTypes.TEXT,
+  allowNull: true
+},
+radius_snapshot: {
+  type: DataTypes.INTEGER,
+  allowNull: true
+}
+```
+
+Keep the existing `rejection_reason` definition unchanged.
+
+- [ ] **Step 6: Register models and associations**
+
+Modify `src/models/index.js`:
+
+```js
+import WfaRequestReason from './wfaRequestReason.model.js';
+import WfaRejectionReason from './wfaRejectionReason.model.js';
+```
+
+Add:
+
+```js
+Booking.belongsTo(WfaRequestReason, {
+  foreignKey: 'request_reason_id',
+  as: 'request_reason'
+});
+
+Booking.belongsTo(WfaRejectionReason, {
+  foreignKey: 'rejection_reason_id',
+  as: 'rejection_reason_detail'
+});
+
+WfaRequestReason.hasMany(Booking, {
+  foreignKey: 'request_reason_id',
+  as: 'bookings'
+});
+
+WfaRejectionReason.hasMany(Booking, {
+  foreignKey: 'rejection_reason_id',
+  as: 'bookings'
+});
+```
+
+Export both models.
+
+- [ ] **Step 7: Write the additive migration**
+
+Create `src/models/migrations/20260728010000-add-wfa-request-policy.cjs`.
+
+`up` must:
+
+1. insert `wfa.request.radius_m = 100` only when absent;
+2. create both catalog tables;
+3. insert the approved default rows with deterministic sort orders `10`, `20`, `30`, `999`;
+4. add all five nullable booking columns;
+5. add indexes for both reason FKs;
+6. add `RESTRICT` foreign keys;
+7. leave `rejection_reason` untouched.
+
+Default request rows:
+
+```js
+[
+  ['Pertemuan dengan klien', true, false, 10],
+  ['Pekerjaan lapangan', true, false, 20],
+  ['Perjalanan bisnis', true, false, 30],
+  ['Lainnya', true, true, 999]
+]
+```
+
+Default rejection rows:
+
+```js
+[
+  ['Lokasi tidak memenuhi ketentuan', true, false, 10],
+  ['Tanggal tidak dapat disetujui', true, false, 20],
+  ['Alasan tidak sesuai kebijakan', true, false, 30],
+  ['Data pengajuan belum lengkap', true, false, 40],
+  ['Lainnya', true, true, 999]
+]
+```
+
+`down` may remove only the columns/tables/setting introduced by this migration. It must never remove the legacy `rejection_reason` column.
+
+- [ ] **Step 8: Run model tests and migration status**
+
+```bash
+npm test -- --runInBand tests/wfaSettingsService.test.js
+npm run migrate:status
+```
+
+Expected: tests PASS; migration status lists the new migration as pending before execution.
+
+- [ ] **Step 9: Run migration against a disposable test database**
+
+```bash
+npm run migrate
+npm run migrate:status
+```
+
+Expected: migration succeeds, new tables/columns exist, legacy bookings remain readable.
+
+- [ ] **Step 10: Commit schema and models**
+
+```bash
+git add src/models/migrations/20260728010000-add-wfa-request-policy.cjs src/models/wfaRequestReason.model.js src/models/wfaRejectionReason.model.js src/models/booking.model.js src/models/index.js tests/wfaSettingsService.test.js
+git commit -m "feat: add WFA reason catalogs and booking policy fields"
+```
+
+---
+
+### Task 3: Implement WFA Settings Service and Catalog Invariants
+
+**Files:**
+- Create: `src/services/wfaSettings.service.js`
+- Modify: `tests/wfaSettingsService.test.js`
+
+**Interfaces:**
+- Produces: `readWfaRequestConfig(transaction = null)`.
+- Produces: `resolveActiveWfaRequestReason({ reasonId, otherReasonText, transaction })`.
+- Produces: `resolveActiveWfaRejectionReason({ reasonId, note, transaction })`.
+- Produces: `listWfaReasons({ catalog, includeInactive, transaction })`.
+- Produces: `createWfaReason({ catalog, payload, transaction })`.
+- Produces: `updateWfaReason({ catalog, id, payload, transaction })`.
+
+- [ ] **Step 1: Add failing service behavior tests**
+
+Mock `Settings`, `WfaRequestReason`, and `WfaRejectionReason` through `../src/models/index.js`.
+
+Add tests for:
+
+```js
+await expect(readWfaRequestConfig()).resolves.toEqual({
+  radiusMeters: 100,
+  reasons: [
+    { id: 1, label: 'Pertemuan dengan klien', isOther: false, sortOrder: 10 }
+  ]
+});
+```
+
+Add failure tests:
+
+```js
+await expect(
+  resolveActiveWfaRequestReason({ reasonId: 99, otherReasonText: null })
+).rejects.toMatchObject({
+  status: 400,
+  code: 'WFA_REQUEST_REASON_NOT_FOUND'
+});
+```
+
+```js
+await expect(
+  resolveActiveWfaRequestReason({ reasonId: 4, otherReasonText: '   ' })
+).rejects.toMatchObject({
+  status: 400,
+  code: 'WFA_OTHER_REASON_REQUIRED'
+});
+```
+
+```js
+await expect(
+  resolveActiveWfaRejectionReason({ reasonId: 5, note: '' })
+).rejects.toMatchObject({
+  status: 400,
+  code: 'REJECTION_NOTE_REQUIRED'
+});
+```
+
+Add a catalog invariant test proving a second `is_other=true` row fails with `WFA_REASON_CATALOG_CONFLICT`.
+
+- [ ] **Step 2: Run the service test and verify failure**
+
+```bash
+npm test -- --runInBand tests/wfaSettingsService.test.js
+```
+
+Expected: FAIL because the service does not exist.
+
+- [ ] **Step 3: Implement stable service errors**
+
+Inside `src/services/wfaSettings.service.js`:
+
+```js
+const createWfaError = ({ status = 400, code, message, field = null }) => {
+  const error = new Error(message);
+  error.status = status;
+  error.code = code;
+  error.details = field ? [{ field, code }] : [];
+  return error;
+};
+```
+
+Do not introduce a global error rewrite.
+
+- [ ] **Step 4: Implement catalog model selection**
+
+```js
+const getCatalogModel = (catalog) => {
+  if (catalog === 'request') return WfaRequestReason;
+  if (catalog === 'rejection') return WfaRejectionReason;
+  throw createWfaError({
+    code: 'WFA_REASON_CATALOG_CONFLICT',
+    message: 'Katalog alasan WFA tidak valid.'
+  });
+};
+```
+
+- [ ] **Step 5: Implement employee config read**
+
+Use `getOperationalSettingsStrict(transaction)` and `WfaRequestReason.findAll`:
+
+```js
+export const readWfaRequestConfig = async (transaction = null) => {
+  const [settings, reasons] = await Promise.all([
+    getOperationalSettingsStrict(transaction),
+    WfaRequestReason.findAll({
+      where: { is_active: true },
+      order: [['sort_order', 'ASC'], ['id', 'ASC']],
+      transaction
+    })
+  ]);
+
+  return {
+    radiusMeters: settings.wfaRequestRadiusM,
+    reasons: reasons.map((reason) => ({
+      id: reason.id,
+      label: reason.label,
+      isOther: Boolean(reason.is_other),
+      sortOrder: reason.sort_order
+    }))
+  };
+};
+```
+
+Map strict settings integrity errors to:
+
+```text
+status = 500
+code = WFA_CONFIG_UNAVAILABLE
+```
+
+without exposing raw DB details.
+
+- [ ] **Step 6: Implement active request reason resolution**
+
+Required return shape:
+
+```js
+{
+  reason,
+  normalizedOtherReason: reason.is_other ? trimmedOtherText : null
+}
+```
+
+Rules:
+
+- missing ID → `WFA_REQUEST_REASON_REQUIRED`;
+- not found → `WFA_REQUEST_REASON_NOT_FOUND`;
+- inactive → `WFA_REQUEST_REASON_NOT_ACTIVE`;
+- Other with blank text → `WFA_OTHER_REASON_REQUIRED`;
+- non-Other normalizes supplied Other text to null.
+
+- [ ] **Step 7: Implement active rejection reason resolution**
+
+Required return shape:
+
+```js
+{
+  reason,
+  normalizedNote: trimmedNote || null
+}
+```
+
+Rules:
+
+- missing ID → `REJECTION_REASON_REQUIRED`;
+- not found → `REJECTION_REASON_NOT_FOUND`;
+- inactive → `REJECTION_REASON_NOT_ACTIVE`;
+- Other with blank note → `REJECTION_NOTE_REQUIRED`.
+
+- [ ] **Step 8: Implement catalog list/create/update**
+
+Validation at the service boundary:
+
+```text
+label: trimmed, 1..120 chars
+sort_order: integer >= 0
+is_active: boolean when supplied
+is_other: boolean only on create
+PATCH fields: label, is_active, sort_order only
+```
+
+Before creating an `is_other=true` row, query for any existing Other row in that catalog and fail with `WFA_REASON_CATALOG_CONFLICT`.
+
+Do not implement delete.
+
+- [ ] **Step 9: Run service tests**
+
+```bash
+npm test -- --runInBand tests/wfaSettingsService.test.js
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Commit the service**
+
+```bash
+git add src/services/wfaSettings.service.js tests/wfaSettingsService.test.js
+git commit -m "feat: add WFA settings and reason catalog service"
+```
+
+---
+
+### Task 4: Add Employee Config and Management Catalog Routes
+
+**Files:**
+- Create: `src/controllers/wfaSettings.controller.js`
+- Create: `src/middlewares/wfaSettings.validator.js`
+- Modify: `src/routes/wfa.routes.js`
+- Modify: `src/routes/settings.routes.js`
+- Create: `tests/wfaSettingsRoutesContract.test.js`
+- Create: `tests/wfaRequestConfigContract.test.js`
+
+**Interfaces:**
+- Produces: `GET /api/wfa/request-config`.
+- Produces: management CRUD-lite routes under `/api/settings/wfa`.
+- Consumes: service functions from Task 3.
+
+- [ ] **Step 1: Write failing route composition tests**
+
+Create route-contract tests that assert:
+
+```text
+GET /api/wfa/request-config
+→ verifyToken
+→ getWfaRequestConfig
+```
+
+and:
+
+```text
+GET/POST/PATCH /api/settings/wfa/request-reasons
+GET/POST/PATCH /api/settings/wfa/rejection-reasons
+→ verifyToken
+→ roleGuard(['Admin', 'Management'])
+→ validator on POST/PATCH
+→ controller
+```
+
+Assert no DELETE route exists.
+
+- [ ] **Step 2: Write failing controller response tests**
+
+Mock `readWfaRequestConfig()` and expect:
+
+```js
+{
+  success: true,
+  data: {
+    radius_meters: 100,
+    reasons: [
+      {
+        id: 1,
+        label: 'Pertemuan dengan klien',
+        is_other: false,
+        sort_order: 10
+      }
+    ]
+  }
+}
+```
+
+- [ ] **Step 3: Run route/controller tests and verify failure**
+
+```bash
+npm test -- --runInBand tests/wfaSettingsRoutesContract.test.js tests/wfaRequestConfigContract.test.js
+```
+
+Expected: FAIL because routes/controllers do not exist.
+
+- [ ] **Step 4: Implement catalog validators**
+
+Create `src/middlewares/wfaSettings.validator.js` using `express-validator` and the repository's existing `validate` middleware pattern.
+
+Create exports:
+
+```js
+export const createWfaReasonValidation = [...];
+export const updateWfaReasonValidation = [...];
+export const wfaReasonIdValidation = [...];
+```
+
+POST accepts:
+
+```text
+label required string max 120
+is_other optional boolean
+sort_order optional integer min 0
+```
+
+PATCH accepts at least one of:
+
+```text
+label
+is_active
+sort_order
+```
+
+PATCH rejects `is_other` changes.
+
+- [ ] **Step 5: Implement thin controllers**
+
+Create exports in `src/controllers/wfaSettings.controller.js`:
+
+```js
+getWfaRequestConfig
+listWfaRequestReasons
+createWfaRequestReason
+updateWfaRequestReason
+listWfaRejectionReasons
+createWfaRejectionReason
+updateWfaRejectionReason
+```
+
+Each controller:
+
+- calls one service function;
+- maps domain/service output to snake_case HTTP fields;
+- returns `next(error)` on failure;
+- does not query Sequelize directly.
+
+- [ ] **Step 6: Mount the employee route**
+
+Modify `src/routes/wfa.routes.js` after `router.use(verifyToken)`:
+
+```js
+router.get('/request-config', getWfaRequestConfig);
+```
+
+Keep recommendation/AHP routes unchanged.
+
+- [ ] **Step 7: Mount management catalog routes**
+
+Modify `src/routes/settings.routes.js`:
+
+```js
+router.get(
+  '/wfa/request-reasons',
+  roleGuard(['Admin', 'Management']),
+  listWfaRequestReasons
+);
+router.post(
+  '/wfa/request-reasons',
+  roleGuard(['Admin', 'Management']),
+  createWfaReasonValidation,
+  validate,
+  createWfaRequestReason
+);
+router.patch(
+  '/wfa/request-reasons/:id',
+  roleGuard(['Admin', 'Management']),
+  wfaReasonIdValidation,
+  updateWfaReasonValidation,
+  validate,
+  updateWfaRequestReason
+);
+```
+
+Add equivalent rejection reason routes.
+
+- [ ] **Step 8: Run route/controller tests**
+
+```bash
+npm test -- --runInBand tests/wfaSettingsRoutesContract.test.js tests/wfaRequestConfigContract.test.js
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit routes and controllers**
+
+```bash
+git add src/controllers/wfaSettings.controller.js src/middlewares/wfaSettings.validator.js src/routes/wfa.routes.js src/routes/settings.routes.js tests/wfaSettingsRoutesContract.test.js tests/wfaRequestConfigContract.test.js
+git commit -m "feat: expose WFA request config and reason management routes"
+```
+
+---
+
+### Task 5: Harden Booking Creation with Server-Owned Policy
+
+**Files:**
+- Modify: `src/middlewares/validator.js`
+- Modify: `src/routes/booking.routes.js`
+- Modify: `src/controllers/booking.controller.js`
+- Create: `tests/bookingWfaPolicyContract.test.js`
+- Modify: `tests/bookingsReadinessContract.test.js`
+
+**Interfaces:**
+- Consumes: `readWfaRequestConfig` and `resolveActiveWfaRequestReason` from Task 3.
+- Produces: canonical `POST /api/bookings` request/response contract.
+- Produces: server-owned location radius and booking `radius_snapshot`.
+
+- [ ] **Step 1: Write failing validator contract tests**
+
+Test valid canonical payload:
+
+```js
+{
+  schedule_date: '2026-08-10',
+  request_reason_id: 1,
+  request_other_reason: null,
+  notes: 'Pertemuan project',
+  latitude: -0.9,
+  longitude: 119.87,
+  description: 'Lokasi klien'
+}
+```
+
+Test failures:
+
+```text
+10-08-2026 → INVALID_SCHEDULE_DATE
+08-10-2026 → INVALID_SCHEDULE_DATE
+missing request_reason_id → WFA_REQUEST_REASON_REQUIRED
+invalid latitude/longitude → E_VALIDATION
+```
+
+Keep compatibility fields accepted by validation:
+
+```text
+radius
+suitability_score
+suitability_label
+```
+
+but do not make them required or authoritative.
+
+- [ ] **Step 2: Write failing controller behavior tests**
+
+Mock service/model calls and prove:
+
+```js
+expect(Location.create).toHaveBeenCalledWith(
+  expect.objectContaining({ radius: 150 }),
+  expect.any(Object)
+);
+
+expect(Booking.create).toHaveBeenCalledWith(
+  expect.objectContaining({
+    request_reason_id: 1,
+    request_other_reason: null,
+    radius_snapshot: 150,
+    status: 3
+  }),
+  expect.any(Object)
+);
+```
+
+Send `radius: 9999` in the test payload and prove it is not persisted.
+
+Send fake suitability inputs and prove the controller uses server-calculated values.
+
+- [ ] **Step 3: Run booking policy tests and verify failure**
+
+```bash
+npm test -- --runInBand tests/bookingWfaPolicyContract.test.js tests/bookingsReadinessContract.test.js
+```
+
+Expected: FAIL because the current controller trusts client radius and does not require a reason.
+
+- [ ] **Step 4: Enforce strict ISO date validation**
+
+Update `createBookingValidation` in `src/middlewares/validator.js`:
+
+```js
+body('schedule_date')
+  .isString()
+  .matches(/^\d{4}-\d{2}-\d{2}$/)
+  .withMessage('schedule_date harus menggunakan format YYYY-MM-DD');
+
+body('request_reason_id')
+  .isInt({ min: 1 })
+  .withMessage('request_reason_id wajib diisi');
+```
+
+Keep latitude/longitude numeric range validation and existing notes/description limits.
+
+- [ ] **Step 5: Replace ambiguous date parsing in `createBooking`**
+
+Use one strict parser path:
+
+```js
+const isoDatePattern = /^\d{4}-\d{2}-\d{2}$/;
+if (!isoDatePattern.test(schedule_date)) {
+  return res.status(400).json({
+    success: false,
+    code: 'INVALID_SCHEDULE_DATE',
+    message: 'Tanggal WFA harus menggunakan format YYYY-MM-DD.',
+    errors: [{ field: 'schedule_date', code: 'INVALID_SCHEDULE_DATE' }]
+  });
+}
+```
+
+Validate calendar correctness by round-tripping year/month/day rather than relying on permissive JavaScript parsing.
+
+Use WIB today semantics from the repository's existing settings/date helper rather than Android/client time.
+
+- [ ] **Step 6: Resolve server configuration and request reason inside the existing transaction**
+
+At the start of the existing booking transaction:
+
+```js
+const { radiusMeters } = await readWfaRequestConfig(transaction);
+const { reason, normalizedOtherReason } = await resolveActiveWfaRequestReason({
+  reasonId: request_reason_id,
+  otherReasonText: request_other_reason,
+  transaction
+});
+```
+
+Do not read `radius` from the request body for persistence.
+
+- [ ] **Step 7: Preserve existing duplicate and suitability logic**
+
+Keep:
+
+```text
+past/same-day rejection
+duplicate pending/approved detection
+server status pending
+server timestamps
+Location reuse/creation
+server suitability calculation
+```
+
+Remove the branch that trusts client-supplied `suitability_score` and `suitability_label`. Always calculate or resolve suitability server-side.
+
+- [ ] **Step 8: Persist server-owned fields**
+
+Location creation/reuse must use `radiusMeters` for new location radius.
+
+Booking creation must include:
+
+```js
+request_reason_id: reason.id,
+request_other_reason: normalizedOtherReason,
+radius_snapshot: radiusMeters
+```
+
+Normalize optional notes to the existing non-null model requirement:
+
+```js
+notes: typeof notes === 'string' ? notes.trim() : ''
+```
+
+- [ ] **Step 9: Return backend-confirmed result data**
+
+Return:
+
+```js
+{
+  success: true,
+  message: 'Booking WFA berhasil dibuat.',
+  data: {
+    booking_id,
+    schedule_date,
+    status: 'pending',
+    request_reason: {
+      id: reason.id,
+      label: reason.label,
+      is_other: Boolean(reason.is_other),
+      other_text: normalizedOtherReason
+    },
+    location: {
+      location_id,
+      latitude,
+      longitude,
+      radius: radiusMeters,
+      description
+    },
+    radius_snapshot: radiusMeters,
+    suitability_score,
+    suitability_label,
+    created_at
+  }
+}
+```
+
+Do not return raw Sequelize instances.
+
+- [ ] **Step 10: Run booking creation tests**
+
+```bash
+npm test -- --runInBand tests/bookingWfaPolicyContract.test.js tests/bookingsReadinessContract.test.js
+```
+
+Expected: PASS.
+
+- [ ] **Step 11: Commit booking creation hardening**
+
+```bash
+git add src/middlewares/validator.js src/routes/booking.routes.js src/controllers/booking.controller.js tests/bookingWfaPolicyContract.test.js tests/bookingsReadinessContract.test.js
+git commit -m "feat: enforce server-owned WFA booking policy"
+```
+
+---
+
+### Task 6: Require Explicit Rejection Reasons for Management Decisions
+
+**Files:**
+- Modify: `src/middlewares/validator.js`
+- Modify: `src/controllers/booking.controller.js`
+- Create: `tests/bookingWfaRejectionContract.test.js`
+
+**Interfaces:**
+- Consumes: `resolveActiveWfaRejectionReason` from Task 3.
+- Produces: typed Management reject contract on `PATCH /api/bookings/:id`.
+- Preserves: approval without rejection fields and automated resolver behavior.
+
+- [ ] **Step 1: Write failing rejection contract tests**
+
+Cover:
+
+```text
+approved without reason → success
+rejected without reason → REJECTION_REASON_REQUIRED
+rejected with missing reason → REJECTION_REASON_NOT_FOUND
+rejected with inactive reason → REJECTION_REASON_NOT_ACTIVE
+rejected with Other and blank note → REJECTION_NOTE_REQUIRED
+rejected with normal reason and no note → success
+rejected with Other and note → success
+```
+
+Assert persisted fields:
+
+```js
+expect(booking.update).toHaveBeenCalledWith(
+  expect.objectContaining({
+    status: 2,
+    rejection_reason_id: 5,
+    rejection_note: 'Keterangan khusus',
+    approved_by: 9,
+    processed_at: expect.any(Date)
+  }),
+  expect.any(Object)
+);
+```
+
+- [ ] **Step 2: Run rejection tests and verify failure**
+
+```bash
+npm test -- --runInBand tests/bookingWfaRejectionContract.test.js
+```
+
+Expected: FAIL because the current handler reads only `status`.
+
+- [ ] **Step 3: Extend status validation**
+
+Update the existing status validator so:
+
+```text
+status=approved → rejection fields optional and ignored
+status=rejected → rejection_reason_id integer >= 1
+rejection_note optional string max 500 at HTTP boundary
+```
+
+Conditional Other validation remains in the service because it requires database state.
+
+- [ ] **Step 4: Resolve rejection reason only for rejection**
+
+Inside the existing transaction:
+
+```js
+let rejectionDecision = {
+  reason: null,
+  normalizedNote: null
+};
+
+if (status === 'rejected') {
+  rejectionDecision = await resolveActiveWfaRejectionReason({
+    reasonId: req.body.rejection_reason_id,
+    note: req.body.rejection_note,
+    transaction
+  });
+}
+```
+
+- [ ] **Step 5: Persist approval and rejection fields explicitly**
+
+Approval update:
+
+```js
+{
+  status: 1,
+  rejection_reason_id: null,
+  rejection_note: null,
+  approved_by: req.user.id,
+  processed_at: new Date()
+}
+```
+
+Rejection update:
+
+```js
+{
+  status: 2,
+  rejection_reason_id: rejectionDecision.reason.id,
+  rejection_note: rejectionDecision.normalizedNote,
+  approved_by: req.user.id,
+  processed_at: new Date()
+}
+```
+
+Do not write the legacy `rejection_reason` column.
+
+- [ ] **Step 6: Extend the update response**
+
+For rejected bookings return:
+
+```js
+rejection_reason: {
+  id: rejectionDecision.reason.id,
+  label: rejectionDecision.reason.label,
+  is_other: Boolean(rejectionDecision.reason.is_other),
+  note: rejectionDecision.normalizedNote
+}
+```
+
+For approved bookings return `rejection_reason: null`.
+
+- [ ] **Step 7: Run rejection tests**
+
+```bash
+npm test -- --runInBand tests/bookingWfaRejectionContract.test.js
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit reject semantics**
+
+```bash
+git add src/middlewares/validator.js src/controllers/booking.controller.js tests/bookingWfaRejectionContract.test.js
+git commit -m "feat: require WFA rejection reasons"
+```
+
+---
+
+### Task 7: Update Booking Read Projections and Protect Nightly Resolver Behavior
+
+**Files:**
+- Modify: `src/controllers/booking.controller.js`
+- Create: `tests/bookingWfaProjectionContract.test.js`
+- Modify: `tests/resolveWfaBookingsJobIdempotency.test.js`
+
+**Interfaces:**
+- Produces: null-safe request/rejection reason and radius snapshot projections for create/list/history/update responses.
+- Preserves: automated expiry rejection with null human reason.
+
+- [ ] **Step 1: Write failing projection tests**
+
+New booking expectation:
+
+```js
+expect(projectedBooking).toMatchObject({
+  request_reason: {
+    id: 1,
+    label: 'Pertemuan dengan klien',
+    is_other: false,
+    other_text: null
+  },
+  rejection_reason: null,
+  radius_snapshot: 100
+});
+```
+
+Rejected booking expectation:
+
+```js
+expect(projectedBooking.rejection_reason).toEqual({
+  id: 2,
+  label: 'Lokasi tidak memenuhi ketentuan',
+  is_other: false,
+  note: 'Di luar area operasional'
+});
+```
+
+Legacy row expectation:
+
+```js
+expect(projectedBooking).toMatchObject({
+  request_reason: null,
+  rejection_reason: null,
+  radius_snapshot: 100
+});
+```
+
+where `100` is a read-only fallback from `location.radius` because the legacy row has null `radius_snapshot`.
+
+- [ ] **Step 2: Run projection tests and verify failure**
+
+```bash
+npm test -- --runInBand tests/bookingWfaProjectionContract.test.js
+```
+
+Expected: FAIL because current read projections do not include the new associations.
+
+- [ ] **Step 3: Add reason associations to booking queries**
+
+For create/list/history/detail/update refetches, include:
+
+```js
+{
+  model: WfaRequestReason,
+  as: 'request_reason',
+  attributes: ['id', 'label', 'is_other']
+},
+{
+  model: WfaRejectionReason,
+  as: 'rejection_reason_detail',
+  attributes: ['id', 'label', 'is_other']
+}
+```
+
+Use model imports from `src/models/index.js`.
+
+- [ ] **Step 4: Add one focused projection helper inside the controller file**
+
+Do not create a mapper layer. Add a local helper:
+
+```js
+const projectWfaReasonData = (booking) => ({
+  request_reason: booking.request_reason
+    ? {
+        id: booking.request_reason.id,
+        label: booking.request_reason.label,
+        is_other: Boolean(booking.request_reason.is_other),
+        other_text: booking.request_other_reason || null
+      }
+    : null,
+  rejection_reason: booking.rejection_reason_detail
+    ? {
+        id: booking.rejection_reason_detail.id,
+        label: booking.rejection_reason_detail.label,
+        is_other: Boolean(booking.rejection_reason_detail.is_other),
+        note: booking.rejection_note || null
+      }
+    : null,
+  radius_snapshot: booking.radius_snapshot ?? booking.location?.radius ?? null
+});
+```
+
+Apply it consistently without replacing unrelated response fields.
+
+- [ ] **Step 5: Add nightly resolver regression assertions**
+
+Extend `tests/resolveWfaBookingsJobIdempotency.test.js` to assert system expiry rejection still calls:
+
+```js
+booking.update(
+  expect.objectContaining({
+    status: 2,
+    approved_by: null
+  })
+);
+```
+
+and does not require or fabricate `rejection_reason_id`.
+
+- [ ] **Step 6: Run projection and resolver tests**
+
+```bash
+npm test -- --runInBand tests/bookingWfaProjectionContract.test.js tests/resolveWfaBookingsJobIdempotency.test.js
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit projections and regression protection**
+
+```bash
+git add src/controllers/booking.controller.js tests/bookingWfaProjectionContract.test.js tests/resolveWfaBookingsJobIdempotency.test.js
+git commit -m "feat: expose WFA policy data in booking responses"
+```
+
+---
+
+### Task 8: Document OpenAPI Contract and Complete Verification
+
+**Files:**
+- Modify: `docs/openapi.yaml`
+- Create: `tests/openapiWfaPolicyContract.test.js`
+- Verify: all implementation files from Tasks 1–7
+
+**Interfaces:**
+- Produces: OpenAPI as the documented contract for Android and Management Web.
+- Produces: final lint/test/migration/runtime evidence.
+
+- [ ] **Step 1: Write failing OpenAPI source-contract tests**
+
+Create `tests/openapiWfaPolicyContract.test.js` asserting the YAML contains:
+
+```text
+/api/wfa/request-config
+/api/settings/wfa/request-reasons
+/api/settings/wfa/request-reasons/{id}
+/api/settings/wfa/rejection-reasons
+/api/settings/wfa/rejection-reasons/{id}
+wfaRequestRadiusM
+request_reason_id
+request_other_reason
+rejection_reason_id
+rejection_note
+radius_snapshot
+```
+
+Assert canonical booking schema does not declare these fields as authoritative request properties:
+
+```text
+radius
+suitability_score
+suitability_label
+user_id
+status
+```
+
+- [ ] **Step 2: Run the OpenAPI test and verify failure**
+
+```bash
+npm test -- --runInBand tests/openapiWfaPolicyContract.test.js
+```
+
+Expected: FAIL because the contract is not documented.
+
+- [ ] **Step 3: Document operational settings radius**
+
+Extend the existing operational settings schemas with:
+
+```yaml
+wfaRequestRadiusM:
+  type: integer
+  minimum: 1
+  example: 100
+```
+
+- [ ] **Step 4: Document employee request config**
+
+Add `GET /api/wfa/request-config` with:
+
+```text
+Bearer auth
+200 config response
+401 session failure
+500 WFA_CONFIG_UNAVAILABLE
+```
+
+- [ ] **Step 5: Document reason catalog routes**
+
+Document GET/POST/PATCH for both catalogs, Admin/Management authorization, payload validation, response schemas, and no DELETE operation.
+
+- [ ] **Step 6: Update booking create and status schemas**
+
+Document strict ISO date, required `request_reason_id`, conditional Other text, server-owned radius, and rejection reason payload.
+
+Document stable error codes from the design spec.
+
+- [ ] **Step 7: Run focused contract tests**
+
+```bash
+npm test -- --runInBand \
+  tests/operationalSettings.test.js \
+  tests/settingsOperationalRoutesContract.test.js \
+  tests/wfaSettingsService.test.js \
+  tests/wfaSettingsRoutesContract.test.js \
+  tests/wfaRequestConfigContract.test.js \
+  tests/bookingWfaPolicyContract.test.js \
+  tests/bookingWfaRejectionContract.test.js \
+  tests/bookingWfaProjectionContract.test.js \
+  tests/resolveWfaBookingsJobIdempotency.test.js \
+  tests/openapiWfaPolicyContract.test.js
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Run full static and test verification**
+
+```bash
+npm run lint
+npm test
+npm run migrate:status
+git diff --check
+```
+
+Expected: all commands PASS. If an unrelated baseline test fails, capture the exact pre-existing failure and prove all INF-270 focused tests pass.
+
+- [ ] **Step 9: Run test-database migration verification**
+
+On a disposable MySQL database:
+
+```bash
+npm run migrate
+npm run migrate:status
+```
+
+Verify:
+
+```text
+wfa.request.radius_m exists with value 100
+both catalog tables contain defaults
+bookings has five new nullable fields
+legacy rejection_reason still exists
+existing booking rows remain readable
+```
+
+- [ ] **Step 10: Run authenticated API smoke verification**
+
+Capture request/response evidence for:
+
+```text
+GET /api/wfa/request-config
+PATCH /api/settings/operational with wfaRequestRadiusM
+GET/POST/PATCH request reasons
+GET/POST/PATCH rejection reasons
+POST /api/bookings normal reason
+POST /api/bookings Other reason
+POST /api/bookings with radius=9999 proving persisted radius uses settings
+PATCH approve
+PATCH reject normal reason
+PATCH reject Other with note
+negative auth and RBAC cases
+```
+
+Use disposable booking/catalog data and remove or deactivate smoke rows after verification.
+
+- [ ] **Step 11: Review sensitive-area impact**
+
+Confirm explicitly in PR notes:
+
+```text
+attendance final state unchanged
+auth/session middleware unchanged
+role semantics reused
+nightly resolver behavior unchanged
+WIB date behavior verified
+OpenAPI updated
+migration risk documented
+Android/Web rollout coordination documented
+```
+
+- [ ] **Step 12: Commit documentation and final test contract**
+
+```bash
+git add docs/openapi.yaml tests/openapiWfaPolicyContract.test.js
+git commit -m "docs: publish WFA policy API contract"
+```
+
+- [ ] **Step 13: Open the implementation PR**
+
+Open a PR from the implementation feature branch into `develop` with:
+
+```text
+Primary Linear issue: INF-270
+Architecture impact
+Database migration impact
+API contract changes
+Compatibility behavior
+Focused and full test output
+Migration evidence
+Authenticated smoke evidence
+Android INF-265 dependency note
+Web INF-271 dependency note
+```
+
+Do not mark INF-270 Done until runtime evidence and contract review are attached.
+
+---
+
+## Plan Self-Review
+
+### Spec coverage
+
+- Global radius through existing settings: Task 1 and Task 2 migration.
+- Typed request/rejection catalogs: Tasks 2–4.
+- Employee request config: Task 4.
+- Server-authoritative booking creation: Task 5.
+- Required Management rejection reason: Task 6.
+- Backward-compatible read projections: Task 7.
+- Nightly resolver preservation: Task 7.
+- OpenAPI, migration, tests, and smoke evidence: Task 8.
+
+### Type consistency
+
+The plan consistently uses:
+
+```text
+wfaRequestRadiusM ↔ wfa.request.radius_m
+request_reason_id ↔ WfaRequestReason
+rejection_reason_id ↔ WfaRejectionReason
+request_reason association alias
+rejection_reason_detail association alias
+radius_snapshot
+```
+
+### Scope boundary
+
+The plan does not include modular MVC migration, legacy table cleanup, reason hard deletion, Android/Web implementation, idempotency keys, or attendance/scheduler redesign.

--- a/docs/superpowers/specs/2026-07-28-inf-270-wfa-policy-and-reason-catalogs-design.md
+++ b/docs/superpowers/specs/2026-07-28-inf-270-wfa-policy-and-reason-catalogs-design.md
@@ -1,0 +1,716 @@
+# INF-270 Server-Authoritative WFA Policy and Reason Catalogs Design — 2026-07-28
+
+Branch: `docs/inf-270-wfa-policy-spec-plan`  
+Linear: `INF-270 — Backend: Add Global WFA Policy, Request Reasons, and Rejection Reasons`  
+Consumers: `INF-265` Android WFA Request Form, `INF-271` Management Web WFA Settings and Reject Flow  
+Design status: approved product direction, documented for implementation planning.
+
+## Goal
+
+Make the backend the final authority for the WFA request radius, allowed request reasons, allowed rejection reasons, and booking approval/rejection validation while preserving the repository's current layer-first architecture.
+
+The resulting backend contract must let Android:
+
+- load the global WFA radius and active request reasons;
+- submit a WFA request without sending an authoritative radius;
+- receive a backend-confirmed booking result;
+- map stable backend failure codes.
+
+It must also let Management Web:
+
+- update the global WFA radius through the existing operational settings endpoint;
+- manage request and rejection reason catalogs;
+- reject a booking only with an explicit active rejection reason.
+
+## Current repository facts
+
+- Backend stack is Node.js ESM, Express, Sequelize, and MySQL.
+- Business timezone is `Asia/Jakarta`.
+- `/api/bookings` is owned by `src/routes/booking.routes.js` and `src/controllers/booking.controller.js`.
+- `/api/wfa` is owned by `src/routes/wfa.routes.js`.
+- `/api/settings` is owned by `src/routes/settings.routes.js`, `src/controllers/settings.controller.js`, and `src/services/operationalSettings.service.js`.
+- The existing `settings` table is already the source for operational numeric/time configuration.
+- The existing operational settings contract is mapped in `src/utils/settings.js`.
+- `bookings` is the runtime source of truth for WFA requests and approvals.
+- The legacy `wfa_requests` model/table is not the active Android booking flow and is not migrated in this scope.
+- `booking.controller.js` currently owns date validation, duplicate checks, location creation, suitability calculation, booking creation, and status update.
+- `resolveWfaBookings.job.js` reads existing booking status/date/location fields and must continue working unchanged.
+- The current `bookings.rejection_reason` column is nullable and not part of the active reject contract.
+
+## Locked decisions
+
+1. Preserve the current architecture:
+
+   ```text
+   Route
+   → auth / role guard / validator
+   → Controller
+   → focused existing-layer service/helper
+   → Sequelize Model
+   → MySQL
+   ```
+
+2. Do not introduce `src/modules`, repository, adapter, policy, mapper, base-controller, or v2 API layers.
+3. Reuse the existing `settings` table and operational settings API for the global WFA radius.
+4. Do not create a separate `wfa_settings` table.
+5. Add typed relational catalogs for employee request reasons and management rejection reasons.
+6. Keep `bookings` as the WFA request source of truth.
+7. Do not use the legacy `wfa_requests` table for this flow.
+8. Android must not control radius, status, user identity, timestamps, or suitability.
+9. Use strict ISO `YYYY-MM-DD` for the canonical booking request date.
+10. Backend validation remains authoritative even when Android performs early validation.
+11. Used reasons are deactivated, never hard-deleted.
+12. Existing booking rows and the legacy `rejection_reason` column must not be destructively discarded.
+13. OpenAPI and contract tests are part of the change, not follow-up documentation.
+
+## Architecture
+
+### Request/config flow
+
+```text
+GET /api/wfa/request-config
+→ verifyToken
+→ wfa.routes.js
+→ wfaSettings.controller.js
+→ wfaSettings.service.js
+→ Settings + WfaRequestReason
+→ response projection
+```
+
+### Management settings flow
+
+```text
+GET/PATCH /api/settings/operational
+→ existing settings route/controller/service
+→ Settings
+```
+
+The WFA radius becomes another operational field; the existing settings architecture remains canonical.
+
+### Reason catalog flow
+
+```text
+/api/settings/wfa/request-reasons
+/api/settings/wfa/rejection-reasons
+→ verifyToken
+→ roleGuard(['Admin', 'Management'])
+→ focused validator
+→ wfaSettings.controller.js
+→ wfaSettings.service.js
+→ reason models
+```
+
+### Booking creation flow
+
+```text
+POST /api/bookings
+→ verifyToken
+→ createBookingValidation
+→ createBooking
+→ resolve WFA settings and active reason
+→ server-side date/duplicate/suitability validation
+→ Location + Booking transaction
+→ backend-confirmed response
+```
+
+### Approval/rejection flow
+
+```text
+PATCH /api/bookings/:id
+→ verifyToken
+→ roleGuard(['Admin', 'Management'])
+→ updateStatusValidation
+→ updateBookingStatus
+→ validate active rejection reason when rejected
+→ transaction
+→ backend-confirmed response
+```
+
+## File boundary decisions
+
+The repository remains layer-first, but new logic should not make existing controllers larger than necessary.
+
+Create focused files inside existing folders:
+
+```text
+src/controllers/wfaSettings.controller.js
+src/services/wfaSettings.service.js
+src/middlewares/wfaSettings.validator.js
+src/models/wfaRequestReason.model.js
+src/models/wfaRejectionReason.model.js
+```
+
+Responsibilities:
+
+- `wfaSettings.controller.js`: HTTP orchestration only.
+- `wfaSettings.service.js`: read global radius, build employee config, CRUD-lite catalog operations, active-reason resolution, and `is_other` invariant checks.
+- `wfaSettings.validator.js`: request body/path validation for catalog endpoints.
+- `booking.controller.js`: remains the only booking mutation controller, but delegates WFA setting/reason lookup to the focused service.
+- `operationalSettings.service.js`: remains the only mutation path for the global radius setting.
+
+No second booking implementation is introduced.
+
+## Data model
+
+### Existing `settings` table
+
+Add one row through a new migration:
+
+```text
+setting_key   = wfa.request.radius_m
+setting_value = 100
+```
+
+Expose it through the operational settings API as:
+
+```json
+{
+  "wfaRequestRadiusM": 100
+}
+```
+
+Update:
+
+```text
+OPERATIONAL_SETTING_KEYS
+OPERATIONAL_SETTING_DEFAULTS
+OPERATIONAL_SETTING_INTEGER_FIELDS
+```
+
+The value must be a positive integer. The server must fail with an explicit configuration error when strict runtime reads find the setting missing or invalid.
+
+### `wfa_request_reasons`
+
+```text
+id          INTEGER PK AUTO_INCREMENT
+label       VARCHAR(120) NOT NULL
+is_active   BOOLEAN NOT NULL DEFAULT true
+is_other    BOOLEAN NOT NULL DEFAULT false
+sort_order  INTEGER NOT NULL DEFAULT 0
+created_at  DATETIME NOT NULL
+updated_at  DATETIME NOT NULL
+```
+
+### `wfa_rejection_reasons`
+
+Use the same column contract as `wfa_request_reasons`.
+
+Catalog invariants:
+
+- trimmed label is required;
+- label length is at most 120 characters;
+- sort order is a non-negative integer;
+- only one active or inactive row per catalog may be marked `is_other = true`;
+- a used row cannot be hard-deleted;
+- PATCH may update `label`, `is_active`, and `sort_order`;
+- `is_other` is fixed after creation to avoid changing historical form semantics.
+
+### Seed defaults
+
+Request reasons:
+
+```text
+Pertemuan dengan klien
+Pekerjaan lapangan
+Perjalanan bisnis
+Lainnya (is_other=true)
+```
+
+Rejection reasons:
+
+```text
+Lokasi tidak memenuhi ketentuan
+Tanggal tidak dapat disetujui
+Alasan tidak sesuai kebijakan
+Data pengajuan belum lengkap
+Lainnya (is_other=true)
+```
+
+### `bookings` additions
+
+```text
+request_reason_id       INTEGER NULL FK → wfa_request_reasons.id
+request_other_reason    TEXT NULL
+rejection_reason_id     INTEGER NULL FK → wfa_rejection_reasons.id
+rejection_note          TEXT NULL
+radius_snapshot         INTEGER NULL
+```
+
+New booking mutations enforce the required fields in application logic. Columns remain nullable during this bounded migration so existing rows stay valid.
+
+Foreign-key delete behavior is `RESTRICT`. Catalogs use deactivation instead of deletion.
+
+The existing `rejection_reason` column remains untouched in this migration. New code must not write it. A later cleanup may remove or rename it only after production data verification proves that removal is safe.
+
+## API contracts
+
+### Employee configuration
+
+```http
+GET /api/wfa/request-config
+Authorization: Bearer <token>
+```
+
+Response:
+
+```json
+{
+  "success": true,
+  "data": {
+    "radius_meters": 100,
+    "reasons": [
+      {
+        "id": 1,
+        "label": "Pertemuan dengan klien",
+        "is_other": false,
+        "sort_order": 10
+      }
+    ]
+  }
+}
+```
+
+Rules:
+
+- authenticated user access;
+- only active request reasons are returned;
+- reasons are ordered by `sort_order ASC`, then `id ASC`;
+- no settings mutation metadata is exposed;
+- missing/invalid strict radius configuration returns `500 WFA_CONFIG_UNAVAILABLE`.
+
+### Operational radius
+
+Reuse the existing routes:
+
+```http
+GET   /api/settings/operational
+PATCH /api/settings/operational
+```
+
+PATCH example:
+
+```json
+{
+  "wfaRequestRadiusM": 150
+}
+```
+
+The existing Admin/Management authorization remains unchanged.
+
+### Request reason catalog
+
+```http
+GET   /api/settings/wfa/request-reasons
+POST  /api/settings/wfa/request-reasons
+PATCH /api/settings/wfa/request-reasons/:id
+```
+
+POST:
+
+```json
+{
+  "label": "Kunjungan operasional",
+  "is_other": false,
+  "sort_order": 30
+}
+```
+
+PATCH:
+
+```json
+{
+  "label": "Kunjungan lapangan",
+  "is_active": true,
+  "sort_order": 30
+}
+```
+
+GET returns active and inactive rows for management configuration.
+
+### Rejection reason catalog
+
+```http
+GET   /api/settings/wfa/rejection-reasons
+POST  /api/settings/wfa/rejection-reasons
+PATCH /api/settings/wfa/rejection-reasons/:id
+```
+
+Use the same CRUD-lite contract and invariants as request reasons.
+
+No DELETE route is added.
+
+## Booking creation contract
+
+```http
+POST /api/bookings
+```
+
+Canonical request:
+
+```json
+{
+  "schedule_date": "2026-08-10",
+  "request_reason_id": 1,
+  "request_other_reason": null,
+  "notes": "Pertemuan project",
+  "latitude": -0.9,
+  "longitude": 119.87,
+  "description": "Lokasi klien"
+}
+```
+
+Required:
+
+```text
+schedule_date
+request_reason_id
+latitude
+longitude
+```
+
+Conditional:
+
+```text
+request_other_reason required only when selected reason is Other
+```
+
+Optional:
+
+```text
+notes
+description
+location_id when supported by the validated current location contract
+```
+
+Client-authoritative fields:
+
+```text
+radius
+user_id
+status
+suitability_score
+suitability_label
+created_at
+approved_by
+processed_at
+```
+
+must not influence persisted business state.
+
+Compatibility behavior for the first backend rollout:
+
+- legacy clients may still include `radius`, `suitability_score`, or `suitability_label`;
+- the backend accepts but ignores them;
+- they are removed from the canonical OpenAPI request schema;
+- tests prove the persisted radius and suitability are server-resolved.
+
+Server behavior:
+
+1. parse only strict ISO `YYYY-MM-DD`;
+2. evaluate date rules using WIB business semantics;
+3. resolve user from `req.user.id`;
+4. load strict `wfaRequestRadiusM`;
+5. resolve the request reason and require it to be active;
+6. require trimmed Other text only for an `is_other` reason;
+7. reject Other text for non-Other reasons by normalizing it to null;
+8. preserve duplicate pending/approved booking rules;
+9. calculate suitability on the server;
+10. create or reuse the location using the server radius;
+11. create the booking as pending;
+12. persist request reason fields and `radius_snapshot` in the existing transaction;
+13. return backend-confirmed booking data.
+
+### Create response
+
+```json
+{
+  "success": true,
+  "message": "Booking WFA berhasil dibuat.",
+  "data": {
+    "booking_id": 1042,
+    "schedule_date": "2026-08-10",
+    "status": "pending",
+    "request_reason": {
+      "id": 1,
+      "label": "Pertemuan dengan klien",
+      "is_other": false,
+      "other_text": null
+    },
+    "location": {
+      "location_id": 81,
+      "latitude": -0.9,
+      "longitude": 119.87,
+      "radius": 100,
+      "description": "Lokasi klien"
+    },
+    "radius_snapshot": 100,
+    "suitability_score": 78.4,
+    "suitability_label": "Layak",
+    "created_at": "2026-07-28T10:30:00.000Z"
+  }
+}
+```
+
+## Approval and rejection contract
+
+```http
+PATCH /api/bookings/:id
+```
+
+Approval:
+
+```json
+{
+  "status": "approved"
+}
+```
+
+Rejection:
+
+```json
+{
+  "status": "rejected",
+  "rejection_reason_id": 2,
+  "rejection_note": "Lokasi berada di luar area operasional."
+}
+```
+
+Rules:
+
+- status must remain `approved` or `rejected`;
+- `rejection_reason_id` is required only for rejection;
+- rejection reason must exist and be active;
+- `rejection_note` is required and trimmed when the reason is Other;
+- non-Other rejection note is optional;
+- approval clears or leaves null all new rejection fields;
+- existing schedule-date guard, transaction, `approved_by`, and `processed_at` semantics remain intact;
+- automated expiry rejection in `resolveWfaBookings.job.js` is not forced to select a human catalog reason in this issue.
+
+System expiry rejection remains identifiable by:
+
+```text
+status = rejected
+approved_by = null
+rejection_reason_id = null
+```
+
+This keeps the nightly job behavior stable and distinguishes system rejection from Management rejection.
+
+## Read projection contract
+
+Booking create/list/history/detail/update projections must expose when available:
+
+```text
+request_reason { id, label, is_other, other_text }
+rejection_reason { id, label, is_other, note }
+radius_snapshot
+```
+
+Backward compatibility:
+
+- existing rows may have null reason fields;
+- existing rows may have null `radius_snapshot`;
+- read projection may fall back to `location.radius` for legacy rows only;
+- API must not fabricate a reason label for old rows.
+
+## Error contract
+
+Use stable top-level codes for WFA-specific failures while preserving the existing response envelope:
+
+```text
+INVALID_SCHEDULE_DATE
+WFA_CONFIG_UNAVAILABLE
+WFA_REQUEST_REASON_REQUIRED
+WFA_REQUEST_REASON_NOT_FOUND
+WFA_REQUEST_REASON_NOT_ACTIVE
+WFA_OTHER_REASON_REQUIRED
+DUPLICATE_BOOKING
+REJECTION_REASON_REQUIRED
+REJECTION_REASON_NOT_FOUND
+REJECTION_REASON_NOT_ACTIVE
+REJECTION_NOTE_REQUIRED
+WFA_REASON_CATALOG_CONFLICT
+```
+
+Recommended shape:
+
+```json
+{
+  "success": false,
+  "code": "WFA_REQUEST_REASON_NOT_ACTIVE",
+  "message": "Alasan WFA tidak lagi tersedia.",
+  "errors": [
+    {
+      "field": "request_reason_id",
+      "code": "WFA_REQUEST_REASON_NOT_ACTIVE"
+    }
+  ]
+}
+```
+
+Android and Management Web map `code`; they must not parse localized message text.
+
+## Migration and rollout
+
+### Migration order
+
+One new forward migration performs:
+
+1. insert `wfa.request.radius_m` when absent;
+2. create both catalog tables;
+3. seed default reason rows;
+4. add nullable booking columns;
+5. add indexes and foreign keys;
+6. leave legacy `rejection_reason` untouched.
+
+The migration must be idempotency-safe with explicit existence checks where the repository migration conventions support them.
+
+### Rollout order
+
+```text
+1. Backend migration and contract deployment
+2. Backend smoke verification
+3. Android INF-265 integration
+4. Management Web INF-271 integration
+```
+
+During the compatibility window, backend ignores legacy client radius/suitability inputs. Once supported clients are deployed, removal of compatibility input acceptance can be a separate contract-hardening issue.
+
+## Security and authorization
+
+- All routes require the existing stateful JWT session validation.
+- Employee config requires authentication only.
+- Settings and reason catalog management uses existing Admin/Management role guards.
+- Booking creation scopes identity to `req.user.id`.
+- Approval/rejection keeps existing Admin/Management authorization.
+- No endpoint accepts arbitrary employee `user_id` for normal booking creation.
+- No new token, cookie, session, or role convention is introduced.
+
+## Testing strategy
+
+Required focused tests:
+
+```text
+operational radius setting normalization and strict integrity
+migration/model/association contract
+employee request-config authentication and projection
+catalog list/create/update/deactivate and Other invariant
+booking ISO date contract
+server-authoritative radius and suitability
+active/inactive/Other request reason handling
+approve without rejection fields
+reject missing/inactive/Other reason handling
+read projection for new and legacy rows
+resolveWfaBookings job regression
+OpenAPI/runtime contract alignment
+```
+
+Required commands:
+
+```bash
+npm run lint
+npm test
+npm run migrate:status
+npm run test:integration  # when test DB is available
+git diff --check
+```
+
+Required runtime evidence on a disposable/test environment:
+
+```text
+GET /api/wfa/request-config
+PATCH /api/settings/operational
+request reason create/update/deactivate
+rejection reason create/update/deactivate
+POST /api/bookings with normal reason
+POST /api/bookings with Other
+POST /api/bookings proving client radius is ignored
+PATCH approve
+PATCH reject with normal reason
+PATCH reject with Other and note
+negative RBAC/auth cases
+```
+
+## Risks and mitigations
+
+### Existing clients send radius and ambiguous dates
+
+Mitigation:
+
+- accept but ignore radius/suitability during the compatibility window;
+- enforce ISO date with a stable error code;
+- coordinate deployment with Android INF-265.
+
+### Existing booking rows have no reason or snapshot
+
+Mitigation:
+
+- new columns are nullable;
+- projections remain null-safe;
+- radius fallback is limited to legacy reads.
+
+### Legacy `rejection_reason` contains unknown production values
+
+Mitigation:
+
+- do not drop or overwrite it;
+- add new `rejection_reason_id` separately;
+- require production data inspection before any cleanup issue.
+
+### Nightly resolver rejects expired pending bookings without a human reason
+
+Mitigation:
+
+- preserve current job semantics;
+- allow system rejections to keep `rejection_reason_id = null` and `approved_by = null`;
+- add regression tests proving the job remains idempotent.
+
+### Controller growth
+
+Mitigation:
+
+- use focused `wfaSettings.controller.js` and `wfaSettings.service.js` within the existing layer-first folders;
+- keep booking mutation in the existing booking controller;
+- do not introduce a parallel booking service architecture.
+
+## Out of scope
+
+```text
+INF-252 modular MVC migration
+src/modules extraction
+repository/adapter/policy/mapper layers
+radius per reason/user/division/location
+hard deletion of reason rows
+generic settings rewrite
+legacy wfa_requests cleanup
+legacy rejection_reason cleanup
+backend idempotency-key contract
+Management Web implementation
+Android UI implementation
+WFA history redesign
+attendance/geofence redesign
+scheduler behavior changes
+```
+
+## Acceptance criteria
+
+- [ ] Current layer-first architecture remains intact.
+- [ ] Existing `settings` table owns the global WFA radius.
+- [ ] Operational settings expose and update `wfaRequestRadiusM`.
+- [ ] Employee config returns radius and active request reasons.
+- [ ] Both reason catalogs support list/create/update/deactivate.
+- [ ] Used reasons are not hard-deleted.
+- [ ] Booking creation uses strict ISO date and authenticated user identity.
+- [ ] Client radius and suitability do not control persisted values.
+- [ ] Request reason and conditional Other text are validated and persisted.
+- [ ] New locations use the server radius.
+- [ ] Booking stores `radius_snapshot`.
+- [ ] Management rejection requires an active rejection reason.
+- [ ] Other rejection requires a note.
+- [ ] Approval remains valid without rejection fields.
+- [ ] Automated expiry rejection remains stable.
+- [ ] New and legacy booking projections are null-safe.
+- [ ] Legacy `rejection_reason` data is not discarded.
+- [ ] Stable error codes support typed Android/Web mapping.
+- [ ] OpenAPI matches runtime behavior.
+- [ ] Lint, tests, migration checks, and authenticated smoke evidence are attached before completion.

--- a/src/controllers/booking.controller.js
+++ b/src/controllers/booking.controller.js
@@ -9,7 +9,8 @@ import logger from '../utils/logger.js';
 import { getJakartaDateString } from '../utils/geofence.js';
 import {
   readWfaRequestConfig,
-  resolveActiveWfaRequestReason
+  resolveActiveWfaRequestReason,
+  resolveActiveWfaRejectionReason
 } from '../services/wfaSettings.service.js';
 
 const BOOKING_STATUS = Object.freeze({
@@ -345,7 +346,7 @@ export const updateBookingStatus = async (req, res, next) => {
 
   try {
     const { id } = req.params;
-    const { status } = req.body;
+    const { status, rejection_reason_id, rejection_note } = req.body;
     const approvedBy = req.user.id;
 
     // Validasi: cari booking
@@ -395,18 +396,34 @@ export const updateBookingStatus = async (req, res, next) => {
       });
     }
 
-    // Konversi status text ke ID
-    const statusId = status === 'approved' ? 1 : 2;
+    let rejectionDecision = { reason: null, normalizedNote: null };
+    if (status === 'rejected') {
+      rejectionDecision = await resolveActiveWfaRejectionReason({
+        reasonId: rejection_reason_id,
+        note: rejection_note,
+        transaction
+      });
+    }
+
+    const decisionPayload =
+      status === 'approved'
+        ? {
+            status: 1,
+            rejection_reason_id: null,
+            rejection_note: null,
+            approved_by: approvedBy,
+            processed_at: new Date()
+          }
+        : {
+            status: 2,
+            rejection_reason_id: rejectionDecision.reason.id,
+            rejection_note: rejectionDecision.normalizedNote,
+            approved_by: approvedBy,
+            processed_at: new Date()
+          };
 
     // Update record booking
-    await booking.update(
-      {
-        status: statusId,
-        approved_by: approvedBy,
-        processed_at: new Date()
-      },
-      { transaction }
-    );
+    await booking.update(decisionPayload, { transaction });
 
     await transaction.commit();
 
@@ -448,6 +465,15 @@ export const updateBookingStatus = async (req, res, next) => {
           radius: updatedBooking.location.radius,
           description: updatedBooking.location.description
         },
+        rejection_reason:
+          status === 'rejected'
+            ? {
+                id: rejectionDecision.reason.id,
+                label: rejectionDecision.reason.label,
+                is_other: Boolean(rejectionDecision.reason.is_other),
+                note: rejectionDecision.normalizedNote
+              }
+            : null,
         processed_at: updatedBooking.processed_at
       }
     });

--- a/src/controllers/booking.controller.js
+++ b/src/controllers/booking.controller.js
@@ -1,5 +1,5 @@
 import { Op } from 'sequelize';
-import { isValid, parseISO, parse } from 'date-fns';
+import { isValid, parseISO } from 'date-fns';
 import axios from 'axios';
 
 import sequelize from '../config/database.js';
@@ -7,6 +7,10 @@ import { Booking, Location, BookingStatus, User, Position, Role } from '../model
 import fuzzyEngine from '../utils/fuzzyAhpEngine.js';
 import logger from '../utils/logger.js';
 import { getJakartaDateString } from '../utils/geofence.js';
+import {
+  readWfaRequestConfig,
+  resolveActiveWfaRequestReason
+} from '../services/wfaSettings.service.js';
 
 const BOOKING_STATUS = Object.freeze({
   approved: { id: 1, label: 'Approved' },
@@ -145,63 +149,40 @@ export const createBooking = async (req, res, next) => {
     const userId = req.user.id;
     const {
       schedule_date,
+      request_reason_id,
+      request_other_reason,
       latitude,
       longitude,
-      radius = 100,
       description,
       notes = '',
-      suitability_score: provided_score,
-      suitability_label: provided_label,
       location_id
     } = req.body;
-    // A) Normalisasi & Sanitasi schedule_date (ISO YYYY-MM-DD only)
-    const errors = [];
     const isoPattern = /^\d{4}-\d{2}-\d{2}$/;
-    const mdyPattern = /^\d{2}-\d{2}-\d{4}$/; // MM-DD-YYYY
-    let scheduleDateISO = null;
-    let scheduleDateObj = null;
-    if (!schedule_date || typeof schedule_date !== 'string') {
-      errors.push({
-        field: 'schedule_date',
-        code: 'INVALID_DATE_FORMAT',
-        message: "schedule_date harus berformat 'YYYY-MM-DD' atau 'MM-DD-YYYY' yang valid."
-      });
-    } else if (isoPattern.test(schedule_date)) {
-      scheduleDateISO = schedule_date;
-      scheduleDateObj = parseISO(`${scheduleDateISO}T00:00:00Z`);
-      if (!isValid(scheduleDateObj)) {
-        errors.push({
-          field: 'schedule_date',
-          code: 'INVALID_DATE_VALUE',
-          message: 'schedule_date tidak valid.'
-        });
-      }
-    } else if (mdyPattern.test(schedule_date)) {
-      // Parse MM-DD-YYYY strictly and normalize to ISO YYYY-MM-DD
-      const parsed = parse(schedule_date, 'MM-dd-yyyy', new Date());
-      if (!isValid(parsed)) {
-        errors.push({
-          field: 'schedule_date',
-          code: 'INVALID_DATE_VALUE',
-          message: 'schedule_date tidak valid.'
-        });
-      } else {
-        const y = parsed.getFullYear();
-        const m = String(parsed.getMonth() + 1).padStart(2, '0');
-        const d = String(parsed.getDate()).padStart(2, '0');
-        scheduleDateISO = `${y}-${m}-${d}`;
-        scheduleDateObj = parseISO(`${scheduleDateISO}T00:00:00Z`);
-      }
-    } else {
-      errors.push({
-        field: 'schedule_date',
-        code: 'INVALID_DATE_FORMAT',
-        message: "schedule_date harus berformat 'YYYY-MM-DD' atau 'MM-DD-YYYY' yang valid."
+    const isStrictCalendarDate = (value) => {
+      if (typeof value !== 'string' || !isoPattern.test(value)) return false;
+      const [year, month, day] = value.split('-').map(Number);
+      const parsed = new Date(Date.UTC(year, month - 1, day));
+      return (
+        parsed.getUTCFullYear() === year &&
+        parsed.getUTCMonth() === month - 1 &&
+        parsed.getUTCDate() === day
+      );
+    };
+
+    if (!isStrictCalendarDate(schedule_date)) {
+      await transaction.rollback();
+      return res.status(400).json({
+        success: false,
+        code: 'INVALID_SCHEDULE_DATE',
+        message: 'Tanggal WFA harus menggunakan format YYYY-MM-DD.',
+        errors: [{ field: 'schedule_date', code: 'INVALID_SCHEDULE_DATE' }]
       });
     }
 
     // Build today (Jakarta) string for comparisons
     const todayIso = getJakartaDateString();
+    const scheduleDateISO = schedule_date;
+    const errors = [];
 
     // B) Aturan Bisnis
     if (errors.length === 0) {
@@ -235,6 +216,13 @@ export const createBooking = async (req, res, next) => {
     // No hour-based H-1: next-day (scheduleDateISO > todayIso) is acceptable
 
     const formattedScheduleDate = scheduleDateISO;
+    const { radiusMeters } = await readWfaRequestConfig(transaction);
+    const { reason, normalizedOtherReason } = await resolveActiveWfaRequestReason({
+      reasonId: request_reason_id,
+      otherReasonText: request_other_reason,
+      transaction
+    });
+
     // Cek booking conflict pada tanggal yang sama (pending/approved)
     const existingBookingOnDate = await Booking.findOne({
       where: {
@@ -249,6 +237,7 @@ export const createBooking = async (req, res, next) => {
       await transaction.rollback();
       return res.status(409).json({
         success: false,
+        code: 'DUPLICATE_BOOKING',
         message: 'Validasi booking gagal.',
         errors: [
           {
@@ -260,26 +249,11 @@ export const createBooking = async (req, res, next) => {
       });
     }
 
-    // Langkah Tambahan: Hitung atau gunakan Suitability Score yang ada
-    let suitability_score;
-    let suitability_label;
-
-    if (provided_score && provided_label) {
-      // Gunakan skor dari rekomendasi jika tersedia
-      suitability_score = provided_score;
-      suitability_label = provided_label;
-      logger.info(
-        `Using provided suitability score: ${suitability_score} (${suitability_label}) for user ${userId}`
-      );
-    } else {
-      // Hitung skor untuk lokasi kustom (manual)
-      const scoreResult = await getSuitabilityScoreForCustomLocation(latitude, longitude);
-      suitability_score = scoreResult.suitability_score;
-      suitability_label = scoreResult.suitability_label;
-      logger.info(
-        `Calculated suitability score for custom location: ${suitability_score} (${suitability_label}) for user ${userId}`
-      );
-    }
+    const scoreResult = await getSuitabilityScoreForCustomLocation(latitude, longitude);
+    const { suitability_score, suitability_label } = scoreResult;
+    logger.info(
+      `Calculated suitability score for custom location: ${suitability_score} (${suitability_label}) for user ${userId}`
+    );
 
     // Proses Database: validasi lokasi (by id) atau buat baru dari koordinat (tanpa kebijakan jarak)
     let newLocation;
@@ -307,7 +281,7 @@ export const createBooking = async (req, res, next) => {
           id_attendance_categories: 3, // WFA category
           latitude: parseFloat(latitude),
           longitude: parseFloat(longitude),
-          radius: parseFloat(radius),
+          radius: radiusMeters,
           description: description || 'WFA Location'
         },
         { transaction }
@@ -319,10 +293,13 @@ export const createBooking = async (req, res, next) => {
         user_id: userId,
         schedule_date: formattedScheduleDate, // YYYY-MM-DD format
         location_id: newLocation.location_id,
-        notes: notes,
+        notes: typeof notes === 'string' ? notes.trim() : '',
         status: 3, // pending
-        suitability_score, // Simpan skor
-        suitability_label, // Simpan label
+        suitability_score,
+        suitability_label,
+        request_reason_id: reason.id,
+        request_other_reason: normalizedOtherReason,
+        radius_snapshot: radiusMeters,
         created_at: new Date()
       },
       { transaction }
@@ -330,17 +307,30 @@ export const createBooking = async (req, res, next) => {
 
     await transaction.commit();
 
-    // Respons Sukses
-    res.status(201).json({
+    return res.status(201).json({
       success: true,
-      message: 'Booking WFA berhasil diajukan dan menunggu persetujuan.',
+      message: 'Booking WFA berhasil dibuat.',
       data: {
         booking_id: newBooking.booking_id,
         schedule_date: newBooking.schedule_date,
-        location_id: newBooking.location_id,
         status: 'pending',
-        suitability_score: newBooking.suitability_score,
-        suitability_label: newBooking.suitability_label
+        request_reason: {
+          id: reason.id,
+          label: reason.label,
+          is_other: Boolean(reason.is_other),
+          other_text: normalizedOtherReason
+        },
+        location: {
+          location_id: newLocation.location_id,
+          latitude: Number(newLocation.latitude ?? latitude),
+          longitude: Number(newLocation.longitude ?? longitude),
+          radius: radiusMeters,
+          description: newLocation.description ?? description ?? null
+        },
+        radius_snapshot: radiusMeters,
+        suitability_score,
+        suitability_label,
+        created_at: newBooking.created_at
       }
     });
   } catch (error) {

--- a/src/controllers/booking.controller.js
+++ b/src/controllers/booking.controller.js
@@ -3,7 +3,16 @@ import { isValid, parseISO } from 'date-fns';
 import axios from 'axios';
 
 import sequelize from '../config/database.js';
-import { Booking, Location, BookingStatus, User, Position, Role } from '../models/index.js';
+import {
+  Booking,
+  Location,
+  BookingStatus,
+  User,
+  Position,
+  Role,
+  WfaRequestReason,
+  WfaRejectionReason
+} from '../models/index.js';
 import fuzzyEngine from '../utils/fuzzyAhpEngine.js';
 import logger from '../utils/logger.js';
 import { getJakartaDateString } from '../utils/geofence.js';
@@ -31,6 +40,44 @@ const BOOKING_HISTORY_STATUS_FILTERS = Object.freeze({
   approved: BOOKING_STATUS.approved.id,
   rejected: BOOKING_STATUS.rejected.id,
   pending: BOOKING_STATUS.pending.id
+});
+
+const buildWfaReasonIncludes = () => [
+  {
+    model: WfaRequestReason,
+    as: 'request_reason',
+    attributes: ['id', 'label', 'is_other']
+  },
+  {
+    model: WfaRejectionReason,
+    as: 'rejection_reason_detail',
+    attributes: ['id', 'label', 'is_other']
+  }
+];
+
+const projectWfaReasonData = (booking) => ({
+  request_reason: booking.request_reason
+    ? {
+        id: booking.request_reason.id,
+        label: booking.request_reason.label,
+        is_other: Boolean(booking.request_reason.is_other),
+        other_text: booking.request_other_reason || null
+      }
+    : null,
+  rejection_reason: booking.rejection_reason_detail
+    ? {
+        id: booking.rejection_reason_detail.id,
+        label: booking.rejection_reason_detail.label,
+        is_other: Boolean(booking.rejection_reason_detail.is_other),
+        note: booking.rejection_note || null
+      }
+    : null,
+  radius_snapshot:
+    booking.radius_snapshot != null
+      ? Number(booking.radius_snapshot)
+      : booking.location?.radius != null
+        ? Number(booking.location.radius)
+        : null
 });
 
 function getBookingStatusPresentation(booking) {
@@ -360,7 +407,8 @@ export const updateBookingStatus = async (req, res, next) => {
         {
           model: Location,
           as: 'location'
-        }
+        },
+        ...buildWfaReasonIncludes()
       ],
       transaction
     });
@@ -443,7 +491,8 @@ export const updateBookingStatus = async (req, res, next) => {
           model: BookingStatus,
           as: 'booking_status',
           attributes: ['name_status']
-        }
+        },
+        ...buildWfaReasonIncludes()
       ]
     });
 
@@ -465,6 +514,7 @@ export const updateBookingStatus = async (req, res, next) => {
           radius: updatedBooking.location.radius,
           description: updatedBooking.location.description
         },
+        ...projectWfaReasonData(updatedBooking),
         rejection_reason:
           status === 'rejected'
             ? {
@@ -630,7 +680,8 @@ export const getAllBookings = async (req, res, next) => {
           model: BookingStatus,
           as: 'booking_status',
           attributes: ['name_status']
-        }
+        },
+        ...buildWfaReasonIncludes()
       ],
       order: [
         // Urutan kustom untuk status: 3 (pending), 1 (approved), 2 (rejected)
@@ -664,7 +715,8 @@ export const getAllBookings = async (req, res, next) => {
       suitability_label: booking.suitability_label,
       created_at: booking.created_at,
       processed_at: booking.processed_at,
-      approved_by: booking.approved_by
+      approved_by: booking.approved_by,
+      ...projectWfaReasonData(booking)
     }));
 
     // Response dengan struktur data yang flattened
@@ -720,7 +772,8 @@ export const getMyBookings = async (req, res, next) => {
           model: BookingStatus,
           as: 'booking_status',
           attributes: ['name_status']
-        }
+        },
+        ...buildWfaReasonIncludes()
       ],
       order: [['created_at', 'DESC']],
       limit: parseInt(limit),
@@ -748,7 +801,8 @@ export const getMyBookings = async (req, res, next) => {
       suitability_label: booking.suitability_label,
       created_at: booking.created_at,
       processed_at: booking.processed_at,
-      approved_by: booking.approved_by
+      approved_by: booking.approved_by,
+      ...projectWfaReasonData(booking)
     }));
 
     res.status(200).json({
@@ -919,7 +973,8 @@ export const getBookingHistory = async (req, res, next) => {
           model: BookingStatus,
           as: 'booking_status',
           attributes: ['name_status']
-        }
+        },
+        ...buildWfaReasonIncludes()
       ],
       order: orderClause,
       limit: limitNum,
@@ -955,7 +1010,8 @@ export const getBookingHistory = async (req, res, next) => {
         suitability_label: booking.suitability_label,
         created_at: booking.created_at,
         processed_at: booking.processed_at,
-        approved_by: booking.approved_by
+        approved_by: booking.approved_by,
+        ...projectWfaReasonData(booking)
       };
     });
 

--- a/src/controllers/wfaSettings.controller.js
+++ b/src/controllers/wfaSettings.controller.js
@@ -1,0 +1,83 @@
+import {
+  createWfaReason,
+  listWfaReasons,
+  readWfaRequestConfig,
+  updateWfaReason
+} from '../services/wfaSettings.service.js';
+
+const projectReason = (reason) => ({
+  id: reason.id,
+  label: reason.label,
+  is_active: Boolean(reason.is_active),
+  is_other: Boolean(reason.is_other),
+  sort_order: reason.sort_order,
+  created_at: reason.created_at,
+  updated_at: reason.updated_at
+});
+
+export const getWfaRequestConfig = async (_req, res, next) => {
+  try {
+    const config = await readWfaRequestConfig();
+    return res.status(200).json({
+      success: true,
+      data: {
+        radius_meters: config.radiusMeters,
+        reasons: config.reasons.map((reason) => ({
+          id: reason.id,
+          label: reason.label,
+          is_other: reason.isOther,
+          sort_order: reason.sortOrder
+        }))
+      }
+    });
+  } catch (error) {
+    return next(error);
+  }
+};
+
+const createListController = (catalog) => async (_req, res, next) => {
+  try {
+    const reasons = await listWfaReasons({ catalog, includeInactive: true });
+    return res.status(200).json({
+      success: true,
+      data: { reasons: reasons.map(projectReason) }
+    });
+  } catch (error) {
+    return next(error);
+  }
+};
+
+const createCreateController = (catalog) => async (req, res, next) => {
+  try {
+    const reason = await createWfaReason({ catalog, payload: req.body });
+    return res.status(201).json({
+      success: true,
+      data: { reason: projectReason(reason) }
+    });
+  } catch (error) {
+    return next(error);
+  }
+};
+
+const createUpdateController = (catalog) => async (req, res, next) => {
+  try {
+    const reason = await updateWfaReason({
+      catalog,
+      id: req.params.id,
+      payload: req.body
+    });
+    return res.status(200).json({
+      success: true,
+      data: { reason: projectReason(reason) }
+    });
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const listWfaRequestReasons = createListController('request');
+export const createWfaRequestReason = createCreateController('request');
+export const updateWfaRequestReason = createUpdateController('request');
+export const listWfaRejectionReasons = createListController('rejection');
+export const createWfaRejectionReason = createCreateController('rejection');
+export const updateWfaRejectionReason = createUpdateController('rejection');

--- a/src/middlewares/errorHandler.js
+++ b/src/middlewares/errorHandler.js
@@ -5,7 +5,8 @@ import { toErrorResponse } from '../shared/http/toErrorResponse.js';
 
 const PUBLIC_ERROR_CODES = new Set([
   'E_OPERATIONAL_SETTINGS_INVALID',
-  'E_INVALID_REFERENCE_STATE'
+  'E_INVALID_REFERENCE_STATE',
+  'WFA_CONFIG_UNAVAILABLE'
 ]);
 
 export const errorHandler = (err, req, res, _next) => {

--- a/src/middlewares/validator.js
+++ b/src/middlewares/validator.js
@@ -598,7 +598,28 @@ export const updateStatusValidation = [
     .notEmpty()
     .withMessage('Status wajib diisi')
     .isIn(['approved', 'rejected'])
-    .withMessage('Status harus "approved" atau "rejected"')
+    .withMessage('Status harus "approved" atau "rejected"'),
+  body('rejection_reason_id')
+    .if(body('status').equals('rejected'))
+    .exists({ values: 'falsy' })
+    .withMessage({
+      code: 'REJECTION_REASON_REQUIRED',
+      message: 'rejection_reason_id wajib diisi untuk penolakan'
+    })
+    .bail()
+    .isInt({ min: 1 })
+    .withMessage({
+      code: 'REJECTION_REASON_REQUIRED',
+      message: 'rejection_reason_id wajib berupa integer positif'
+    })
+    .toInt(),
+  body('rejection_note')
+    .optional({ nullable: true })
+    .isString()
+    .withMessage('rejection_note harus berupa string')
+    .trim()
+    .isLength({ max: 500 })
+    .withMessage('rejection_note maksimal 500 karakter')
 ];
 
 export const disciplineFahpValidation = [

--- a/src/middlewares/validator.js
+++ b/src/middlewares/validator.js
@@ -208,11 +208,30 @@ export const validateLogin = [
 export const validate = (req, res, next) => {
   const errors = validationResult(req);
   if (!errors.isEmpty()) {
+    const rawErrors = errors.array();
+    const normalizedErrors = rawErrors.map((error) => {
+      if (!error.msg || typeof error.msg !== 'object') {
+        return error;
+      }
+
+      return {
+        ...error,
+        msg: error.msg.message,
+        code: error.msg.code
+      };
+    });
+    const typedCode =
+      rawErrors[0].msg && typeof rawErrors[0].msg === 'object' ? rawErrors[0].msg.code : null;
+    const message =
+      rawErrors[0].msg && typeof rawErrors[0].msg === 'object'
+        ? rawErrors[0].msg.message
+        : rawErrors[0].msg;
+
     return res.status(400).json({
       success: false,
-      code: 'E_VALIDATION',
-      message: errors.array()[0].msg,
-      errors: errors.array()
+      code: typedCode || 'E_VALIDATION',
+      message,
+      errors: normalizedErrors
     });
   }
   next();
@@ -488,7 +507,60 @@ export const checkInValidation = [
 
 // Booking validation rules
 export const createBookingValidation = [
-  body('schedule_date').notEmpty().withMessage('Tanggal jadwal wajib diisi'),
+  body('schedule_date')
+    .exists({ values: 'falsy' })
+    .withMessage({
+      code: 'INVALID_SCHEDULE_DATE',
+      message: 'schedule_date wajib menggunakan format YYYY-MM-DD'
+    })
+    .bail()
+    .isString()
+    .withMessage({
+      code: 'INVALID_SCHEDULE_DATE',
+      message: 'schedule_date wajib menggunakan format YYYY-MM-DD'
+    })
+    .bail()
+    .matches(/^\d{4}-\d{2}-\d{2}$/)
+    .withMessage({
+      code: 'INVALID_SCHEDULE_DATE',
+      message: 'schedule_date wajib menggunakan format YYYY-MM-DD'
+    })
+    .bail()
+    .custom((value) => {
+      const [year, month, day] = value.split('-').map(Number);
+      const parsed = new Date(Date.UTC(year, month - 1, day));
+      return (
+        parsed.getUTCFullYear() === year &&
+        parsed.getUTCMonth() === month - 1 &&
+        parsed.getUTCDate() === day
+      );
+    })
+    .withMessage({
+      code: 'INVALID_SCHEDULE_DATE',
+      message: 'schedule_date tidak merepresentasikan tanggal kalender yang valid'
+    }),
+
+  body('request_reason_id')
+    .exists({ values: 'falsy' })
+    .withMessage({
+      code: 'WFA_REQUEST_REASON_REQUIRED',
+      message: 'request_reason_id wajib diisi'
+    })
+    .bail()
+    .isInt({ min: 1 })
+    .withMessage({
+      code: 'WFA_REQUEST_REASON_REQUIRED',
+      message: 'request_reason_id wajib berupa integer positif'
+    })
+    .toInt(),
+
+  body('request_other_reason')
+    .optional({ nullable: true })
+    .isString()
+    .withMessage('request_other_reason harus berupa string')
+    .trim()
+    .isLength({ max: 500 })
+    .withMessage('request_other_reason maksimal 500 karakter'),
 
   body('latitude')
     .notEmpty()
@@ -505,12 +577,6 @@ export const createBookingValidation = [
     .withMessage('Longitude tidak valid')
     .custom((value) => parseFloat(value) !== 0)
     .withMessage('Longitude tidak boleh 0'),
-
-  body('radius')
-    .optional()
-    .default(100)
-    .isFloat({ gt: 0 })
-    .withMessage('Radius harus lebih besar dari 0'),
 
   body('description')
     .optional()

--- a/src/middlewares/wfaSettings.validator.js
+++ b/src/middlewares/wfaSettings.validator.js
@@ -1,0 +1,61 @@
+import { body, param } from 'express-validator';
+
+const mutableReasonFields = ['label', 'is_active', 'sort_order'];
+
+export const createWfaReasonValidation = [
+  body('label')
+    .exists({ values: 'falsy' })
+    .withMessage('label wajib diisi')
+    .bail()
+    .isString()
+    .withMessage('label harus berupa string')
+    .bail()
+    .trim()
+    .isLength({ min: 1, max: 120 })
+    .withMessage('label wajib diisi dan maksimal 120 karakter'),
+  body('is_active').optional().isBoolean().withMessage('is_active harus boolean'),
+  body('is_other').optional().isBoolean().withMessage('is_other harus boolean'),
+  body('sort_order')
+    .optional()
+    .isInt({ min: 0 })
+    .withMessage('sort_order harus bilangan bulat non-negatif')
+    .toInt()
+];
+
+export const updateWfaReasonValidation = [
+  body().custom((value) => {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      throw new Error('Body harus berupa object');
+    }
+    if (Object.hasOwn(value, 'is_other')) {
+      throw new Error('is_other tidak dapat diubah setelah alasan dibuat');
+    }
+
+    const unknownField = Object.keys(value).find((field) => !mutableReasonFields.includes(field));
+    if (unknownField) {
+      throw new Error(`Field ${unknownField} tidak didukung`);
+    }
+    if (!mutableReasonFields.some((field) => Object.hasOwn(value, field))) {
+      throw new Error('Minimal satu field perubahan wajib diisi');
+    }
+    return true;
+  }),
+  body('label')
+    .optional()
+    .isString()
+    .withMessage('label harus berupa string')
+    .bail()
+    .trim()
+    .isLength({ min: 1, max: 120 })
+    .withMessage('label wajib diisi dan maksimal 120 karakter'),
+  body('is_active').optional().isBoolean().withMessage('is_active harus boolean'),
+  body('sort_order')
+    .optional()
+    .isInt({ min: 0 })
+    .withMessage('sort_order harus bilangan bulat non-negatif')
+    .toInt()
+];
+
+export const wfaReasonIdValidation = [
+  param('id').isInt({ min: 1 }).withMessage('id alasan tidak valid').toInt()
+];

--- a/src/models/booking.model.js
+++ b/src/models/booking.model.js
@@ -66,6 +66,34 @@ const Booking = sequelize.define(
       type: DataTypes.STRING(50),
       allowNull: true
     },
+    request_reason_id: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      references: {
+        model: 'wfa_request_reasons',
+        key: 'id'
+      }
+    },
+    request_other_reason: {
+      type: DataTypes.TEXT,
+      allowNull: true
+    },
+    rejection_reason_id: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      references: {
+        model: 'wfa_rejection_reasons',
+        key: 'id'
+      }
+    },
+    rejection_note: {
+      type: DataTypes.TEXT,
+      allowNull: true
+    },
+    radius_snapshot: {
+      type: DataTypes.INTEGER,
+      allowNull: true
+    },
     rejection_reason: {
       type: DataTypes.INTEGER,
       allowNull: true

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -18,6 +18,8 @@ import Booking from './booking.model.js';
 import BookingStatus from './bookingStatus.model.js';
 import LocationEvent from './locationEvent.model.js';
 import AuthSession from './authSession.model.js';
+import WfaRequestReason from './wfaRequestReason.model.js';
+import WfaRejectionReason from './wfaRejectionReason.model.js';
 
 // Jalankan relasi SETELAH define semua model
 User.belongsTo(Role, { foreignKey: 'id_roles', as: 'role' });
@@ -114,6 +116,22 @@ Booking.hasMany(Attendance, {
   foreignKey: 'booking_id',
   as: 'attendances'
 });
+Booking.belongsTo(WfaRequestReason, {
+  foreignKey: 'request_reason_id',
+  as: 'request_reason'
+});
+Booking.belongsTo(WfaRejectionReason, {
+  foreignKey: 'rejection_reason_id',
+  as: 'rejection_reason_detail'
+});
+WfaRequestReason.hasMany(Booking, {
+  foreignKey: 'request_reason_id',
+  as: 'bookings'
+});
+WfaRejectionReason.hasMany(Booking, {
+  foreignKey: 'rejection_reason_id',
+  as: 'bookings'
+});
 
 // BookingStatus relations
 BookingStatus.hasMany(Booking, {
@@ -139,5 +157,7 @@ export {
   Booking,
   BookingStatus,
   LocationEvent,
-  AuthSession
+  AuthSession,
+  WfaRequestReason,
+  WfaRejectionReason
 };

--- a/src/models/migrations/20260728010000-add-wfa-request-policy.cjs
+++ b/src/models/migrations/20260728010000-add-wfa-request-policy.cjs
@@ -1,0 +1,185 @@
+'use strict';
+
+const REQUEST_REASON_TABLE = 'wfa_request_reasons';
+const REJECTION_REASON_TABLE = 'wfa_rejection_reasons';
+const BOOKINGS_TABLE = 'bookings';
+const RADIUS_SETTING_KEY = 'wfa.request.radius_m';
+const RADIUS_SETTING_DESCRIPTION = '[INF-270] Global radius in meters for WFA booking requests.';
+
+const REQUEST_REASONS = [
+  ['Pertemuan dengan klien', true, false, 10],
+  ['Pekerjaan lapangan', true, false, 20],
+  ['Perjalanan bisnis', true, false, 30],
+  ['Lainnya', true, true, 999]
+];
+
+const REJECTION_REASONS = [
+  ['Lokasi tidak memenuhi ketentuan', true, false, 10],
+  ['Tanggal tidak dapat disetujui', true, false, 20],
+  ['Alasan tidak sesuai kebijakan', true, false, 30],
+  ['Data pengajuan belum lengkap', true, false, 40],
+  ['Lainnya', true, true, 999]
+];
+
+const reasonColumns = (Sequelize) => ({
+  id: {
+    type: Sequelize.INTEGER,
+    allowNull: false,
+    autoIncrement: true,
+    primaryKey: true
+  },
+  label: { type: Sequelize.STRING(120), allowNull: false },
+  is_active: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: true },
+  is_other: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: false },
+  sort_order: { type: Sequelize.INTEGER, allowNull: false, defaultValue: 0 },
+  created_at: { type: Sequelize.DATE, allowNull: false },
+  updated_at: { type: Sequelize.DATE, allowNull: false }
+});
+
+const reasonRows = (rows, timestamp) =>
+  rows.map(([label, is_active, is_other, sort_order]) => ({
+    label,
+    is_active,
+    is_other,
+    sort_order,
+    created_at: timestamp,
+    updated_at: timestamp
+  }));
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      const [existingSettings] = await queryInterface.sequelize.query(
+        'SELECT setting_key FROM settings WHERE setting_key = :settingKey',
+        { replacements: { settingKey: RADIUS_SETTING_KEY }, transaction }
+      );
+      const now = new Date();
+
+      if (existingSettings.length === 0) {
+        await queryInterface.bulkInsert(
+          'settings',
+          [
+            {
+              setting_key: RADIUS_SETTING_KEY,
+              setting_value: '100',
+              description: RADIUS_SETTING_DESCRIPTION,
+              updated_at: now
+            }
+          ],
+          { transaction }
+        );
+      }
+
+      await queryInterface.createTable(REQUEST_REASON_TABLE, reasonColumns(Sequelize), {
+        transaction
+      });
+      await queryInterface.createTable(REJECTION_REASON_TABLE, reasonColumns(Sequelize), {
+        transaction
+      });
+      await queryInterface.bulkInsert(REQUEST_REASON_TABLE, reasonRows(REQUEST_REASONS, now), {
+        transaction
+      });
+      await queryInterface.bulkInsert(
+        REJECTION_REASON_TABLE,
+        reasonRows(REJECTION_REASONS, now),
+        { transaction }
+      );
+
+      await queryInterface.addColumn(
+        BOOKINGS_TABLE,
+        'request_reason_id',
+        { type: Sequelize.INTEGER, allowNull: true },
+        { transaction }
+      );
+      await queryInterface.addColumn(
+        BOOKINGS_TABLE,
+        'request_other_reason',
+        { type: Sequelize.TEXT, allowNull: true },
+        { transaction }
+      );
+      await queryInterface.addColumn(
+        BOOKINGS_TABLE,
+        'rejection_reason_id',
+        { type: Sequelize.INTEGER, allowNull: true },
+        { transaction }
+      );
+      await queryInterface.addColumn(
+        BOOKINGS_TABLE,
+        'rejection_note',
+        { type: Sequelize.TEXT, allowNull: true },
+        { transaction }
+      );
+      await queryInterface.addColumn(
+        BOOKINGS_TABLE,
+        'radius_snapshot',
+        { type: Sequelize.INTEGER, allowNull: true },
+        { transaction }
+      );
+
+      await queryInterface.addIndex(BOOKINGS_TABLE, ['request_reason_id'], {
+        name: 'idx_bookings_request_reason_id',
+        transaction
+      });
+      await queryInterface.addIndex(BOOKINGS_TABLE, ['rejection_reason_id'], {
+        name: 'idx_bookings_rejection_reason_id',
+        transaction
+      });
+      await queryInterface.addConstraint(BOOKINGS_TABLE, {
+        fields: ['request_reason_id'],
+        type: 'foreign key',
+        name: 'fk_bookings_wfa_request_reason',
+        references: { table: REQUEST_REASON_TABLE, field: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'RESTRICT',
+        transaction
+      });
+      await queryInterface.addConstraint(BOOKINGS_TABLE, {
+        fields: ['rejection_reason_id'],
+        type: 'foreign key',
+        name: 'fk_bookings_wfa_rejection_reason',
+        references: { table: REJECTION_REASON_TABLE, field: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'RESTRICT',
+        transaction
+      });
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.removeConstraint(BOOKINGS_TABLE, 'fk_bookings_wfa_rejection_reason', {
+        transaction
+      });
+      await queryInterface.removeConstraint(BOOKINGS_TABLE, 'fk_bookings_wfa_request_reason', {
+        transaction
+      });
+      await queryInterface.removeIndex(BOOKINGS_TABLE, 'idx_bookings_rejection_reason_id', {
+        transaction
+      });
+      await queryInterface.removeIndex(BOOKINGS_TABLE, 'idx_bookings_request_reason_id', {
+        transaction
+      });
+
+      for (const column of [
+        'radius_snapshot',
+        'rejection_note',
+        'rejection_reason_id',
+        'request_other_reason',
+        'request_reason_id'
+      ]) {
+        await queryInterface.removeColumn(BOOKINGS_TABLE, column, { transaction });
+      }
+
+      await queryInterface.dropTable(REJECTION_REASON_TABLE, { transaction });
+      await queryInterface.dropTable(REQUEST_REASON_TABLE, { transaction });
+      await queryInterface.bulkDelete(
+        'settings',
+        {
+          setting_key: RADIUS_SETTING_KEY,
+          description: RADIUS_SETTING_DESCRIPTION
+        },
+        { transaction }
+      );
+    });
+  }
+};

--- a/src/models/wfaRejectionReason.model.js
+++ b/src/models/wfaRejectionReason.model.js
@@ -1,0 +1,22 @@
+import { DataTypes } from 'sequelize';
+
+import sequelize from '../config/database.js';
+
+const WfaRejectionReason = sequelize.define(
+  'WfaRejectionReason',
+  {
+    id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
+    label: { type: DataTypes.STRING(120), allowNull: false },
+    is_active: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: true },
+    is_other: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false },
+    sort_order: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
+    created_at: { type: DataTypes.DATE, allowNull: false },
+    updated_at: { type: DataTypes.DATE, allowNull: false }
+  },
+  {
+    tableName: 'wfa_rejection_reasons',
+    timestamps: false
+  }
+);
+
+export default WfaRejectionReason;

--- a/src/models/wfaRequestReason.model.js
+++ b/src/models/wfaRequestReason.model.js
@@ -1,0 +1,22 @@
+import { DataTypes } from 'sequelize';
+
+import sequelize from '../config/database.js';
+
+const WfaRequestReason = sequelize.define(
+  'WfaRequestReason',
+  {
+    id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
+    label: { type: DataTypes.STRING(120), allowNull: false },
+    is_active: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: true },
+    is_other: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false },
+    sort_order: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
+    created_at: { type: DataTypes.DATE, allowNull: false },
+    updated_at: { type: DataTypes.DATE, allowNull: false }
+  },
+  {
+    tableName: 'wfa_request_reasons',
+    timestamps: false
+  }
+);
+
+export default WfaRequestReason;

--- a/src/routes/settings.routes.js
+++ b/src/routes/settings.routes.js
@@ -4,9 +4,23 @@ import {
   getOperationalSettings,
   patchOperationalSettings
 } from '../controllers/settings.controller.js';
+import {
+  createWfaRejectionReason,
+  createWfaRequestReason,
+  listWfaRejectionReasons,
+  listWfaRequestReasons,
+  updateWfaRejectionReason,
+  updateWfaRequestReason
+} from '../controllers/wfaSettings.controller.js';
 import { verifyToken } from '../middlewares/authJwt.js';
 import roleGuard from '../middlewares/roleGuard.js';
 import { operationalSettingsPatchValidation } from '../middlewares/settings.validator.js';
+import { validate } from '../middlewares/validator.js';
+import {
+  createWfaReasonValidation,
+  updateWfaReasonValidation,
+  wfaReasonIdValidation
+} from '../middlewares/wfaSettings.validator.js';
 
 const router = express.Router();
 
@@ -18,6 +32,39 @@ router.patch(
   roleGuard(['Admin', 'Management']),
   operationalSettingsPatchValidation,
   patchOperationalSettings
+);
+
+router.get('/wfa/request-reasons', roleGuard(['Admin', 'Management']), listWfaRequestReasons);
+router.post(
+  '/wfa/request-reasons',
+  roleGuard(['Admin', 'Management']),
+  createWfaReasonValidation,
+  validate,
+  createWfaRequestReason
+);
+router.patch(
+  '/wfa/request-reasons/:id',
+  roleGuard(['Admin', 'Management']),
+  wfaReasonIdValidation,
+  updateWfaReasonValidation,
+  validate,
+  updateWfaRequestReason
+);
+router.get('/wfa/rejection-reasons', roleGuard(['Admin', 'Management']), listWfaRejectionReasons);
+router.post(
+  '/wfa/rejection-reasons',
+  roleGuard(['Admin', 'Management']),
+  createWfaReasonValidation,
+  validate,
+  createWfaRejectionReason
+);
+router.patch(
+  '/wfa/rejection-reasons/:id',
+  roleGuard(['Admin', 'Management']),
+  wfaReasonIdValidation,
+  updateWfaReasonValidation,
+  validate,
+  updateWfaRejectionReason
 );
 
 export default router;

--- a/src/routes/wfa.routes.js
+++ b/src/routes/wfa.routes.js
@@ -1,6 +1,7 @@
 import express from 'express';
 
 import { getWfaRecommendations, getWfaAhpConfig, testFuzzyAhp } from '../controllers/wfa.controller.js';
+import { getWfaRequestConfig } from '../controllers/wfaSettings.controller.js';
 import { verifyToken } from '../middlewares/authJwt.js';
 import roleGuard from '../middlewares/roleGuard.js';
 
@@ -8,6 +9,8 @@ const router = express.Router();
 
 // All WFA routes require authentication
 router.use(verifyToken);
+
+router.get('/request-config', getWfaRequestConfig);
 
 // GET /api/wfa/recommendations - Get WFA recommendations based on user location
 router.get('/recommendations', getWfaRecommendations);

--- a/src/services/wfaSettings.service.js
+++ b/src/services/wfaSettings.service.js
@@ -1,0 +1,305 @@
+import { WfaRejectionReason, WfaRequestReason } from '../models/index.js';
+import { getOperationalSettingsStrict } from '../utils/settings.js';
+
+const CATALOG_MODELS = Object.freeze({
+  request: WfaRequestReason,
+  rejection: WfaRejectionReason
+});
+
+const CATALOG_NOT_FOUND_CODES = Object.freeze({
+  request: 'WFA_REQUEST_REASON_NOT_FOUND',
+  rejection: 'REJECTION_REASON_NOT_FOUND'
+});
+
+const createWfaError = ({ status = 400, code, message, field = null }) => {
+  const error = new Error(message);
+  error.status = status;
+  error.code = code;
+  error.details = field ? [{ field, code }] : [];
+  return error;
+};
+
+const createValidationError = (message, field) =>
+  createWfaError({ code: 'E_VALIDATION', message, field });
+
+const getCatalogModel = (catalog) => {
+  const model = CATALOG_MODELS[catalog];
+
+  if (!model) {
+    throw createWfaError({
+      status: 409,
+      code: 'WFA_REASON_CATALOG_CONFLICT',
+      message: 'Katalog alasan WFA tidak valid.'
+    });
+  }
+
+  return model;
+};
+
+const normalizeOptionalText = (value) =>
+  typeof value === 'string' && value.trim() !== '' ? value.trim() : null;
+
+const assertReasonId = (reasonId, { code, field, message }) => {
+  if (!Number.isInteger(Number(reasonId)) || Number(reasonId) < 1) {
+    throw createWfaError({ code, message, field });
+  }
+};
+
+const normalizeCreatePayload = (payload) => {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    throw createValidationError('Body katalog alasan harus berupa object.', null);
+  }
+
+  const allowedFields = ['label', 'is_active', 'is_other', 'sort_order'];
+  const unknownField = Object.keys(payload).find((field) => !allowedFields.includes(field));
+  if (unknownField) {
+    throw createValidationError(`Field ${unknownField} tidak didukung.`, unknownField);
+  }
+
+  const label = normalizeOptionalText(payload.label);
+  if (!label || label.length > 120) {
+    throw createValidationError('Label alasan wajib diisi dan maksimal 120 karakter.', 'label');
+  }
+
+  const sortOrder = payload.sort_order ?? 0;
+  if (!Number.isInteger(sortOrder) || sortOrder < 0) {
+    throw createValidationError('sort_order harus bilangan bulat non-negatif.', 'sort_order');
+  }
+
+  if (payload.is_active !== undefined && typeof payload.is_active !== 'boolean') {
+    throw createValidationError('is_active harus boolean.', 'is_active');
+  }
+
+  if (payload.is_other !== undefined && typeof payload.is_other !== 'boolean') {
+    throw createValidationError('is_other harus boolean.', 'is_other');
+  }
+
+  return {
+    label,
+    is_active: payload.is_active ?? true,
+    is_other: payload.is_other ?? false,
+    sort_order: sortOrder
+  };
+};
+
+const normalizeUpdatePayload = (payload) => {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    throw createValidationError('Body katalog alasan harus berupa object.', null);
+  }
+
+  if (Object.hasOwn(payload, 'is_other')) {
+    throw createWfaError({
+      status: 409,
+      code: 'WFA_REASON_CATALOG_CONFLICT',
+      message: 'Tipe Other tidak dapat diubah setelah alasan dibuat.',
+      field: 'is_other'
+    });
+  }
+
+  const allowedFields = ['label', 'is_active', 'sort_order'];
+  const providedFields = Object.keys(payload);
+  const unknownField = providedFields.find((field) => !allowedFields.includes(field));
+  if (unknownField) {
+    throw createValidationError(`Field ${unknownField} tidak didukung.`, unknownField);
+  }
+  if (providedFields.length === 0) {
+    throw createValidationError('Minimal satu field perubahan wajib diisi.', null);
+  }
+
+  const normalized = {};
+  if (Object.hasOwn(payload, 'label')) {
+    const label = normalizeOptionalText(payload.label);
+    if (!label || label.length > 120) {
+      throw createValidationError('Label alasan wajib diisi dan maksimal 120 karakter.', 'label');
+    }
+    normalized.label = label;
+  }
+  if (Object.hasOwn(payload, 'is_active')) {
+    if (typeof payload.is_active !== 'boolean') {
+      throw createValidationError('is_active harus boolean.', 'is_active');
+    }
+    normalized.is_active = payload.is_active;
+  }
+  if (Object.hasOwn(payload, 'sort_order')) {
+    if (!Number.isInteger(payload.sort_order) || payload.sort_order < 0) {
+      throw createValidationError('sort_order harus bilangan bulat non-negatif.', 'sort_order');
+    }
+    normalized.sort_order = payload.sort_order;
+  }
+
+  return normalized;
+};
+
+export const readWfaRequestConfig = async (transaction = null) => {
+  let settings;
+
+  try {
+    settings = await getOperationalSettingsStrict(transaction);
+  } catch (_error) {
+    throw createWfaError({
+      status: 500,
+      code: 'WFA_CONFIG_UNAVAILABLE',
+      message: 'Konfigurasi WFA belum tersedia.'
+    });
+  }
+
+  const reasons = await WfaRequestReason.findAll({
+    where: { is_active: true },
+    order: [
+      ['sort_order', 'ASC'],
+      ['id', 'ASC']
+    ],
+    transaction
+  });
+
+  return {
+    radiusMeters: settings.wfaRequestRadiusM,
+    reasons: reasons.map((reason) => ({
+      id: reason.id,
+      label: reason.label,
+      isOther: Boolean(reason.is_other),
+      sortOrder: reason.sort_order
+    }))
+  };
+};
+
+export const resolveActiveWfaRequestReason = async ({
+  reasonId,
+  otherReasonText = null,
+  transaction = null
+}) => {
+  assertReasonId(reasonId, {
+    code: 'WFA_REQUEST_REASON_REQUIRED',
+    field: 'request_reason_id',
+    message: 'Alasan pengajuan WFA wajib dipilih.'
+  });
+
+  const reason = await WfaRequestReason.findByPk(Number(reasonId), { transaction });
+  if (!reason) {
+    throw createWfaError({
+      code: 'WFA_REQUEST_REASON_NOT_FOUND',
+      message: 'Alasan pengajuan WFA tidak ditemukan.',
+      field: 'request_reason_id'
+    });
+  }
+  if (!reason.is_active) {
+    throw createWfaError({
+      code: 'WFA_REQUEST_REASON_NOT_ACTIVE',
+      message: 'Alasan WFA tidak lagi tersedia.',
+      field: 'request_reason_id'
+    });
+  }
+
+  const trimmedOtherReason = normalizeOptionalText(otherReasonText);
+  if (reason.is_other && !trimmedOtherReason) {
+    throw createWfaError({
+      code: 'WFA_OTHER_REASON_REQUIRED',
+      message: 'Keterangan alasan lainnya wajib diisi.',
+      field: 'request_other_reason'
+    });
+  }
+
+  return {
+    reason,
+    normalizedOtherReason: reason.is_other ? trimmedOtherReason : null
+  };
+};
+
+export const resolveActiveWfaRejectionReason = async ({
+  reasonId,
+  note = null,
+  transaction = null
+}) => {
+  assertReasonId(reasonId, {
+    code: 'REJECTION_REASON_REQUIRED',
+    field: 'rejection_reason_id',
+    message: 'Alasan penolakan wajib dipilih.'
+  });
+
+  const reason = await WfaRejectionReason.findByPk(Number(reasonId), { transaction });
+  if (!reason) {
+    throw createWfaError({
+      code: 'REJECTION_REASON_NOT_FOUND',
+      message: 'Alasan penolakan tidak ditemukan.',
+      field: 'rejection_reason_id'
+    });
+  }
+  if (!reason.is_active) {
+    throw createWfaError({
+      code: 'REJECTION_REASON_NOT_ACTIVE',
+      message: 'Alasan penolakan tidak lagi tersedia.',
+      field: 'rejection_reason_id'
+    });
+  }
+
+  const normalizedNote = normalizeOptionalText(note);
+  if (reason.is_other && !normalizedNote) {
+    throw createWfaError({
+      code: 'REJECTION_NOTE_REQUIRED',
+      message: 'Catatan wajib diisi untuk alasan penolakan Lainnya.',
+      field: 'rejection_note'
+    });
+  }
+
+  return { reason, normalizedNote };
+};
+
+export const listWfaReasons = async ({
+  catalog,
+  includeInactive = false,
+  transaction = null
+}) => {
+  const model = getCatalogModel(catalog);
+  return model.findAll({
+    where: includeInactive ? {} : { is_active: true },
+    order: [
+      ['sort_order', 'ASC'],
+      ['id', 'ASC']
+    ],
+    transaction
+  });
+};
+
+export const createWfaReason = async ({ catalog, payload, transaction = null }) => {
+  const model = getCatalogModel(catalog);
+  const normalized = normalizeCreatePayload(payload);
+
+  if (normalized.is_other) {
+    const existingOther = await model.findOne({ where: { is_other: true }, transaction });
+    if (existingOther) {
+      throw createWfaError({
+        status: 409,
+        code: 'WFA_REASON_CATALOG_CONFLICT',
+        message: 'Katalog ini sudah memiliki alasan Lainnya.',
+        field: 'is_other'
+      });
+    }
+  }
+
+  const now = new Date();
+  return model.create(
+    {
+      ...normalized,
+      created_at: now,
+      updated_at: now
+    },
+    { transaction }
+  );
+};
+
+export const updateWfaReason = async ({ catalog, id, payload, transaction = null }) => {
+  const model = getCatalogModel(catalog);
+  const normalized = normalizeUpdatePayload(payload);
+  const reason = await model.findByPk(Number(id), { transaction });
+
+  if (!reason) {
+    throw createWfaError({
+      code: CATALOG_NOT_FOUND_CODES[catalog],
+      message: 'Alasan WFA tidak ditemukan.',
+      field: 'id'
+    });
+  }
+
+  await reason.update({ ...normalized, updated_at: new Date() }, { transaction });
+  return reason;
+};

--- a/src/utils/settings.js
+++ b/src/utils/settings.js
@@ -7,7 +7,8 @@ export const OPERATIONAL_SETTING_KEYS = {
   autoCheckoutIdleMin: 'attendance.auto_checkout.idle_min',
   autoCheckoutTBufferMin: 'attendance.auto_checkout.tbuffer_min',
   lateCheckoutToleranceMin: 'attendance.auto_checkout.late_tolerance_min',
-  defaultShiftEnd: 'checkout.fallback_time'
+  defaultShiftEnd: 'checkout.fallback_time',
+  wfaRequestRadiusM: 'wfa.request.radius_m'
 };
 
 export const OPERATIONAL_SETTING_DEFAULTS = {
@@ -15,7 +16,8 @@ export const OPERATIONAL_SETTING_DEFAULTS = {
   autoCheckoutIdleMin: 10,
   autoCheckoutTBufferMin: 30,
   lateCheckoutToleranceMin: 15,
-  defaultShiftEnd: '17:00:00'
+  defaultShiftEnd: '17:00:00',
+  wfaRequestRadiusM: 100
 };
 
 export const OPERATIONAL_SETTING_FIELDS = Object.freeze(Object.keys(OPERATIONAL_SETTING_KEYS));
@@ -30,7 +32,8 @@ export const OPERATIONAL_SETTING_INTEGER_FIELDS = Object.freeze([
   'geofenceRadiusDefaultM',
   'autoCheckoutIdleMin',
   'autoCheckoutTBufferMin',
-  'lateCheckoutToleranceMin'
+  'lateCheckoutToleranceMin',
+  'wfaRequestRadiusM'
 ]);
 
 export const OPERATIONAL_SETTING_TIME_FIELDS = Object.freeze(['defaultShiftEnd']);

--- a/tests/analysisFuzzyAhpContract.test.js
+++ b/tests/analysisFuzzyAhpContract.test.js
@@ -79,6 +79,8 @@ jest.unstable_mockModule('../src/models/index.js', () => ({
   Position: {},
   Photo: {},
   AuthSession: {},
+  WfaRequestReason: {},
+  WfaRejectionReason: {},
   sequelize: {}
 }));
 

--- a/tests/bookingWfaPolicyContract.test.js
+++ b/tests/bookingWfaPolicyContract.test.js
@@ -27,7 +27,9 @@ jest.unstable_mockModule('../src/models/index.js', () => ({
   BookingStatus: {},
   User: {},
   Position: {},
-  Role: {}
+  Role: {},
+  WfaRequestReason: {},
+  WfaRejectionReason: {}
 }));
 jest.unstable_mockModule('../src/services/wfaSettings.service.js', () => ({
   readWfaRequestConfig: mockReadWfaRequestConfig,

--- a/tests/bookingWfaPolicyContract.test.js
+++ b/tests/bookingWfaPolicyContract.test.js
@@ -1,0 +1,199 @@
+import { jest } from '@jest/globals';
+
+process.env.GEOAPIFY_API_KEY = 'test-key';
+
+const transaction = {
+  commit: jest.fn().mockResolvedValue(undefined),
+  rollback: jest.fn().mockResolvedValue(undefined)
+};
+const mockBookingFindOne = jest.fn();
+const mockBookingCreate = jest.fn();
+const mockLocationFindByPk = jest.fn();
+const mockLocationCreate = jest.fn();
+const mockReadWfaRequestConfig = jest.fn();
+const mockResolveActiveWfaRequestReason = jest.fn();
+const mockCalculateWfaScore = jest.fn();
+
+jest.unstable_mockModule('../src/config/database.js', () => ({
+  default: {
+    transaction: jest.fn().mockResolvedValue(transaction),
+    fn: jest.fn(),
+    col: jest.fn()
+  }
+}));
+jest.unstable_mockModule('../src/models/index.js', () => ({
+  Booking: { findOne: mockBookingFindOne, create: mockBookingCreate },
+  Location: { findByPk: mockLocationFindByPk, create: mockLocationCreate },
+  BookingStatus: {},
+  User: {},
+  Position: {},
+  Role: {}
+}));
+jest.unstable_mockModule('../src/services/wfaSettings.service.js', () => ({
+  readWfaRequestConfig: mockReadWfaRequestConfig,
+  resolveActiveWfaRequestReason: mockResolveActiveWfaRequestReason,
+  resolveActiveWfaRejectionReason: jest.fn()
+}));
+jest.unstable_mockModule('../src/utils/fuzzyAhpEngine.js', () => ({
+  default: { calculateWfaScore: mockCalculateWfaScore }
+}));
+jest.unstable_mockModule('../src/utils/geofence.js', () => ({
+  getJakartaDateString: jest.fn(() => '2026-07-28')
+}));
+jest.unstable_mockModule('../src/utils/logger.js', () => ({
+  default: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn()
+  }
+}));
+jest.unstable_mockModule('axios', () => ({
+  default: {
+    get: jest.fn().mockResolvedValue({
+      data: {
+        features: [
+          {
+            properties: { name: 'Lokasi server' },
+            geometry: { type: 'Point', coordinates: [119.87, -0.9] }
+          }
+        ]
+      }
+    })
+  }
+}));
+
+const { createBooking } = await import('../src/controllers/booking.controller.js');
+
+const buildRes = () => {
+  const res = {};
+  res.status = jest.fn(() => res);
+  res.json = jest.fn(() => res);
+  return res;
+};
+
+describe('server-authoritative WFA booking creation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockBookingFindOne.mockResolvedValue(null);
+    mockReadWfaRequestConfig.mockResolvedValue({ radiusMeters: 150, reasons: [] });
+    mockResolveActiveWfaRequestReason.mockResolvedValue({
+      reason: { id: 1, label: 'Pertemuan dengan klien', is_other: false },
+      normalizedOtherReason: null
+    });
+    mockLocationCreate.mockResolvedValue({
+      location_id: 20,
+      latitude: -0.9,
+      longitude: 119.87,
+      radius: 150,
+      description: 'Lokasi klien'
+    });
+    mockCalculateWfaScore.mockResolvedValue({ score: 82, label: 'Direkomendasikan' });
+    mockBookingCreate.mockImplementation(async (payload) => ({
+      booking_id: 30,
+      ...payload
+    }));
+  });
+
+  it('uses authenticated identity, server radius, server suitability, and pending status', async () => {
+    const req = {
+      user: { id: 9 },
+      body: {
+        schedule_date: '2026-08-10',
+        request_reason_id: 1,
+        request_other_reason: null,
+        notes: '  Pertemuan project  ',
+        latitude: -0.9,
+        longitude: 119.87,
+        description: 'Lokasi klien',
+        radius: 9999,
+        suitability_score: 999,
+        suitability_label: 'client-controlled',
+        user_id: 999,
+        status: 'approved'
+      }
+    };
+    const res = buildRes();
+    const next = jest.fn();
+
+    await createBooking(req, res, next);
+
+    expect(mockReadWfaRequestConfig).toHaveBeenCalledWith(transaction);
+    expect(mockResolveActiveWfaRequestReason).toHaveBeenCalledWith({
+      reasonId: 1,
+      otherReasonText: null,
+      transaction
+    });
+    expect(mockLocationCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ user_id: 9, radius: 150 }),
+      { transaction }
+    );
+    expect(mockBookingCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: 9,
+        request_reason_id: 1,
+        request_other_reason: null,
+        radius_snapshot: 150,
+        status: 3,
+        notes: 'Pertemuan project',
+        suitability_score: 82,
+        suitability_label: 'Direkomendasikan'
+      }),
+      { transaction }
+    );
+    expect(mockBookingCreate.mock.calls[0][0]).not.toEqual(
+      expect.objectContaining({ radius: 9999, user_id: 999, status: 1 })
+    );
+    expect(transaction.commit).toHaveBeenCalled();
+    expect(transaction.rollback).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      message: 'Booking WFA berhasil dibuat.',
+      data: expect.objectContaining({
+        booking_id: 30,
+        schedule_date: '2026-08-10',
+        status: 'pending',
+        radius_snapshot: 150,
+        suitability_score: 82,
+        suitability_label: 'Direkomendasikan',
+        request_reason: {
+          id: 1,
+          label: 'Pertemuan dengan klien',
+          is_other: false,
+          other_text: null
+        },
+        location: expect.objectContaining({ location_id: 20, radius: 150 })
+      })
+    });
+  });
+
+  it('returns INVALID_SCHEDULE_DATE before reading policy for an impossible date', async () => {
+    const res = buildRes();
+    const next = jest.fn();
+
+    await createBooking(
+      {
+        user: { id: 9 },
+        body: {
+          schedule_date: '2026-02-30',
+          request_reason_id: 1,
+          latitude: -0.9,
+          longitude: 119.87
+        }
+      },
+      res,
+      next
+    );
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ success: false, code: 'INVALID_SCHEDULE_DATE' })
+    );
+    expect(mockReadWfaRequestConfig).not.toHaveBeenCalled();
+    expect(mockBookingCreate).not.toHaveBeenCalled();
+    expect(transaction.rollback).toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/tests/bookingWfaProjectionContract.test.js
+++ b/tests/bookingWfaProjectionContract.test.js
@@ -1,0 +1,137 @@
+import { jest } from '@jest/globals';
+
+const mockFindAndCountAll = jest.fn();
+const WfaRequestReason = { modelName: 'WfaRequestReason' };
+const WfaRejectionReason = { modelName: 'WfaRejectionReason' };
+
+jest.unstable_mockModule('../src/config/database.js', () => ({
+  default: {
+    transaction: jest.fn(),
+    fn: jest.fn((...args) => ({ args })),
+    col: jest.fn((value) => value)
+  }
+}));
+jest.unstable_mockModule('../src/models/index.js', () => ({
+  Booking: { findAndCountAll: mockFindAndCountAll },
+  Location: {},
+  BookingStatus: {},
+  User: {},
+  Position: {},
+  Role: {},
+  WfaRequestReason,
+  WfaRejectionReason
+}));
+jest.unstable_mockModule('../src/services/wfaSettings.service.js', () => ({
+  readWfaRequestConfig: jest.fn(),
+  resolveActiveWfaRequestReason: jest.fn(),
+  resolveActiveWfaRejectionReason: jest.fn()
+}));
+jest.unstable_mockModule('../src/utils/fuzzyAhpEngine.js', () => ({ default: {} }));
+jest.unstable_mockModule('../src/utils/logger.js', () => ({
+  default: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+}));
+
+const { getAllBookings } = await import('../src/controllers/booking.controller.js');
+
+const commonBooking = {
+  user: {
+    id_users: 9,
+    full_name: 'User WFA',
+    email: 'wfa@example.com',
+    nip_nim: 'EMP-9',
+    role: { role_name: 'User' },
+    position: { position_name: 'Engineer' }
+  },
+  schedule_date: '2026-08-10',
+  booking_status: { name_status: 'rejected' },
+  location: {
+    location_id: 20,
+    latitude: '-0.9',
+    longitude: '119.87',
+    radius: '100',
+    description: 'Lokasi klien'
+  },
+  notes: '',
+  suitability_score: '82',
+  suitability_label: 'Direkomendasikan',
+  created_at: new Date('2026-07-28T00:00:00.000Z'),
+  processed_at: null,
+  approved_by: null
+};
+
+const buildRes = () => {
+  const res = {};
+  res.status = jest.fn(() => res);
+  res.json = jest.fn(() => res);
+  return res;
+};
+
+describe('WFA booking read projection', () => {
+  it('projects structured reasons and falls back to location radius for legacy rows', async () => {
+    mockFindAndCountAll.mockResolvedValue({
+      count: 2,
+      rows: [
+        {
+          ...commonBooking,
+          booking_id: 31,
+          request_reason: {
+            id: 1,
+            label: 'Pertemuan dengan klien',
+            is_other: false
+          },
+          request_other_reason: null,
+          rejection_reason_detail: {
+            id: 2,
+            label: 'Lokasi tidak memenuhi ketentuan',
+            is_other: false
+          },
+          rejection_note: 'Di luar area operasional',
+          radius_snapshot: 150
+        },
+        {
+          ...commonBooking,
+          booking_id: 32,
+          request_reason: null,
+          request_other_reason: null,
+          rejection_reason_detail: null,
+          rejection_note: null,
+          radius_snapshot: null
+        }
+      ]
+    });
+    const res = buildRes();
+    const next = jest.fn();
+
+    await getAllBookings({ query: {} }, res, next);
+
+    const query = mockFindAndCountAll.mock.calls[0][0];
+    expect(query.include).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ model: WfaRequestReason, as: 'request_reason' }),
+        expect.objectContaining({ model: WfaRejectionReason, as: 'rejection_reason_detail' })
+      ])
+    );
+    const response = res.json.mock.calls[0][0];
+    expect(response.data.bookings[0]).toMatchObject({
+      request_reason: {
+        id: 1,
+        label: 'Pertemuan dengan klien',
+        is_other: false,
+        other_text: null
+      },
+      rejection_reason: {
+        id: 2,
+        label: 'Lokasi tidak memenuhi ketentuan',
+        is_other: false,
+        note: 'Di luar area operasional'
+      },
+      radius_snapshot: 150
+    });
+    expect(response.data.bookings[1]).toMatchObject({
+      request_reason: null,
+      rejection_reason: null,
+      radius_snapshot: 100
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/tests/bookingWfaRejectionContract.test.js
+++ b/tests/bookingWfaRejectionContract.test.js
@@ -21,7 +21,9 @@ jest.unstable_mockModule('../src/models/index.js', () => ({
   BookingStatus: {},
   User: {},
   Position: {},
-  Role: {}
+  Role: {},
+  WfaRequestReason: {},
+  WfaRejectionReason: {}
 }));
 jest.unstable_mockModule('../src/services/wfaSettings.service.js', () => ({
   readWfaRequestConfig: jest.fn(),

--- a/tests/bookingWfaRejectionContract.test.js
+++ b/tests/bookingWfaRejectionContract.test.js
@@ -1,0 +1,180 @@
+import { jest } from '@jest/globals';
+
+const transaction = {
+  commit: jest.fn().mockResolvedValue(undefined),
+  rollback: jest.fn().mockResolvedValue(undefined)
+};
+const mockBookingFindByPk = jest.fn();
+const mockResolveActiveWfaRejectionReason = jest.fn();
+const bookingUpdate = jest.fn().mockResolvedValue(undefined);
+
+jest.unstable_mockModule('../src/config/database.js', () => ({
+  default: {
+    transaction: jest.fn().mockResolvedValue(transaction),
+    fn: jest.fn(),
+    col: jest.fn()
+  }
+}));
+jest.unstable_mockModule('../src/models/index.js', () => ({
+  Booking: { findByPk: mockBookingFindByPk },
+  Location: {},
+  BookingStatus: {},
+  User: {},
+  Position: {},
+  Role: {}
+}));
+jest.unstable_mockModule('../src/services/wfaSettings.service.js', () => ({
+  readWfaRequestConfig: jest.fn(),
+  resolveActiveWfaRequestReason: jest.fn(),
+  resolveActiveWfaRejectionReason: mockResolveActiveWfaRejectionReason
+}));
+jest.unstable_mockModule('../src/utils/fuzzyAhpEngine.js', () => ({ default: {} }));
+jest.unstable_mockModule('../src/utils/logger.js', () => ({
+  default: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+}));
+
+const { updateBookingStatus } = await import('../src/controllers/booking.controller.js');
+
+const buildRes = () => {
+  const res = {};
+  res.status = jest.fn(() => res);
+  res.json = jest.fn(() => res);
+  return res;
+};
+
+const booking = {
+  booking_id: 12,
+  schedule_date: '2099-08-10',
+  update: bookingUpdate
+};
+
+const updatedBooking = {
+  booking_id: 12,
+  schedule_date: '2099-08-10',
+  user: { full_name: 'User WFA', email: 'wfa@example.com' },
+  booking_status: { name_status: 'rejected' },
+  location: {
+    latitude: -0.9,
+    longitude: 119.87,
+    radius: 100,
+    description: 'Lokasi klien'
+  },
+  processed_at: new Date('2026-07-28T00:00:00.000Z')
+};
+
+describe('Management WFA booking decision contract', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockBookingFindByPk.mockResolvedValueOnce(booking).mockResolvedValueOnce(updatedBooking);
+  });
+
+  it('approves without rejection fields and clears stale structured rejection data', async () => {
+    const res = buildRes();
+    const next = jest.fn();
+
+    await updateBookingStatus(
+      { params: { id: '12' }, body: { status: 'approved' }, user: { id: 9 } },
+      res,
+      next
+    );
+
+    expect(mockResolveActiveWfaRejectionReason).not.toHaveBeenCalled();
+    expect(bookingUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 1,
+        rejection_reason_id: null,
+        rejection_note: null,
+        approved_by: 9,
+        processed_at: expect.any(Date)
+      }),
+      { transaction }
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ rejection_reason: null })
+      })
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('persists a resolved rejection reason and normalized note', async () => {
+    const reason = { id: 5, label: 'Lainnya', is_other: true };
+    mockResolveActiveWfaRejectionReason.mockResolvedValue({
+      reason,
+      normalizedNote: 'Keterangan khusus'
+    });
+    const res = buildRes();
+    const next = jest.fn();
+
+    await updateBookingStatus(
+      {
+        params: { id: '12' },
+        body: {
+          status: 'rejected',
+          rejection_reason_id: 5,
+          rejection_note: '  Keterangan khusus  '
+        },
+        user: { id: 9 }
+      },
+      res,
+      next
+    );
+
+    expect(mockResolveActiveWfaRejectionReason).toHaveBeenCalledWith({
+      reasonId: 5,
+      note: '  Keterangan khusus  ',
+      transaction
+    });
+    expect(bookingUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 2,
+        rejection_reason_id: 5,
+        rejection_note: 'Keterangan khusus',
+        approved_by: 9,
+        processed_at: expect.any(Date)
+      }),
+      { transaction }
+    );
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          rejection_reason: {
+            id: 5,
+            label: 'Lainnya',
+            is_other: true,
+            note: 'Keterangan khusus'
+          }
+        })
+      })
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    'REJECTION_REASON_REQUIRED',
+    'REJECTION_REASON_NOT_FOUND',
+    'REJECTION_REASON_NOT_ACTIVE',
+    'REJECTION_NOTE_REQUIRED'
+  ])('rolls back and forwards %s from the reason service', async (code) => {
+    const serviceError = Object.assign(new Error(code), { status: 400, code });
+    mockResolveActiveWfaRejectionReason.mockRejectedValue(serviceError);
+    const res = buildRes();
+    const next = jest.fn();
+
+    await updateBookingStatus(
+      {
+        params: { id: '12' },
+        body: { status: 'rejected', rejection_reason_id: 5 },
+        user: { id: 9 }
+      },
+      res,
+      next
+    );
+
+    expect(transaction.rollback).toHaveBeenCalled();
+    expect(transaction.commit).not.toHaveBeenCalled();
+    expect(bookingUpdate).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(serviceError);
+  });
+});

--- a/tests/bookingsControllerReadiness.test.js
+++ b/tests/bookingsControllerReadiness.test.js
@@ -64,6 +64,12 @@ describe('booking controller readiness regressions', () => {
         debug: jest.fn()
       }
     }));
+
+    jest.unstable_mockModule('../src/services/wfaSettings.service.js', () => ({
+      readWfaRequestConfig: jest.fn(),
+      resolveActiveWfaRequestReason: jest.fn(),
+      resolveActiveWfaRejectionReason: jest.fn()
+    }));
   }
 
   async function importBookingController(models, sequelizeMock = buildSequelizeMock()) {

--- a/tests/bookingsControllerReadiness.test.js
+++ b/tests/bookingsControllerReadiness.test.js
@@ -41,7 +41,9 @@ describe('booking controller readiness regressions', () => {
       BookingStatus: {},
       User: {},
       Position: {},
-      Role: {}
+      Role: {},
+      WfaRequestReason: {},
+      WfaRejectionReason: {}
     };
   }
 

--- a/tests/bookingsReadinessContract.test.js
+++ b/tests/bookingsReadinessContract.test.js
@@ -178,10 +178,28 @@ describe('bookings validator contract', () => {
     await request(app).post('/bookings').send(payload).expect(400);
   });
 
-  test.each(['approved', 'rejected'])('status %s passes', async (status) => {
+  test('status approved passes without rejection fields', async () => {
     const app = buildValidatorApp();
 
-    await request(app).patch('/bookings/123').send({ status }).expect(200);
+    await request(app).patch('/bookings/123').send({ status: 'approved' }).expect(200);
+  });
+
+  test('status rejected requires rejection_reason_id', async () => {
+    const app = buildValidatorApp();
+
+    const res = await request(app).patch('/bookings/123').send({ status: 'rejected' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('REJECTION_REASON_REQUIRED');
+  });
+
+  test('status rejected accepts an integer reason and optional note', async () => {
+    const app = buildValidatorApp();
+
+    await request(app)
+      .patch('/bookings/123')
+      .send({ status: 'rejected', rejection_reason_id: 2, rejection_note: 'Konteks' })
+      .expect(200);
   });
 
   test('any other status returns 400', async () => {

--- a/tests/bookingsReadinessContract.test.js
+++ b/tests/bookingsReadinessContract.test.js
@@ -64,6 +64,7 @@ const buildValidatorApp = () => {
 
 const validBookingPayload = {
   schedule_date: '2026-05-04',
+  request_reason_id: 1,
   latitude: -6.2,
   longitude: 106.8
 };
@@ -104,6 +105,45 @@ describe('bookings validator contract', () => {
     delete payload.schedule_date;
 
     await request(app).post('/bookings').send(payload).expect(400);
+  });
+
+  test.each(['10-08-2026', '08-10-2026', '2026-02-30'])(
+    'schedule_date %s returns INVALID_SCHEDULE_DATE',
+    async (scheduleDate) => {
+      const app = buildValidatorApp();
+
+      const res = await request(app)
+        .post('/bookings')
+        .send({ ...validBookingPayload, schedule_date: scheduleDate });
+
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe('INVALID_SCHEDULE_DATE');
+    }
+  );
+
+  test('missing request_reason_id returns WFA_REQUEST_REASON_REQUIRED', async () => {
+    const app = buildValidatorApp();
+    const payload = { ...validBookingPayload };
+    delete payload.request_reason_id;
+
+    const res = await request(app).post('/bookings').send(payload);
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('WFA_REQUEST_REASON_REQUIRED');
+  });
+
+  test('accepts compatibility radius and suitability fields without trusting their shape', async () => {
+    const app = buildValidatorApp();
+
+    await request(app)
+      .post('/bookings')
+      .send({
+        ...validBookingPayload,
+        radius: 9999,
+        suitability_score: 999,
+        suitability_label: 'client-controlled'
+      })
+      .expect(201);
   });
 
   test.each([

--- a/tests/clientCriticalOpenApiContract.test.js
+++ b/tests/clientCriticalOpenApiContract.test.js
@@ -253,12 +253,20 @@ describe('client-critical OpenAPI contract', () => {
   test('documents booking creation request payload in the public OpenAPI contract', () => {
     const bookingSchema = jsonRequestSchema(openapi.paths['/api/bookings'].post);
 
-    expect(bookingSchema.required).toEqual(['schedule_date', 'latitude', 'longitude']);
+    expect(bookingSchema.required).toEqual([
+      'schedule_date',
+      'request_reason_id',
+      'latitude',
+      'longitude'
+    ]);
     expect(bookingSchema.properties).toMatchObject({
       schedule_date: {
         type: 'string',
-        format: 'date'
+        format: 'date',
+        pattern: '^\\d{4}-\\d{2}-\\d{2}$'
       },
+      request_reason_id: { type: 'integer', minimum: 1 },
+      request_other_reason: { type: 'string', nullable: true },
       latitude: {
         type: 'number',
         format: 'float'
@@ -267,13 +275,15 @@ describe('client-critical OpenAPI contract', () => {
         type: 'number',
         format: 'float'
       },
-      radius: { type: 'number' },
       description: { type: 'string' },
       notes: { type: 'string' }
     });
     expect(bookingSchema.properties).not.toHaveProperty('date');
     expect(bookingSchema.properties).not.toHaveProperty('location_name');
     expect(bookingSchema.properties).not.toHaveProperty('reason');
+    expect(bookingSchema.properties).not.toHaveProperty('radius');
+    expect(bookingSchema.properties).not.toHaveProperty('status');
+    expect(bookingSchema.properties).not.toHaveProperty('suitability_score');
   });
 
   test('documents booking admin list query filters exposed to clients', () => {
@@ -296,14 +306,13 @@ describe('client-critical OpenAPI contract', () => {
       success: { type: 'boolean', example: true },
       message: {
         type: 'string',
-        example: 'Booking WFA berhasil diajukan dan menunggu persetujuan.'
+        example: 'Booking WFA berhasil dibuat.'
       },
       data: { type: 'object' }
     });
     expect(dataSchema.properties).toMatchObject({
       booking_id: { type: 'integer' },
       schedule_date: { type: 'string' },
-      location_id: { type: 'integer' },
       status: {
         type: 'string',
         example: 'pending'
@@ -315,7 +324,11 @@ describe('client-critical OpenAPI contract', () => {
       suitability_label: {
         type: 'string',
         nullable: true
-      }
+      },
+      request_reason: { $ref: '#/components/schemas/WfaRequestReasonProjection' },
+      location: { $ref: '#/components/schemas/WfaBookingLocation' },
+      radius_snapshot: { type: 'integer', minimum: 1 },
+      created_at: { type: 'string', format: 'date-time' }
     });
   });
 

--- a/tests/findingsRegisterGuard.test.js
+++ b/tests/findingsRegisterGuard.test.js
@@ -112,19 +112,20 @@ describe('F13 — the schema cannot be built from migrations', () => {
   const migrations = readdirSync(migrationsDir).filter((f) => f.endsWith('.cjs'));
 
   /**
-   * The original wording claimed zero createTable calls. There are two, both
-   * in the newest migrations. The conclusion is unchanged -- an empty database
+   * The original wording claimed zero createTable calls. There are now three migrations
+   * with createTable calls, all from 2026. The conclusion is unchanged -- an empty database
    * still cannot be built -- but the evidence had to be corrected, and this
    * pins the corrected version.
    */
-  it('creates exactly two tables, both from 2026 migrations', () => {
+  it('creates tables only in the known 2026 migrations', () => {
     const creating = migrations.filter((f) =>
       readFileSync(path.join(migrationsDir, f), 'utf8').includes('createTable')
     );
 
     expect(creating.sort()).toEqual([
       '20260511000000-create-auth-sessions.cjs',
-      '20260707010000-create-attendance-session-states.cjs'
+      '20260707010000-create-attendance-session-states.cjs',
+      '20260728010000-add-wfa-request-policy.cjs'
     ]);
   });
 
@@ -136,7 +137,12 @@ describe('F13 — the schema cannot be built from migrations', () => {
         .map((m) => m[1])
     );
 
-    const created = new Set(['auth_sessions', 'attendance_session_states']);
+    const created = new Set([
+      'auth_sessions',
+      'attendance_session_states',
+      'wfa_request_reasons',
+      'wfa_rejection_reasons'
+    ]);
     const fromBaselineOnly = [...modelled].filter((t) => !created.has(t));
 
     // Includes users, attendance, bookings, locations — the entire core.

--- a/tests/openApiWfaPolicyContract.test.js
+++ b/tests/openApiWfaPolicyContract.test.js
@@ -1,0 +1,96 @@
+import fs from 'fs';
+import path from 'path';
+import YAML from 'yamljs';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const openapi = YAML.parse(
+  fs.readFileSync(path.join(__dirname, '..', 'docs', 'openapi.yaml'), 'utf8')
+);
+
+const requestSchema = (operation) =>
+  operation.requestBody.content['application/json'].schema;
+
+describe('INF-270 public OpenAPI contract', () => {
+  test('documents the authenticated WFA request configuration endpoint', () => {
+    const operation = openapi.paths['/api/wfa/request-config'].get;
+    const data = operation.responses['200'].content['application/json'].schema.properties.data;
+
+    expect(data.required).toEqual(['radius_m', 'request_reasons']);
+    expect(data.properties.radius_m).toMatchObject({ type: 'integer', minimum: 1 });
+    expect(data.properties.request_reasons.items.$ref).toBe('#/components/schemas/WfaReason');
+    expect(operation.responses).toHaveProperty('500');
+  });
+
+  test.each(['request', 'rejection'])(
+    'documents %s reason catalog management without a delete route',
+    (catalog) => {
+      const collection = openapi.paths[`/api/settings/wfa/${catalog}-reasons`];
+      const member = openapi.paths[`/api/settings/wfa/${catalog}-reasons/{id}`];
+
+      expect(Object.keys(collection).sort()).toEqual(['get', 'post']);
+      expect(Object.keys(member).sort()).toEqual(['patch']);
+      expect(requestSchema(collection.post).$ref).toBe('#/components/schemas/WfaReasonCreateRequest');
+      expect(requestSchema(member.patch).$ref).toBe('#/components/schemas/WfaReasonUpdateRequest');
+    }
+  );
+
+  test('adds the server-owned radius to operational settings', () => {
+    const settings = openapi.components.schemas.OperationalSettings;
+    const patch = openapi.components.schemas.OperationalSettingsPatchRequest;
+
+    expect(settings.required).toContain('wfaRequestRadiusM');
+    expect(settings.properties.wfaRequestRadiusM).toMatchObject({
+      type: 'integer',
+      minimum: 1
+    });
+    expect(patch.properties.wfaRequestRadiusM).toMatchObject({
+      type: 'integer',
+      minimum: 1
+    });
+  });
+
+  test('documents the server-owned booking creation policy inputs and outputs', () => {
+    const operation = openapi.paths['/api/bookings'].post;
+    const schema = requestSchema(operation);
+    const data = operation.responses['201'].content['application/json'].schema.properties.data;
+
+    expect(schema.required).toEqual([
+      'schedule_date',
+      'request_reason_id',
+      'latitude',
+      'longitude'
+    ]);
+    expect(schema.properties.schedule_date.pattern).toBe('^\\d{4}-\\d{2}-\\d{2}$');
+    expect(schema.properties).toHaveProperty('request_other_reason');
+    expect(schema.properties).not.toHaveProperty('radius');
+    expect(schema.properties).not.toHaveProperty('suitability_score');
+    expect(schema.properties).not.toHaveProperty('status');
+    expect(operation.description).toContain('WFA_OTHER_REASON_REQUIRED');
+    expect(operation.description).toContain('DUPLICATE_BOOKING');
+    expect(data.properties).toHaveProperty('request_reason');
+    expect(data.properties).toHaveProperty('radius_snapshot');
+    expect(data.properties.location.$ref).toBe('#/components/schemas/WfaBookingLocation');
+    expect(openapi.components.schemas.WfaBookingLocation.properties).toHaveProperty('radius');
+  });
+
+  test('documents structured rejection inputs and reason projections', () => {
+    const patch = requestSchema(openapi.paths['/api/bookings/{id}'].patch);
+    const booking = openapi.components.schemas.Booking;
+    const history = openapi.components.schemas.BookingHistoryItem;
+
+    expect(patch.properties).toHaveProperty('rejection_reason_id');
+    expect(patch.properties).toHaveProperty('rejection_note');
+    expect(patch.properties).not.toHaveProperty('admin_notes');
+    expect(openapi.paths['/api/bookings/{id}'].patch.description).toContain(
+      'REJECTION_NOTE_REQUIRED'
+    );
+    expect(booking.properties).toHaveProperty('request_reason');
+    expect(booking.properties).toHaveProperty('rejection_reason');
+    expect(booking.properties).toHaveProperty('radius_snapshot');
+    expect(history.properties).toHaveProperty('request_reason');
+    expect(history.properties).toHaveProperty('rejection_reason');
+    expect(history.properties).toHaveProperty('radius_snapshot');
+  });
+});

--- a/tests/openApiWfaPolicyContract.test.js
+++ b/tests/openApiWfaPolicyContract.test.js
@@ -17,9 +17,9 @@ describe('INF-270 public OpenAPI contract', () => {
     const operation = openapi.paths['/api/wfa/request-config'].get;
     const data = operation.responses['200'].content['application/json'].schema.properties.data;
 
-    expect(data.required).toEqual(['radius_m', 'request_reasons']);
-    expect(data.properties.radius_m).toMatchObject({ type: 'integer', minimum: 1 });
-    expect(data.properties.request_reasons.items.$ref).toBe('#/components/schemas/WfaReason');
+    expect(data.required).toEqual(['radius_meters', 'reasons']);
+    expect(data.properties.radius_meters).toMatchObject({ type: 'integer', minimum: 1 });
+    expect(data.properties.reasons.items.$ref).toBe('#/components/schemas/WfaPublicReason');
     expect(operation.responses).toHaveProperty('500');
   });
 
@@ -35,6 +35,17 @@ describe('INF-270 public OpenAPI contract', () => {
       expect(requestSchema(member.patch).$ref).toBe('#/components/schemas/WfaReasonUpdateRequest');
     }
   );
+
+  test('documents the catalog mutation wrapper returned by controllers', () => {
+    const mutation =
+      openapi.components.responses.WfaReasonMutationResponse.content['application/json'].schema;
+
+    expect(mutation.properties.data.required).toEqual(['reason']);
+    expect(mutation.properties.data.properties.reason.$ref).toBe('#/components/schemas/WfaReason');
+    expect(openapi.components.schemas.WfaReason.required).toEqual(
+      expect.arrayContaining(['created_at', 'updated_at'])
+    );
+  });
 
   test('adds the server-owned radius to operational settings', () => {
     const settings = openapi.components.schemas.OperationalSettings;

--- a/tests/operationalSettings.test.js
+++ b/tests/operationalSettings.test.js
@@ -46,7 +46,8 @@ describe('operational settings accessor', () => {
       { setting_key: 'attendance.auto_checkout.idle_min', setting_value: '12' },
       { setting_key: 'attendance.auto_checkout.tbuffer_min', setting_value: '45' },
       { setting_key: 'attendance.auto_checkout.late_tolerance_min', setting_value: '20' },
-      { setting_key: 'checkout.fallback_time', setting_value: '18:30:00' }
+      { setting_key: 'checkout.fallback_time', setting_value: '18:30:00' },
+      { setting_key: 'wfa.request.radius_m', setting_value: '100' }
     ]);
 
     const settings = await getOperationalSettings();
@@ -65,7 +66,8 @@ describe('operational settings accessor', () => {
       autoCheckoutIdleMin: 12,
       autoCheckoutTBufferMin: 45,
       lateCheckoutToleranceMin: 20,
-      defaultShiftEnd: '18:30:00'
+      defaultShiftEnd: '18:30:00',
+      wfaRequestRadiusM: 100
     });
   });
 
@@ -124,7 +126,8 @@ describe('operational settings accessor', () => {
       autoCheckoutIdleMin: 10,
       autoCheckoutTBufferMin: 30,
       lateCheckoutToleranceMin: 15,
-      defaultShiftEnd: '17:00:00'
+      defaultShiftEnd: '17:00:00',
+      wfaRequestRadiusM: 100
     });
   });
 
@@ -134,7 +137,8 @@ describe('operational settings accessor', () => {
       autoCheckoutIdleMin: 'attendance.auto_checkout.idle_min',
       autoCheckoutTBufferMin: 'attendance.auto_checkout.tbuffer_min',
       lateCheckoutToleranceMin: 'attendance.auto_checkout.late_tolerance_min',
-      defaultShiftEnd: 'checkout.fallback_time'
+      defaultShiftEnd: 'checkout.fallback_time',
+      wfaRequestRadiusM: 'wfa.request.radius_m'
     });
 
     expect(OPERATIONAL_SETTING_DEFAULTS).toEqual({
@@ -142,7 +146,8 @@ describe('operational settings accessor', () => {
       autoCheckoutIdleMin: 10,
       autoCheckoutTBufferMin: 30,
       lateCheckoutToleranceMin: 15,
-      defaultShiftEnd: '17:00:00'
+      defaultShiftEnd: '17:00:00',
+      wfaRequestRadiusM: 100
     });
 
     expect(OPERATIONAL_SETTING_FIELDS).toEqual([
@@ -150,15 +155,20 @@ describe('operational settings accessor', () => {
       'autoCheckoutIdleMin',
       'autoCheckoutTBufferMin',
       'lateCheckoutToleranceMin',
-      'defaultShiftEnd'
+      'defaultShiftEnd',
+      'wfaRequestRadiusM'
     ]);
     expect(OPERATIONAL_SETTING_INTEGER_FIELDS).toEqual([
       'geofenceRadiusDefaultM',
       'autoCheckoutIdleMin',
       'autoCheckoutTBufferMin',
-      'lateCheckoutToleranceMin'
+      'lateCheckoutToleranceMin',
+      'wfaRequestRadiusM'
     ]);
     expect(OPERATIONAL_SETTING_TIME_FIELDS).toEqual(['defaultShiftEnd']);
+    expect(OPERATIONAL_SETTING_KEYS.wfaRequestRadiusM).toBe('wfa.request.radius_m');
+    expect(OPERATIONAL_SETTING_DEFAULTS.wfaRequestRadiusM).toBe(100);
+    expect(OPERATIONAL_SETTING_INTEGER_FIELDS).toContain('wfaRequestRadiusM');
   });
 
   it('normalizes and serializes operational setting values consistently', () => {
@@ -171,6 +181,8 @@ describe('operational settings accessor', () => {
     expect(normalizeOperationalSettingValue('defaultShiftEnd', '19:15')).toBe('19:15:00');
     expect(normalizeOperationalSettingValue('defaultShiftEnd', '19:15:30')).toBe('19:15:30');
     expect(normalizeOperationalSettingValue('defaultShiftEnd', '19')).toBeNull();
+    expect(normalizeOperationalSettingValue('wfaRequestRadiusM', '150')).toBe(150);
+    expect(normalizeOperationalSettingValue('wfaRequestRadiusM', 0)).toBeNull();
 
     expect(serializeOperationalSettingValue('autoCheckoutIdleMin', 12)).toBe('12');
     expect(serializeOperationalSettingValue('defaultShiftEnd', '19:15')).toBe('19:15:00');
@@ -188,7 +200,8 @@ describe('operational settings accessor', () => {
       autoCheckoutIdleMin: 22,
       autoCheckoutTBufferMin: 30,
       lateCheckoutToleranceMin: 15,
-      defaultShiftEnd: '19:30:00'
+      defaultShiftEnd: '19:30:00',
+      wfaRequestRadiusM: 100
     });
   });
 
@@ -215,14 +228,16 @@ describe('operational settings accessor', () => {
         { setting_key: 'attendance.auto_checkout.idle_min', setting_value: '10' },
         { setting_key: 'attendance.auto_checkout.tbuffer_min', setting_value: '30' },
         { setting_key: 'attendance.auto_checkout.late_tolerance_min', setting_value: '15' },
-        { setting_key: 'checkout.fallback_time', setting_value: '17:00:00' }
+        { setting_key: 'checkout.fallback_time', setting_value: '17:00:00' },
+        { setting_key: 'wfa.request.radius_m', setting_value: '100' }
       ])
       .mockResolvedValueOnce([
         { setting_key: 'attendance.geofence.radius_default_m', setting_value: 'not-a-number' },
         { setting_key: 'attendance.auto_checkout.idle_min', setting_value: '12' },
         { setting_key: 'attendance.auto_checkout.tbuffer_min', setting_value: '30' },
         { setting_key: 'attendance.auto_checkout.late_tolerance_min', setting_value: '15' },
-        { setting_key: 'checkout.fallback_time', setting_value: '17:00:00' }
+        { setting_key: 'checkout.fallback_time', setting_value: '17:00:00' },
+        { setting_key: 'wfa.request.radius_m', setting_value: '100' }
       ]);
 
     mockSettingsFindByPk.mockImplementation(async (settingKey) => {
@@ -273,14 +288,16 @@ describe('operational settings accessor', () => {
         { setting_key: 'attendance.auto_checkout.idle_min', setting_value: '10' },
         { setting_key: 'attendance.auto_checkout.tbuffer_min', setting_value: '30' },
         { setting_key: 'attendance.auto_checkout.late_tolerance_min', setting_value: '15' },
-        { setting_key: 'checkout.fallback_time', setting_value: '17:00:00' }
+        { setting_key: 'checkout.fallback_time', setting_value: '17:00:00' },
+        { setting_key: 'wfa.request.radius_m', setting_value: '100' }
       ])
       .mockResolvedValueOnce([
         { setting_key: 'attendance.geofence.radius_default_m', setting_value: '100' },
         { setting_key: 'attendance.auto_checkout.idle_min', setting_value: '12' },
         { setting_key: 'attendance.auto_checkout.tbuffer_min', setting_value: '30' },
         { setting_key: 'attendance.auto_checkout.late_tolerance_min', setting_value: '15' },
-        { setting_key: 'checkout.fallback_time', setting_value: '17:00:00' }
+        { setting_key: 'checkout.fallback_time', setting_value: '17:00:00' },
+        { setting_key: 'wfa.request.radius_m', setting_value: '100' }
       ]);
 
     mockSettingsFindByPk.mockImplementation(async (settingKey) => {
@@ -296,7 +313,8 @@ describe('operational settings accessor', () => {
       autoCheckoutIdleMin: 12,
       autoCheckoutTBufferMin: 30,
       lateCheckoutToleranceMin: 15,
-      defaultShiftEnd: '17:00:00'
+      defaultShiftEnd: '17:00:00',
+      wfaRequestRadiusM: 100
     });
 
     expect(existingIdleSetting.update).toHaveBeenCalledWith(
@@ -314,14 +332,16 @@ describe('operational settings accessor', () => {
         { setting_key: 'attendance.geofence.radius_default_m', setting_value: '100' },
         { setting_key: 'attendance.auto_checkout.idle_min', setting_value: '10' },
         { setting_key: 'attendance.auto_checkout.tbuffer_min', setting_value: '30' },
-        { setting_key: 'attendance.auto_checkout.late_tolerance_min', setting_value: '15' }
+        { setting_key: 'attendance.auto_checkout.late_tolerance_min', setting_value: '15' },
+        { setting_key: 'wfa.request.radius_m', setting_value: '100' }
       ])
       .mockResolvedValueOnce([
         { setting_key: 'attendance.geofence.radius_default_m', setting_value: '100' },
         { setting_key: 'attendance.auto_checkout.idle_min', setting_value: '10' },
         { setting_key: 'attendance.auto_checkout.tbuffer_min', setting_value: '30' },
         { setting_key: 'attendance.auto_checkout.late_tolerance_min', setting_value: '15' },
-        { setting_key: 'checkout.fallback_time', setting_value: '18:00:00' }
+        { setting_key: 'checkout.fallback_time', setting_value: '18:00:00' },
+        { setting_key: 'wfa.request.radius_m', setting_value: '100' }
       ]);
 
     mockSettingsFindByPk.mockResolvedValueOnce(null);
@@ -332,7 +352,8 @@ describe('operational settings accessor', () => {
       autoCheckoutIdleMin: 10,
       autoCheckoutTBufferMin: 30,
       lateCheckoutToleranceMin: 15,
-      defaultShiftEnd: '18:00:00'
+      defaultShiftEnd: '18:00:00',
+      wfaRequestRadiusM: 100
     });
 
     expect(mockSettingsCreate).toHaveBeenCalledWith(
@@ -355,14 +376,16 @@ describe('operational settings accessor', () => {
         { setting_key: 'attendance.auto_checkout.idle_min', setting_value: '10' },
         { setting_key: 'attendance.auto_checkout.tbuffer_min', setting_value: '30' },
         { setting_key: 'attendance.auto_checkout.late_tolerance_min', setting_value: '15' },
-        { setting_key: 'checkout.fallback_time', setting_value: '17:00:00' }
+        { setting_key: 'checkout.fallback_time', setting_value: '17:00:00' },
+        { setting_key: 'wfa.request.radius_m', setting_value: '100' }
       ])
       .mockResolvedValueOnce([
         { setting_key: 'attendance.geofence.radius_default_m', setting_value: '100' },
         { setting_key: 'attendance.auto_checkout.idle_min', setting_value: '10' },
         { setting_key: 'attendance.auto_checkout.tbuffer_min', setting_value: '30' },
         { setting_key: 'attendance.auto_checkout.late_tolerance_min', setting_value: '15' },
-        { setting_key: 'checkout.fallback_time', setting_value: '17:00:00' }
+        { setting_key: 'checkout.fallback_time', setting_value: '17:00:00' },
+        { setting_key: 'wfa.request.radius_m', setting_value: '100' }
       ]);
 
     await expect(
@@ -372,7 +395,8 @@ describe('operational settings accessor', () => {
       autoCheckoutIdleMin: 10,
       autoCheckoutTBufferMin: 30,
       lateCheckoutToleranceMin: 15,
-      defaultShiftEnd: '17:00:00'
+      defaultShiftEnd: '17:00:00',
+      wfaRequestRadiusM: 100
     });
 
     expect(mockSettingsFindByPk).not.toHaveBeenCalled();

--- a/tests/resolveWfaBookingsJobIdempotency.test.js
+++ b/tests/resolveWfaBookingsJobIdempotency.test.js
@@ -207,6 +207,7 @@ describe('resolveWfaBookings job idempotency and batching', () => {
         updated_at: expect.any(Date)
       })
     );
+    expect(expiredBooking.update.mock.calls[0][0]).not.toHaveProperty('rejection_reason_id');
     expect(result).toEqual({ success: false, error: 'bulk insert failed' });
   });
 

--- a/tests/settingsOperationalRoutesContract.test.js
+++ b/tests/settingsOperationalRoutesContract.test.js
@@ -59,6 +59,7 @@ const buildOperationalSettings = (overrides = {}) => ({
   autoCheckoutTBufferMin: 30,
   lateCheckoutToleranceMin: 15,
   defaultShiftEnd: '17:00:00',
+  wfaRequestRadiusM: 100,
   ...overrides
 });
 
@@ -152,6 +153,20 @@ describe('settings operational routes contract', () => {
     );
   });
 
+  it('allows management to update the global WFA request radius', async () => {
+    currentRole = 'Management';
+    const payload = { wfaRequestRadiusM: 150 };
+    mockUpdateOperationalSettings.mockResolvedValue(
+      buildOperationalSettings({ wfaRequestRadiusM: 150 })
+    );
+
+    const res = await request(scopedApp).patch('/api/settings/operational').send(payload);
+
+    expect(res.status).toBe(200);
+    expect(mockUpdateOperationalSettings).toHaveBeenCalledWith(payload);
+    expect(res.body.wfaRequestRadiusM).toBe(150);
+  });
+
   it('returns 401 when authentication fails before the handler', async () => {
     mockVerifyToken.mockImplementationOnce((_req, res, _next) => {
       res.status(401).json({ message: 'Invalid token' });
@@ -235,6 +250,22 @@ describe('settings operational routes contract', () => {
         code: 'E_VALIDATION',
         message: 'autoCheckoutIdleMin must be a positive integer',
         errors: expect.any(Array)
+      })
+    );
+  });
+
+  it.each([0, -1, 1.5])('rejects invalid WFA radius value %p', async (value) => {
+    const res = await request(scopedApp)
+      .patch('/api/settings/operational')
+      .send({ wfaRequestRadiusM: value });
+
+    expect(res.status).toBe(400);
+    expect(mockUpdateOperationalSettings).not.toHaveBeenCalled();
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        success: false,
+        code: 'E_VALIDATION',
+        message: 'wfaRequestRadiusM must be a positive integer'
       })
     );
   });

--- a/tests/wfaPolicyMigration.test.js
+++ b/tests/wfaPolicyMigration.test.js
@@ -1,0 +1,111 @@
+import { createRequire } from 'node:module';
+import { jest } from '@jest/globals';
+import { DataTypes, Op } from 'sequelize';
+
+const require = createRequire(import.meta.url);
+let migration = null;
+
+try {
+  migration = require('../src/models/migrations/20260728010000-add-wfa-request-policy.cjs');
+} catch (error) {
+  if (error.code !== 'MODULE_NOT_FOUND') throw error;
+}
+
+const Sequelize = { ...DataTypes, Op };
+
+describe('INF-270 WFA policy migration', () => {
+  it('adds reason catalogs, defaults, booking fields, indexes, and restrictive foreign keys', async () => {
+    expect(migration).not.toBeNull();
+
+    const queryInterface = {
+      sequelize: {
+        query: jest.fn().mockResolvedValue([[]]),
+        transaction: jest.fn(async (callback) => callback({ id: 'transaction' }))
+      },
+      bulkInsert: jest.fn().mockResolvedValue(undefined),
+      createTable: jest.fn().mockResolvedValue(undefined),
+      addColumn: jest.fn().mockResolvedValue(undefined),
+      addIndex: jest.fn().mockResolvedValue(undefined),
+      addConstraint: jest.fn().mockResolvedValue(undefined)
+    };
+
+    await migration.up(queryInterface, Sequelize);
+
+    expect(queryInterface.bulkInsert).toHaveBeenCalledWith(
+      'settings',
+      expect.arrayContaining([
+        expect.objectContaining({ setting_key: 'wfa.request.radius_m', setting_value: '100' })
+      ]),
+      expect.objectContaining({ transaction: expect.any(Object) })
+    );
+    expect(queryInterface.createTable).toHaveBeenCalledWith(
+      'wfa_request_reasons',
+      expect.any(Object),
+      expect.objectContaining({ transaction: expect.any(Object) })
+    );
+    expect(queryInterface.createTable).toHaveBeenCalledWith(
+      'wfa_rejection_reasons',
+      expect.any(Object),
+      expect.objectContaining({ transaction: expect.any(Object) })
+    );
+    expect(queryInterface.addColumn.mock.calls.map((call) => call[1])).toEqual([
+      'request_reason_id',
+      'request_other_reason',
+      'rejection_reason_id',
+      'rejection_note',
+      'radius_snapshot'
+    ]);
+    expect(queryInterface.addIndex).toHaveBeenCalledTimes(2);
+    expect(queryInterface.addConstraint).toHaveBeenCalledWith(
+      'bookings',
+      expect.objectContaining({
+        fields: ['request_reason_id'],
+        type: 'foreign key',
+        onDelete: 'RESTRICT'
+      })
+    );
+    expect(queryInterface.addConstraint).toHaveBeenCalledWith(
+      'bookings',
+      expect.objectContaining({
+        fields: ['rejection_reason_id'],
+        type: 'foreign key',
+        onDelete: 'RESTRICT'
+      })
+    );
+  });
+
+  it('removes only INF-270 fields on rollback and leaves legacy rejection_reason alone', async () => {
+    expect(migration).not.toBeNull();
+
+    const queryInterface = {
+      sequelize: {
+        transaction: jest.fn(async (callback) => callback({ id: 'transaction' }))
+      },
+      removeConstraint: jest.fn().mockResolvedValue(undefined),
+      removeIndex: jest.fn().mockResolvedValue(undefined),
+      removeColumn: jest.fn().mockResolvedValue(undefined),
+      dropTable: jest.fn().mockResolvedValue(undefined),
+      bulkDelete: jest.fn().mockResolvedValue(undefined)
+    };
+
+    await migration.down(queryInterface, Sequelize);
+
+    const removedColumns = queryInterface.removeColumn.mock.calls.map((call) => call[1]);
+    expect(removedColumns).toEqual([
+      'radius_snapshot',
+      'rejection_note',
+      'rejection_reason_id',
+      'request_other_reason',
+      'request_reason_id'
+    ]);
+    expect(removedColumns).not.toContain('rejection_reason');
+    expect(queryInterface.bulkDelete).toHaveBeenCalledWith(
+      'settings',
+      {
+        setting_key: 'wfa.request.radius_m',
+        description: '[INF-270] Global radius in meters for WFA booking requests.'
+      },
+      expect.objectContaining({ transaction: expect.any(Object) })
+    );
+  });
+});

--- a/tests/wfaRequestConfigContract.test.js
+++ b/tests/wfaRequestConfigContract.test.js
@@ -1,0 +1,94 @@
+import express from 'express';
+import { jest } from '@jest/globals';
+import request from 'supertest';
+
+const mockReadWfaRequestConfig = jest.fn();
+const mockVerifyToken = jest.fn((req, _res, next) => {
+  req.user = { id: 1, role_name: 'User' };
+  next();
+});
+
+jest.unstable_mockModule('../src/services/wfaSettings.service.js', () => ({
+  readWfaRequestConfig: mockReadWfaRequestConfig,
+  listWfaReasons: jest.fn(),
+  createWfaReason: jest.fn(),
+  updateWfaReason: jest.fn()
+}));
+jest.unstable_mockModule('../src/middlewares/authJwt.js', () => ({ verifyToken: mockVerifyToken }));
+jest.unstable_mockModule('../src/controllers/wfa.controller.js', () => ({
+  getWfaRecommendations: jest.fn(),
+  getWfaAhpConfig: jest.fn(),
+  testFuzzyAhp: jest.fn()
+}));
+
+const { default: wfaRoutes } = await import('../src/routes/wfa.routes.js');
+const { errorHandler } = await import('../src/middlewares/errorHandler.js');
+
+const app = express();
+app.use(express.json());
+app.use('/api/wfa', wfaRoutes);
+app.use(errorHandler);
+
+describe('GET /api/wfa/request-config', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockReadWfaRequestConfig.mockResolvedValue({
+      radiusMeters: 100,
+      reasons: [
+        { id: 1, label: 'Pertemuan dengan klien', isOther: false, sortOrder: 10 }
+      ]
+    });
+  });
+
+  it('requires an authenticated session and returns the employee config projection', async () => {
+    const res = await request(app).get('/api/wfa/request-config');
+
+    expect(res.status).toBe(200);
+    expect(mockVerifyToken).toHaveBeenCalled();
+    expect(mockReadWfaRequestConfig).toHaveBeenCalledTimes(1);
+    expect(res.body).toEqual({
+      success: true,
+      data: {
+        radius_meters: 100,
+        reasons: [
+          {
+            id: 1,
+            label: 'Pertemuan dengan klien',
+            is_other: false,
+            sort_order: 10
+          }
+        ]
+      }
+    });
+  });
+
+  it('does not call the service when authentication fails', async () => {
+    mockVerifyToken.mockImplementationOnce((_req, res, _next) => {
+      res.status(401).json({ success: false, code: 'E_UNAUTHORIZED' });
+    });
+
+    const res = await request(app).get('/api/wfa/request-config');
+
+    expect(res.status).toBe(401);
+    expect(mockReadWfaRequestConfig).not.toHaveBeenCalled();
+  });
+
+  it('forwards stable service failures to the shared error handler', async () => {
+    mockReadWfaRequestConfig.mockRejectedValueOnce(
+      Object.assign(new Error('Konfigurasi WFA belum tersedia.'), {
+        status: 500,
+        code: 'WFA_CONFIG_UNAVAILABLE',
+        details: []
+      })
+    );
+
+    const res = await request(app).get('/api/wfa/request-config');
+
+    expect(res.status).toBe(500);
+    expect(res.body).toMatchObject({
+      success: false,
+      code: 'WFA_CONFIG_UNAVAILABLE',
+      message: 'Konfigurasi WFA belum tersedia.'
+    });
+  });
+});

--- a/tests/wfaSettingsModels.test.js
+++ b/tests/wfaSettingsModels.test.js
@@ -1,0 +1,19 @@
+import * as models from '../src/models/index.js';
+
+describe('WFA policy persistence models', () => {
+  it('exports both reason catalogs and keeps the legacy booking rejection field', () => {
+    expect(models).toHaveProperty('WfaRequestReason');
+    expect(models).toHaveProperty('WfaRejectionReason');
+    expect(models.Booking.rawAttributes).toHaveProperty('request_reason_id');
+    expect(models.Booking.rawAttributes).toHaveProperty('request_other_reason');
+    expect(models.Booking.rawAttributes).toHaveProperty('rejection_reason_id');
+    expect(models.Booking.rawAttributes).toHaveProperty('rejection_note');
+    expect(models.Booking.rawAttributes).toHaveProperty('radius_snapshot');
+    expect(models.Booking.rawAttributes).toHaveProperty('rejection_reason');
+  });
+
+  it('registers stable booking association aliases for both catalogs', () => {
+    expect(models.Booking.associations).toHaveProperty('request_reason');
+    expect(models.Booking.associations).toHaveProperty('rejection_reason_detail');
+  });
+});

--- a/tests/wfaSettingsRoutesContract.test.js
+++ b/tests/wfaSettingsRoutesContract.test.js
@@ -1,0 +1,161 @@
+import express from 'express';
+import { jest } from '@jest/globals';
+import request from 'supertest';
+
+let currentRole = 'Admin';
+const mockVerifyToken = jest.fn((req, _res, next) => {
+  req.user = { id: 1, role_name: currentRole };
+  next();
+});
+const mockRoleGuard = (allowedRoles) => (req, res, next) => {
+  if (!allowedRoles.includes(currentRole)) {
+    return res.status(403).json({ success: false, code: 'E_FORBIDDEN' });
+  }
+  next();
+};
+
+const mockListWfaReasons = jest.fn();
+const mockCreateWfaReason = jest.fn();
+const mockUpdateWfaReason = jest.fn();
+
+jest.unstable_mockModule('../src/middlewares/authJwt.js', () => ({ verifyToken: mockVerifyToken }));
+jest.unstable_mockModule('../src/middlewares/roleGuard.js', () => ({
+  __esModule: true,
+  default: mockRoleGuard
+}));
+jest.unstable_mockModule('../src/services/wfaSettings.service.js', () => ({
+  readWfaRequestConfig: jest.fn(),
+  listWfaReasons: mockListWfaReasons,
+  createWfaReason: mockCreateWfaReason,
+  updateWfaReason: mockUpdateWfaReason
+}));
+
+const { default: settingsRoutes } = await import('../src/routes/settings.routes.js');
+const { errorHandler } = await import('../src/middlewares/errorHandler.js');
+
+const app = express();
+app.use(express.json());
+app.use('/api/settings', settingsRoutes);
+app.use(errorHandler);
+
+const requestReason = {
+  id: 1,
+  label: 'Pertemuan dengan klien',
+  is_active: true,
+  is_other: false,
+  sort_order: 10,
+  created_at: new Date('2026-07-28T00:00:00.000Z'),
+  updated_at: new Date('2026-07-28T00:00:00.000Z')
+};
+
+describe('WFA management reason catalog routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    currentRole = 'Admin';
+    mockListWfaReasons.mockResolvedValue([requestReason]);
+    mockCreateWfaReason.mockResolvedValue(requestReason);
+    mockUpdateWfaReason.mockResolvedValue({ ...requestReason, is_active: false });
+  });
+
+  it.each([
+    ['request', '/api/settings/wfa/request-reasons'],
+    ['rejection', '/api/settings/wfa/rejection-reasons']
+  ])('lists active and inactive %s reasons for management configuration', async (catalog, path) => {
+    currentRole = 'Management';
+
+    const res = await request(app).get(path);
+
+    expect(res.status).toBe(200);
+    expect(mockVerifyToken).toHaveBeenCalled();
+    expect(mockListWfaReasons).toHaveBeenCalledWith({ catalog, includeInactive: true });
+    expect(res.body).toEqual({
+      success: true,
+      data: {
+        reasons: [
+          {
+            id: 1,
+            label: 'Pertemuan dengan klien',
+            is_active: true,
+            is_other: false,
+            sort_order: 10,
+            created_at: '2026-07-28T00:00:00.000Z',
+            updated_at: '2026-07-28T00:00:00.000Z'
+          }
+        ]
+      }
+    });
+  });
+
+  it.each([
+    ['request', '/api/settings/wfa/request-reasons'],
+    ['rejection', '/api/settings/wfa/rejection-reasons']
+  ])('creates a normalized %s reason', async (catalog, path) => {
+    const payload = { label: 'Kunjungan operasional', is_other: false, sort_order: 30 };
+
+    const res = await request(app).post(path).send(payload);
+
+    expect(res.status).toBe(201);
+    expect(mockCreateWfaReason).toHaveBeenCalledWith({ catalog, payload });
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.reason.id).toBe(1);
+  });
+
+  it.each([
+    ['request', '/api/settings/wfa/request-reasons/1'],
+    ['rejection', '/api/settings/wfa/rejection-reasons/1']
+  ])('updates mutable %s reason fields', async (catalog, path) => {
+    const payload = { is_active: false, sort_order: 50 };
+
+    const res = await request(app).patch(path).send(payload);
+
+    expect(res.status).toBe(200);
+    expect(mockUpdateWfaReason).toHaveBeenCalledWith({ catalog, id: 1, payload });
+    expect(res.body.data.reason.is_active).toBe(false);
+  });
+
+  it('rejects invalid create and immutable Other updates before the service', async () => {
+    const invalidCreate = await request(app)
+      .post('/api/settings/wfa/request-reasons')
+      .send({ label: '', sort_order: -1 });
+    const immutablePatch = await request(app)
+      .patch('/api/settings/wfa/request-reasons/1')
+      .send({ is_other: true });
+
+    expect(invalidCreate.status).toBe(400);
+    expect(immutablePatch.status).toBe(400);
+    expect(mockCreateWfaReason).not.toHaveBeenCalled();
+    expect(mockUpdateWfaReason).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid ids and empty patch bodies', async () => {
+    const invalidId = await request(app)
+      .patch('/api/settings/wfa/rejection-reasons/not-a-number')
+      .send({ is_active: false });
+    const emptyPatch = await request(app)
+      .patch('/api/settings/wfa/rejection-reasons/1')
+      .send({});
+
+    expect(invalidId.status).toBe(400);
+    expect(emptyPatch.status).toBe(400);
+    expect(mockUpdateWfaReason).not.toHaveBeenCalled();
+  });
+
+  it('reuses Admin/Management authorization and denies User', async () => {
+    currentRole = 'User';
+
+    const res = await request(app).get('/api/settings/wfa/request-reasons');
+
+    expect(res.status).toBe(403);
+    expect(mockListWfaReasons).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    '/api/settings/wfa/request-reasons/1',
+    '/api/settings/wfa/rejection-reasons/1'
+  ])('does not expose a DELETE route at %s', async (path) => {
+    const res = await request(app).delete(path);
+
+    expect(res.status).toBe(404);
+    expect(mockUpdateWfaReason).not.toHaveBeenCalled();
+  });
+});

--- a/tests/wfaSettingsService.test.js
+++ b/tests/wfaSettingsService.test.js
@@ -1,0 +1,259 @@
+import { jest } from '@jest/globals';
+
+const mockGetOperationalSettingsStrict = jest.fn();
+const mockRequestFindAll = jest.fn();
+const mockRequestFindByPk = jest.fn();
+const mockRequestFindOne = jest.fn();
+const mockRequestCreate = jest.fn();
+const mockRejectionFindAll = jest.fn();
+const mockRejectionFindByPk = jest.fn();
+const mockRejectionFindOne = jest.fn();
+const mockRejectionCreate = jest.fn();
+
+jest.unstable_mockModule('../src/utils/settings.js', () => ({
+  getOperationalSettingsStrict: mockGetOperationalSettingsStrict
+}));
+
+jest.unstable_mockModule('../src/models/index.js', () => ({
+  WfaRequestReason: {
+    findAll: mockRequestFindAll,
+    findByPk: mockRequestFindByPk,
+    findOne: mockRequestFindOne,
+    create: mockRequestCreate
+  },
+  WfaRejectionReason: {
+    findAll: mockRejectionFindAll,
+    findByPk: mockRejectionFindByPk,
+    findOne: mockRejectionFindOne,
+    create: mockRejectionCreate
+  }
+}));
+
+const {
+  readWfaRequestConfig,
+  resolveActiveWfaRequestReason,
+  resolveActiveWfaRejectionReason,
+  listWfaReasons,
+  createWfaReason,
+  updateWfaReason
+} = await import('../src/services/wfaSettings.service.js');
+
+describe('WFA settings service', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('reads strict radius and projects only active request reasons in stable order', async () => {
+    const transaction = { id: 'tx' };
+    mockGetOperationalSettingsStrict.mockResolvedValue({ wfaRequestRadiusM: 100 });
+    mockRequestFindAll.mockResolvedValue([
+      { id: 1, label: 'Pertemuan dengan klien', is_other: false, sort_order: 10 }
+    ]);
+
+    await expect(readWfaRequestConfig(transaction)).resolves.toEqual({
+      radiusMeters: 100,
+      reasons: [
+        { id: 1, label: 'Pertemuan dengan klien', isOther: false, sortOrder: 10 }
+      ]
+    });
+    expect(mockRequestFindAll).toHaveBeenCalledWith({
+      where: { is_active: true },
+      order: [
+        ['sort_order', 'ASC'],
+        ['id', 'ASC']
+      ],
+      transaction
+    });
+  });
+
+  it('maps strict operational setting failures to a stable WFA configuration error', async () => {
+    mockGetOperationalSettingsStrict.mockRejectedValue(
+      Object.assign(new Error('raw settings details'), { code: 'E_OPERATIONAL_SETTINGS_INVALID' })
+    );
+    mockRequestFindAll.mockResolvedValue([]);
+
+    await expect(readWfaRequestConfig()).rejects.toMatchObject({
+      status: 500,
+      code: 'WFA_CONFIG_UNAVAILABLE',
+      details: []
+    });
+  });
+
+  it.each([
+    [null, 'WFA_REQUEST_REASON_REQUIRED'],
+    [undefined, 'WFA_REQUEST_REASON_REQUIRED']
+  ])('requires a request reason id (%p)', async (reasonId, code) => {
+    await expect(resolveActiveWfaRequestReason({ reasonId })).rejects.toMatchObject({
+      status: 400,
+      code
+    });
+  });
+
+  it('rejects a request reason that does not exist', async () => {
+    mockRequestFindByPk.mockResolvedValue(null);
+
+    await expect(
+      resolveActiveWfaRequestReason({ reasonId: 99, otherReasonText: null })
+    ).rejects.toMatchObject({
+      status: 400,
+      code: 'WFA_REQUEST_REASON_NOT_FOUND'
+    });
+  });
+
+  it('rejects an inactive request reason', async () => {
+    mockRequestFindByPk.mockResolvedValue({ id: 3, is_active: false, is_other: false });
+
+    await expect(resolveActiveWfaRequestReason({ reasonId: 3 })).rejects.toMatchObject({
+      status: 400,
+      code: 'WFA_REQUEST_REASON_NOT_ACTIVE'
+    });
+  });
+
+  it('requires trimmed text for an Other request reason', async () => {
+    mockRequestFindByPk.mockResolvedValue({ id: 4, is_active: true, is_other: true });
+
+    await expect(
+      resolveActiveWfaRequestReason({ reasonId: 4, otherReasonText: '   ' })
+    ).rejects.toMatchObject({
+      status: 400,
+      code: 'WFA_OTHER_REASON_REQUIRED'
+    });
+  });
+
+  it('normalizes request Other text only when the selected reason is Other', async () => {
+    const reason = { id: 4, is_active: true, is_other: true };
+    mockRequestFindByPk.mockResolvedValueOnce(reason).mockResolvedValueOnce({
+      id: 1,
+      is_active: true,
+      is_other: false
+    });
+
+    await expect(
+      resolveActiveWfaRequestReason({ reasonId: 4, otherReasonText: '  Keperluan khusus  ' })
+    ).resolves.toEqual({ reason, normalizedOtherReason: 'Keperluan khusus' });
+    await expect(
+      resolveActiveWfaRequestReason({ reasonId: 1, otherReasonText: 'ignored' })
+    ).resolves.toMatchObject({ normalizedOtherReason: null });
+  });
+
+  it('requires an active rejection reason and a note for Other', async () => {
+    mockRejectionFindByPk
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ id: 3, is_active: false, is_other: false })
+      .mockResolvedValueOnce({ id: 5, is_active: true, is_other: true });
+
+    await expect(resolveActiveWfaRejectionReason({ reasonId: null })).rejects.toMatchObject({
+      code: 'REJECTION_REASON_REQUIRED'
+    });
+    await expect(resolveActiveWfaRejectionReason({ reasonId: 99 })).rejects.toMatchObject({
+      code: 'REJECTION_REASON_NOT_FOUND'
+    });
+    await expect(resolveActiveWfaRejectionReason({ reasonId: 3 })).rejects.toMatchObject({
+      code: 'REJECTION_REASON_NOT_ACTIVE'
+    });
+    await expect(
+      resolveActiveWfaRejectionReason({ reasonId: 5, note: '' })
+    ).rejects.toMatchObject({ code: 'REJECTION_NOTE_REQUIRED' });
+  });
+
+  it('normalizes optional rejection notes', async () => {
+    const reason = { id: 2, is_active: true, is_other: false };
+    mockRejectionFindByPk.mockResolvedValue(reason);
+
+    await expect(
+      resolveActiveWfaRejectionReason({ reasonId: 2, note: '  Konteks tambahan  ' })
+    ).resolves.toEqual({ reason, normalizedNote: 'Konteks tambahan' });
+  });
+
+  it('lists the selected catalog with optional inactive rows', async () => {
+    mockRequestFindAll.mockResolvedValue([{ id: 1 }]);
+
+    await expect(
+      listWfaReasons({ catalog: 'request', includeInactive: true })
+    ).resolves.toEqual([{ id: 1 }]);
+    expect(mockRequestFindAll).toHaveBeenCalledWith({
+      where: {},
+      order: [
+        ['sort_order', 'ASC'],
+        ['id', 'ASC']
+      ],
+      transaction: null
+    });
+  });
+
+  it('rejects a second Other row in the same catalog', async () => {
+    mockRequestFindOne.mockResolvedValue({ id: 4, is_other: true });
+
+    await expect(
+      createWfaReason({
+        catalog: 'request',
+        payload: { label: 'Lain lagi', is_other: true, sort_order: 1000 }
+      })
+    ).rejects.toMatchObject({
+      status: 409,
+      code: 'WFA_REASON_CATALOG_CONFLICT'
+    });
+    expect(mockRequestCreate).not.toHaveBeenCalled();
+  });
+
+  it('creates a normalized catalog row', async () => {
+    const created = { id: 10 };
+    mockRejectionCreate.mockResolvedValue(created);
+
+    await expect(
+      createWfaReason({
+        catalog: 'rejection',
+        payload: { label: '  Kebijakan lain  ', is_other: false, sort_order: 25 }
+      })
+    ).resolves.toBe(created);
+    expect(mockRejectionCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        label: 'Kebijakan lain',
+        is_active: true,
+        is_other: false,
+        sort_order: 25,
+        created_at: expect.any(Date),
+        updated_at: expect.any(Date)
+      }),
+      { transaction: null }
+    );
+  });
+
+  it('updates only mutable catalog fields and preserves fixed is_other semantics', async () => {
+    const update = jest.fn().mockResolvedValue(undefined);
+    const reason = { id: 7, is_other: true, update };
+    mockRequestFindByPk.mockResolvedValue(reason);
+
+    await expect(
+      updateWfaReason({
+        catalog: 'request',
+        id: 7,
+        payload: { label: '  Lainnya terbaru ', is_active: false, sort_order: 900 }
+      })
+    ).resolves.toBe(reason);
+    expect(update).toHaveBeenCalledWith(
+      {
+        label: 'Lainnya terbaru',
+        is_active: false,
+        sort_order: 900,
+        updated_at: expect.any(Date)
+      },
+      { transaction: null }
+    );
+
+    await expect(
+      updateWfaReason({ catalog: 'request', id: 7, payload: { is_other: false } })
+    ).rejects.toMatchObject({ code: 'WFA_REASON_CATALOG_CONFLICT' });
+  });
+
+  it.each([
+    [{ label: '   ' }, 'label'],
+    [{ label: 'x'.repeat(121) }, 'label'],
+    [{ label: 'Valid', sort_order: -1 }, 'sort_order'],
+    [{ label: 'Valid', is_active: 'yes' }, 'is_active']
+  ])('rejects invalid catalog payload %p', async (payload, field) => {
+    await expect(
+      createWfaReason({ catalog: 'request', payload })
+    ).rejects.toMatchObject({ status: 400, code: 'E_VALIDATION', details: [{ field, code: 'E_VALIDATION' }] });
+  });
+});


### PR DESCRIPTION
## Summary

Implements the approved INF-270 design and implementation plan:

- adds backend-authoritative `wfa.request.radius_m` to operational settings
- adds request/rejection reason catalogs with CRUD-lite Admin/Management routes and no DELETE path
- adds authenticated employee WFA request configuration
- hardens booking creation with strict ISO/WIB date checks, authenticated identity, server-owned radius/suitability/status, and request reasons
- requires structured rejection reasons and exposes stable reason/radius projections on booking reads
- adds the additive migration, OpenAPI contract, and focused regression coverage

Primary Linear issue: [INF-270](https://linear.app/infinite-track-palu/issue/INF-270/backend-add-global-wfa-policy-request-reasons-and-rejection-reasons)

## Architecture and contract impact

- Backend remains the source of truth for WFA radius, suitability, request identity, and booking state.
- Existing `rejection_reason` remains untouched; new structured fields are additive and nullable for legacy rows.
- Reason deletion is intentionally unsupported; catalogs use activation/deactivation.
- Android/Web clients should consume `GET /api/wfa/request-config` and the reason projections after the backend migration is deployed.
- Attendance final-state logic is unchanged.
- Auth/session middleware is unchanged.
- Existing Admin/Management role semantics are reused.
- The nightly booking resolver remains unchanged and is regression-tested.
- WIB date behavior is covered by booking policy tests.

## Verification

- `npm run lint` — PASS
- `npm test -- --runInBand` — PASS (135 suites, 1273 tests)
- focused OpenAPI/runtime contract tests — PASS
- `git diff --check` — PASS

## Needs Verification

- Disposable-MySQL migration up/status/data inspection was not run: this isolated worktree has no database configuration, `npm run migrate:status` cannot connect, and the local Docker Desktop engine is unavailable.
- Authenticated end-to-end API smoke scenarios were not run for the same reason.
- Production deployment and client rollout are not proven by this PR.

Before marking INF-270 complete, run the plan's disposable-DB migration checks and authenticated smoke matrix, including radius override proof, normal/Other request reasons, approve/reject flows, and negative auth/RBAC cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added server-managed WFA radius and request/rejection reason catalogs.
  * Added an endpoint to retrieve active WFA request configuration.
  * Added management endpoints to list, create, and update WFA reasons.
  * Booking responses now include reason details, location data, and captured radius information.
  * Rejections now support structured reasons and notes.

* **Bug Fixes**
  * Enforced strict calendar-valid `YYYY-MM-DD` booking dates.
  * Improved validation and standardized WFA configuration errors.
  * Ensured suitability and radius values are determined consistently by the server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->