### PR TITLE
fix(INF-274): standardize management booking pagination envelope

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -3392,7 +3392,7 @@ paths:
                         items:
                           $ref: '#/components/schemas/BookingManagementItem'
                       pagination:
-                        $ref: '#/components/schemas/Pagination'
+                        $ref: '#/components/schemas/BookingManagementPagination'
                   message:
                     type: string
                     example: Daftar booking berhasil diambil
@@ -7841,6 +7841,48 @@ components:
           minimum: 1
           nullable: true
           description: Server-owned WFA radius captured at booking submission; legacy rows may fall back to location radius.
+
+    BookingManagementPagination:
+      type: object
+      required: [current_page, total_pages, total_records, records_per_page, has_next_page, has_prev_page, total_items, items_per_page]
+      properties:
+        current_page:
+          type: integer
+          minimum: 1
+          example: 2
+        total_pages:
+          type: integer
+          minimum: 0
+          example: 3
+        total_records:
+          type: integer
+          minimum: 0
+          example: 11
+        records_per_page:
+          type: integer
+          minimum: 1
+          maximum: 100
+          example: 5
+        has_next_page:
+          type: boolean
+          example: true
+        has_prev_page:
+          type: boolean
+          example: true
+        total_items:
+          type: integer
+          minimum: 0
+          deprecated: true
+          description: Deprecated compatibility alias for total_records.
+          example: 11
+        items_per_page:
+          type: integer
+          minimum: 1
+          maximum: 100
+          deprecated: true
+          description: Deprecated compatibility alias for records_per_page.
+          example: 5
+
     Booking:
       type: object
       properties:

--- a/docs/superpowers/plans/2026-08-10-inf-274-management-booking-pagination-envelope.md
+++ b/docs/superpowers/plans/2026-08-10-inf-274-management-booking-pagination-envelope.md
@@ -1,0 +1,212 @@
+# Management Booking Pagination Envelope Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Standardize `GET /api/bookings` pagination metadata with canonical Management Attendance field names while preserving INF-274 compatibility aliases.
+
+**Architecture:** Keep the existing route → controller → `listManagementBookings` read-service path unchanged. Modify only the booking read-service pagination projection and publish a booking-specific OpenAPI pagination schema; controller remains a pass-through adapter.
+
+**Tech Stack:** Node.js ESM, Express, Sequelize, Jest 29, YAML OpenAPI 3.x, ESLint.
+
+## Global Constraints
+
+- Base contract is `origin/develop` after PR #136 (`cfdaed1`).
+- Preserve server-side `page` / `limit` validation and query semantics.
+- Preserve `total_items` and `items_per_page` as deprecated aliases.
+- Add `total_records`, `records_per_page`, `has_next_page`, and `has_prev_page` as canonical fields.
+- Do not change search, filters, ordering, approval/rejection, scoring, auth, models, or migrations.
+- Do not mutate the shared OpenAPI `Pagination` schema.
+
+---
+### Task 1: Lock and implement the runtime pagination envelope
+
+**Files:**
+- Modify: `tests/bookingManagementReadService.test.js`
+- Modify: `tests/bookingManagementController.test.js`
+- Modify: `src/modules/booking/bookingManagementRead.service.js`
+
+**Interfaces:**
+- Consumes: validated `{ page?: number, limit?: number, ...filters }` query.
+- Produces: `{ bookings, pagination }` where `pagination` contains eight fields: six canonical fields plus two compatibility aliases.
+
+- [ ] **Step 1: Write failing read-service tests**
+
+For `count: 11`, `page: 2`, `limit: 5`, expect:
+```js
+pagination: {
+  current_page: 2,
+  total_pages: 3,
+  total_records: 11,
+  records_per_page: 5,
+  has_next_page: true,
+  has_prev_page: true,
+  total_items: 11,
+  items_per_page: 5
+}
+```
+
+For `count: 0`, default page/limit, expect `total_pages: 0`, both navigation booleans `false`, and both alias pairs equal.
+- [ ] **Step 2: Run the focused read-service test and verify RED**
+
+Run:
+```powershell
+npm test -- --runInBand tests/bookingManagementReadService.test.js
+```
+Expected: FAIL because canonical fields and navigation booleans are absent.
+
+- [ ] **Step 3: Implement the minimal read-service projection**
+
+Compute `totalPages` once, then return:
+```js
+pagination: {
+  current_page: page,
+  total_pages: totalPages,
+  total_records: count,
+  records_per_page: limit,
+  has_next_page: page < totalPages,
+  has_prev_page: totalPages > 0 && page > 1,
+  total_items: count,
+  items_per_page: limit
+}
+```
+
+- [ ] **Step 4: Update the controller contract fixture**
+
+Change only the mocked/expected pagination object in `bookingManagementController.test.js`; controller implementation should remain unchanged.
+
+- [ ] **Step 5: Run focused runtime tests and verify GREEN**
+
+Run:
+```powershell
+npm test -- --runInBand tests/bookingManagementReadService.test.js tests/bookingManagementController.test.js
+```
+Expected: both suites PASS.
+- [ ] **Step 6: Commit runtime contract**
+
+```powershell
+git add src/modules/booking/bookingManagementRead.service.js tests/bookingManagementReadService.test.js tests/bookingManagementController.test.js
+git commit -m "fix(INF-274): standardize booking pagination envelope"
+```
+
+### Task 2: Publish the booking-specific OpenAPI pagination schema
+
+**Files:**
+- Modify: `docs/openapi.yaml`
+- Modify: `tests/bookingManagementOpenApiContract.test.js`
+
+**Interfaces:**
+- Consumes: runtime pagination object from Task 1.
+- Produces: `#/components/schemas/BookingManagementPagination`, referenced by `GET /api/bookings`.
+
+- [ ] **Step 1: Write failing OpenAPI contract assertions**
+
+Assert that the 200 response pagination `$ref` is:
+```js
+'#/components/schemas/BookingManagementPagination'
+```
+
+Assert the schema requires:
+```js
+[
+  'current_page', 'total_pages', 'total_records', 'records_per_page',
+  'has_next_page', 'has_prev_page', 'total_items', 'items_per_page'
+]
+```
+and that `total_items.deprecated === true` and `items_per_page.deprecated === true`.
+- [ ] **Step 2: Run the focused OpenAPI test and verify RED**
+
+Run:
+```powershell
+npm test -- --runInBand tests/bookingManagementOpenApiContract.test.js
+```
+Expected: FAIL because `/api/bookings` still references shared `Pagination` and the booking-specific schema does not exist.
+
+- [ ] **Step 3: Add `BookingManagementPagination` to OpenAPI**
+
+Define an object schema with all eight required fields. Use integer types for counts/pages, boolean types for navigation flags, and mark only `total_items` and `items_per_page` as `deprecated: true` with descriptions pointing consumers to their canonical replacements.
+
+- [ ] **Step 4: Repoint `GET /api/bookings` pagination reference**
+
+Replace only:
+```yaml
+pagination:
+  $ref: '#/components/schemas/Pagination'
+```
+inside `GET /api/bookings` with:
+```yaml
+pagination:
+  $ref: '#/components/schemas/BookingManagementPagination'
+```
+Do not change other endpoints using the shared schema.
+
+- [ ] **Step 5: Run OpenAPI and runtime drift tests**
+
+Run:
+```powershell
+npm test -- --runInBand tests/bookingManagementOpenApiContract.test.js tests/openApiRuntimeDriftContract.test.js
+```
+Expected: both suites PASS.
+- [ ] **Step 6: Commit OpenAPI contract**
+
+```powershell
+git add docs/openapi.yaml tests/bookingManagementOpenApiContract.test.js
+git commit -m "docs(INF-274): publish booking pagination contract"
+```
+
+### Task 3: Final regression, branch audit, and PR
+
+**Files:**
+- Verify all files changed by Tasks 1-2 plus spec/plan docs.
+
+**Interfaces:**
+- Produces: a clean branch ready for review against `refs/remotes/origin/develop`.
+
+- [ ] **Step 1: Run focused Management Booking regression**
+
+```powershell
+npm test -- --runInBand tests/bookingManagementReadService.test.js tests/bookingManagementController.test.js tests/bookingManagementOpenApiContract.test.js tests/bookingManagementQueryValidation.test.js tests/bookingManagementQuery.test.js
+```
+Expected: all selected suites PASS.
+
+- [ ] **Step 2: Run lint**
+
+```powershell
+npm run lint
+```
+Expected: exit code `0`.
+
+- [ ] **Step 3: Run the full non-integration suite**
+
+```powershell
+npm test -- --runInBand
+```
+Expected: no failures; compare suite/test counts with the baseline `155/155` and `1477/1477`, allowing the total test count to increase only from newly added assertions/tests.
+- [ ] **Step 4: Verify Git hygiene and scope**
+
+```powershell
+git diff --check refs/remotes/origin/develop...HEAD
+git status --short
+git diff --stat refs/remotes/origin/develop...HEAD
+git rev-list --left-right --count refs/remotes/origin/develop...HEAD
+```
+Expected: no whitespace errors, clean worktree, bounded diff, branch ahead of and not behind `origin/develop`.
+
+- [ ] **Step 5: Push the branch**
+
+```powershell
+git push -u origin fix/inf-274-booking-pagination-envelope
+```
+Expected: remote branch created successfully.
+
+- [ ] **Step 6: Create the PR targeting `develop`**
+
+Title:
+```text
+fix(INF-274): standardize management booking pagination envelope
+```
+
+PR body must state: canonical fields added; legacy aliases retained/deprecated; no DB migration; search/filter/ordering/booking lifecycle unchanged; focused/lint/full-suite evidence; runtime/Postman not required because this is a deterministic read-response projection change.
+
+- [ ] **Step 7: Verify the created PR**
+
+Confirm base=`develop`, head=`fix/inf-274-booking-pagination-envelope`, changed files match the planned scope, and CI/checks have started.

--- a/docs/superpowers/specs/2026-08-10-inf-274-management-booking-pagination-envelope-design.md
+++ b/docs/superpowers/specs/2026-08-10-inf-274-management-booking-pagination-envelope-design.md
@@ -1,0 +1,158 @@
+# INF-274 Follow-up — Management Booking Pagination Envelope Design
+
+**Date:** 2026-08-10  
+**Repository:** `Infinite-LearningV1/Infinit_Track_BE`  
+**Base:** `origin/develop` at `cfdaed1`  
+**Branch:** `fix/inf-274-booking-pagination-envelope`
+
+## Purpose
+
+Standardize the Management Booking pagination response with the canonical Management Attendance vocabulary without breaking existing consumers of the INF-274 response.
+
+`GET /api/bookings` already performs server-side pagination with validated `page` and `limit`, `findAndCountAll()`, and `(page - 1) * limit` offset. This follow-up changes only the pagination response contract and its documentation/tests.
+
+## Current Contract
+
+Management Booking currently returns:
+
+```json
+{
+  "current_page": 2,
+  "total_pages": 3,
+  "total_items": 11,
+  "items_per_page": 5
+}
+```
+Management Attendance already uses the preferred vocabulary:
+
+```json
+{
+  "current_page": 2,
+  "total_pages": 3,
+  "total_records": 11,
+  "records_per_page": 5,
+  "has_next_page": true,
+  "has_prev_page": true
+}
+```
+
+The Web FE currently compensates by normalizing `total_items` / `items_per_page` and deriving navigation booleans. The Backend should publish the canonical fields directly while preserving the existing aliases during migration.
+
+## Design Decision
+
+The Management Booking response becomes additive:
+
+```json
+{
+  "current_page": 2,
+  "total_pages": 3,
+  "total_records": 11,
+  "records_per_page": 5,
+  "has_next_page": true,
+  "has_prev_page": true,
+  "total_items": 11,
+  "items_per_page": 5
+}
+```
+
+Canonical fields are:
+
+- `current_page`
+- `total_pages`
+- `total_records`
+- `records_per_page`
+- `has_next_page`
+- `has_prev_page`
+
+Compatibility aliases are retained temporarily:
+
+- `total_items` = `total_records`
+- `items_per_page` = `records_per_page`
+
+The aliases must be documented as deprecated. They are not removed in this change.
+
+## Pagination Semantics
+
+For non-empty results:
+
+- `total_pages = Math.ceil(total_records / records_per_page)`
+- `has_next_page = current_page < total_pages`
+- `has_prev_page = total_pages > 0 && current_page > 1`
+For an empty result set:
+
+```json
+{
+  "current_page": 1,
+  "total_pages": 0,
+  "total_records": 0,
+  "records_per_page": 10,
+  "has_next_page": false,
+  "has_prev_page": false,
+  "total_items": 0,
+  "items_per_page": 10
+}
+```
+
+This issue does **not** introduce page clamping. Existing query semantics remain unchanged when a caller requests a page beyond `total_pages`.
+
+## Architecture
+
+The existing read path remains:
+
+```text
+Route validation
+→ getAllBookings controller
+→ listManagementBookings read service
+→ booking query builder
+→ Booking.findAndCountAll
+→ booking mapper + pagination envelope
+```
+Only the read-service pagination projection changes. No controller business logic, query construction, database model, migration, WFA scoring, approval/rejection behavior, or authentication behavior changes.
+
+## OpenAPI Contract
+
+Do not broaden or mutate the shared `Pagination` schema because it is reused by unrelated endpoints with historical contracts.
+
+Add the booking-specific schema `BookingManagementPagination` and point `GET /api/bookings` to it. The schema must require all eight runtime fields. `total_items` and `items_per_page` remain required during the compatibility window but are marked deprecated, while the six canonical fields are the preferred consumer contract.
+
+The endpoint's `page` / `limit` request parameters remain unchanged:
+
+- `page`: integer, minimum `1`, default `1`
+- `limit`: integer, minimum `1`, maximum `100`, default `10`
+
+## Error Handling
+
+No new failure class is introduced. Existing query validation and canonical error middleware remain authoritative. Pagination projection uses values already validated before controller execution.
+
+## Testing Strategy
+
+TDD must lock the response before production changes:
+
+1. Update `bookingManagementReadService.test.js` to expect canonical fields and compatibility aliases for non-empty and empty datasets.
+2. Update `bookingManagementController.test.js` to prove the richer pagination object passes through unchanged.
+3. Extend `bookingManagementOpenApiContract.test.js` to require `BookingManagementPagination`, all eight required runtime fields, and deprecated compatibility aliases.
+4. Run focused Management Booking tests.
+5. Run `npm run lint` and the full non-integration Jest suite before completion.
+
+Baseline before this change is `155/155` suites and `1477/1477` tests passing.
+
+## Acceptance Criteria
+
+- `GET /api/bookings` still paginates server-side using the existing `page` and `limit` query contract.
+- Response pagination contains all six canonical fields.
+- `total_items` and `items_per_page` remain present and equal their canonical counterparts.
+- `has_next_page` and `has_prev_page` are Backend-authored, not inferred by the API consumer.
+- Empty pagination returns `total_pages: 0` and both navigation booleans `false`.
+- OpenAPI publishes a Management Booking-specific pagination schema and marks compatibility aliases deprecated.
+- Existing search, filters, ordering, projection, approval/rejection, and authorization behavior remain unchanged.
+- No database migration is added.
+- Focused tests, lint, full non-integration tests, and `git diff --check` pass.
+
+## Non-Goals
+
+- Removing compatibility aliases.
+- Standardizing every Backend endpoint in this PR.
+- Changing Web FE pagination state in this Backend PR.
+- Adding cursor pagination.
+- Page clamping or pagination policy redesign.
+- Changing sorting, search, WFA scoring, or booking lifecycle semantics.

--- a/docs/superpowers/specs/2026-08-10-inf-274-management-booking-pagination-envelope-design.md
+++ b/docs/superpowers/specs/2026-08-10-inf-274-management-booking-pagination-envelope-design.md
@@ -1,8 +1,8 @@
 # INF-274 Follow-up — Management Booking Pagination Envelope Design
 
-**Date:** 2026-08-10  
-**Repository:** `Infinite-LearningV1/Infinit_Track_BE`  
-**Base:** `origin/develop` at `cfdaed1`  
+**Date:** 2026-08-10
+**Repository:** `Infinite-LearningV1/Infinit_Track_BE`
+**Base:** `origin/develop` at `cfdaed1`
 **Branch:** `fix/inf-274-booking-pagination-envelope`
 
 ## Purpose

--- a/src/modules/booking/bookingManagementRead.service.js
+++ b/src/modules/booking/bookingManagementRead.service.js
@@ -9,12 +9,17 @@ export const listManagementBookings = async (query = {}) => {
   const { count, rows } = await Booking.findAndCountAll(
     buildBookingManagementListQuery(normalizedQuery)
   );
+  const totalPages = Math.ceil(count / limit);
 
   return {
     bookings: rows.map(mapBookingManagementRow),
     pagination: {
       current_page: page,
-      total_pages: Math.ceil(count / limit),
+      total_pages: totalPages,
+      total_records: count,
+      records_per_page: limit,
+      has_next_page: page < totalPages,
+      has_prev_page: totalPages > 0 && page > 1,
       total_items: count,
       items_per_page: limit
     }

--- a/tests/bookingManagementController.test.js
+++ b/tests/bookingManagementController.test.js
@@ -61,6 +61,10 @@ test('delegates the validated management query and preserves the existing respon
     pagination: {
       current_page: 2,
       total_pages: 3,
+      total_records: 11,
+      records_per_page: 5,
+      has_next_page: true,
+      has_prev_page: true,
       total_items: 11,
       items_per_page: 5
     }
@@ -82,6 +86,10 @@ test('delegates the validated management query and preserves the existing respon
       pagination: {
         current_page: 2,
         total_pages: 3,
+        total_records: 11,
+        records_per_page: 5,
+        has_next_page: true,
+        has_prev_page: true,
         total_items: 11,
         items_per_page: 5
       }

--- a/tests/bookingManagementOpenApiContract.test.js
+++ b/tests/bookingManagementOpenApiContract.test.js
@@ -76,3 +76,30 @@ test('documents processor identity and truthful nullable suitability semantics',
     '#/components/schemas/WfaRejectionReasonProjection'
   );
 });
+
+
+test('publishes the canonical Management Booking pagination envelope with deprecated aliases', () => {
+  const operation = openapi.paths['/api/bookings'].get;
+  const paginationRef =
+    operation.responses['200'].content['application/json'].schema.properties.data.properties
+      .pagination.$ref;
+
+  expect(paginationRef).toBe('#/components/schemas/BookingManagementPagination');
+
+  const pagination = openapi.components.schemas.BookingManagementPagination;
+  expect(pagination.type).toBe('object');
+  expect(pagination.required).toEqual([
+    'current_page',
+    'total_pages',
+    'total_records',
+    'records_per_page',
+    'has_next_page',
+    'has_prev_page',
+    'total_items',
+    'items_per_page'
+  ]);
+  expect(pagination.properties.total_items.deprecated).toBe(true);
+  expect(pagination.properties.items_per_page.deprecated).toBe(true);
+  expect(pagination.properties.has_next_page.type).toBe('boolean');
+  expect(pagination.properties.has_prev_page.type).toBe('boolean');
+});

--- a/tests/bookingManagementReadService.test.js
+++ b/tests/bookingManagementReadService.test.js
@@ -51,6 +51,10 @@ test('executes one paginated query and maps the returned booking rows', async ()
     pagination: {
       current_page: 2,
       total_pages: 3,
+      total_records: 11,
+      records_per_page: 5,
+      has_next_page: true,
+      has_prev_page: true,
       total_items: 11,
       items_per_page: 5
     }
@@ -66,6 +70,10 @@ test('returns stable empty pagination metadata', async () => {
     pagination: {
       current_page: 1,
       total_pages: 0,
+      total_records: 0,
+      records_per_page: 10,
+      has_next_page: false,
+      has_prev_page: false,
       total_items: 0,
       items_per_page: 10
     }


### PR DESCRIPTION
﻿## Summary
- add canonical Management Booking pagination fields: `total_records`, `records_per_page`, `has_next_page`, and `has_prev_page`
- retain `total_items` and `items_per_page` as deprecated compatibility aliases
- publish a dedicated `BookingManagementPagination` OpenAPI schema without changing the shared `Pagination` schema

## Architecture / behavior
- `GET /api/bookings` remains server-side paginated through the existing validated `page` / `limit` query path
- `getAllBookings` remains a thin controller pass-through; pagination projection stays owned by `listManagementBookings`
- search, filters, deterministic ordering, WFA scoring, approval/rejection, authentication, models, and database schema are unchanged
- no database migration

## Contract
Canonical fields:
- `current_page`
- `total_pages`
- `total_records`
- `records_per_page`
- `has_next_page`
- `has_prev_page`

Compatibility aliases retained and documented as deprecated:
- `total_items` -> `total_records`
- `items_per_page` -> `records_per_page`

## Verification
- focused Management Booking regression: 5 suites / 30 tests passed
- OpenAPI/runtime drift contract: passed
- `npm run lint`: passed
- full non-integration Jest: 155/155 suites, 1478/1478 tests passed
- `git diff --check`: passed

Runtime/Postman smoke was not executed because this change is limited to a deterministic read-response projection and OpenAPI contract.

Refs INF-274.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Standardized booking-management pagination with total records, records per page, and next/previous page indicators.
  * Preserved legacy pagination fields for compatibility, marked as deprecated.
  * Updated the booking API contract to document the new pagination response.

* **Tests**
  * Added coverage for populated and empty booking results, pagination metadata, and API contract compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->