### PR TITLE
feat(#139): standardize management profile photo projection

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -7262,7 +7262,7 @@ components:
           format: date
         user:
           type: object
-          required: [id, full_name, nip_nim, role]
+          required: [id, full_name, nip_nim, role, photo, photo_updated_at]
           properties:
             id:
               type: integer
@@ -7275,6 +7275,14 @@ components:
               nullable: true
             role:
               type: string
+              nullable: true
+            photo:
+              type: string
+              format: uri
+              nullable: true
+            photo_updated_at:
+              type: string
+              format: date-time
               nullable: true
         time_in:
           type: string
@@ -7331,7 +7339,7 @@ components:
           nullable: true
         user:
           type: object
-          required: [id, full_name, nip_nim, email, role]
+          required: [id, full_name, nip_nim, email, role, photo, photo_updated_at]
           properties:
             id:
               type: integer
@@ -7348,6 +7356,14 @@ components:
               nullable: true
             role:
               type: string
+              nullable: true
+            photo:
+              type: string
+              format: uri
+              nullable: true
+            photo_updated_at:
+              type: string
+              format: date-time
               nullable: true
         location:
           type: object
@@ -7789,6 +7805,14 @@ components:
           type: string
           nullable: true
           example: EMP-007
+        user_photo:
+          type: string
+          format: uri
+          nullable: true
+        user_photo_updated_at:
+          type: string
+          format: date-time
+          nullable: true
         user_position_name:
           type: string
           nullable: true

--- a/docs/superpowers/plans/2026-08-10-gh-139-profile-photo-projection.md
+++ b/docs/superpowers/plans/2026-08-10-gh-139-profile-photo-projection.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Add Backend-authored profile-photo metadata to Management Attendance list/detail and Management Booking applicant rows without adding endpoints, migrations, N+1 lookups, or implicit global photo loading.
+**Goal:** Add Backend-authored profile-photo metadata to Management Attendance list/detail and Management Booking applicant rows, and consolidate Management User read projections onto the same canonical helper without changing its public API behavior.
 
-**Architecture:** Keep Photo owned by User. Add one small reusable explicit projection helper under `src/utils/`, then make the existing Attendance and Booking query builders opt into the optional `User -> photo_file` join and map the result into their existing response shapes. Preserve every existing request, filter, sorting, pagination, authorization, mutation, and storage contract.
+**Architecture:** Keep Photo owned by User. One reusable explicit read-projection helper under `src/utils/` is consumed by Management User, Attendance, and Booking at their existing read boundaries; each feature keeps ownership of its surrounding response shape and business semantics. Photo upload/storage mutation remains explicit write-side logic and never depends on the read helper.
 
 **Tech Stack:** Node.js ESM, Express 4, Sequelize 6, MySQL, Jest 29 with VM modules, OpenAPI YAML.
 
@@ -12,7 +12,7 @@
 
 - Base branch: `develop`; implementation worktree base commit: `577793842c172018b3cb40c44853438d90c14c22`.
 - Work only on `feature/gh-139-profile-photo-projection` in the isolated worktree.
-- TDD is mandatory: each production behavior starts with a focused failing test.
+- TDD is mandatory for new production behavior. Management User consolidation is a behavior-preserving refactor: first pin characterization behavior GREEN, then refactor while keeping those contracts GREEN.
 - No new route, endpoint, request parameter, status code, or response envelope.
 - No database migration or User/Photo association change.
 - No photo upload, storage, deletion, URL signing, probing, caching, or fallback behavior.
@@ -21,56 +21,84 @@
 - Attendance photo fields are exactly `user.photo` and `user.photo_updated_at` in list and detail.
 - Booking applicant photo fields are exactly `user_photo` and `user_photo_updated_at`.
 - Booking `processed_by` does not gain photo fields.
+- Management User public fields remain exactly `photo` and `photo_updated_at` on list/detail/create/update response projections.
 - Missing photo evidence produces explicit `null` values and never removes the parent row.
 - Preserve Attendance search/filter/sort/pagination/detail semantics unchanged.
 - Preserve Booking search/filter/order/pagination/approval/rejection/scoring semantics unchanged.
-- Leave Management User implementation unchanged; use its tests only as regression/reference evidence.
+- Preserve Management User search/filter/sort/pagination, `404 E_NOT_FOUND`, `409 E_USER_LOCATION_INTEGRITY`, and photo upload/storage mutation semantics unchanged.
+- Auth photo projection consolidation remains out of scope.
 
----## File Map
+## Current Branch State
 
-**Create**
-- `src/utils/userPhotoProjection.js` — reusable explicit Sequelize include descriptor plus null-safe photo metadata mapper.
-- `tests/userPhotoProjection.test.js` — pins helper alias, selected attributes, optionality, persisted values, and null semantics.
+Tasks 1-4 already landed on this branch and are historical execution evidence; do not rerun their RED phases as if the code were absent. Their commits are:
 
-**Modify — Attendance**
-- `src/modules/attendance/attendance.query.js` — explicitly include `Photo` under the existing User include for list and detail.
-- `src/modules/attendance/attendance.mapper.js` — add `photo` and `photo_updated_at` to the nested user projection.
-- `tests/attendanceManagementQuery.test.js` — pin optional Photo include without changing parent User search behavior.
-- `tests/attendanceManagementMapper.test.js` — pin present/null photo fields in list and detail.
-- `tests/attendanceManagementReadService.test.js` — add the `Photo` model mock required by the real query builder and keep service behavior unchanged.
+```text
+38f0792 feat(#139): add explicit user photo projection helper
+e63c19a feat(#139): project profile photo in attendance reads
+685867a feat(#139): project applicant photo in booking reads
+014a86f docs(#139): publish management profile photo fields [contract tests]
+20b9e24 docs(#139): publish management profile photo fields [OpenAPI]
+65c7e9a test(#139): update booking controller model mocks
+```
 
-**Modify — Booking**
-- `src/modules/booking/bookingManagement.query.js` — explicitly include `Photo` for applicant User only.
-- `src/modules/booking/bookingManagement.mapper.js` — add flattened `user_photo` and `user_photo_updated_at`.
-- `tests/bookingManagementQuery.test.js` — pin applicant Photo include and processor exclusion.
-- `tests/bookingManagementMapper.test.js` — pin present/null applicant photo projection.
+The remaining implementation work starts at Task 5. Task 6 must rerun fresh verification for the expanded scope.
 
-**Modify — Public contract**
-- `docs/openapi.yaml` — document Attendance list/detail nested photo fields and Booking flattened applicant photo fields.
-- `tests/attendanceManagementOpenApiContract.test.js` — pin exact nullable Attendance photo schema.
-- `tests/bookingManagementOpenApiContract.test.js` — pin exact nullable Booking photo schema.
+---
 
-**Regression only; do not modify unless a scoped failure proves necessary**
-- `tests/bookingManagementReadService.test.js`
-- `tests/userListProjectionContract.test.js`
+## File Map
+
+**Already created**
+
+- `src/utils/userPhotoProjection.js` - canonical explicit Sequelize photo include descriptor plus null-safe photo metadata mapper.
+- `tests/userPhotoProjection.test.js` - helper alias, selected attributes, optionality, persisted values, and null semantics.
+
+**Modify - Management User consolidation**
+
+- `src/controllers/user.controller.js` - replace four duplicated read/refetch Photo includes and two duplicated photo mappings with the canonical helper; keep write-side photo persistence explicit.
+- `tests/userListProjectionContract.test.js` - pin nullable photo payload and optional list Photo join.
+- `tests/userDetailProjectionContract.test.js` - pin nullable detail photo payload and optional detail Photo join while preserving 404/409 behavior.
+- `tests/userCreateUpdateProjectionContract.test.js` - pin photo metadata on create/update response refetches.
+- `tests/uploadUserPhotoController.test.js` - regression only; prove write-side storage/mutation remains independent of the read helper.
+
+**Already modified - Attendance**
+
+- `src/modules/attendance/attendance.query.js`
+- `src/modules/attendance/attendance.mapper.js`
+- `tests/attendanceManagementQuery.test.js`
+- `tests/attendanceManagementMapper.test.js`
+- `tests/attendanceManagementReadService.test.js`
+
+**Already modified - Booking**
+
+- `src/modules/booking/bookingManagement.query.js`
+- `src/modules/booking/bookingManagement.mapper.js`
+- `tests/bookingManagementQuery.test.js`
+- `tests/bookingManagementMapper.test.js`
+- booking controller/readiness model mocks touched only as compatibility tests require.
+
+**Already modified - Public contract**
+
+- `docs/openapi.yaml`
+- `tests/attendanceManagementOpenApiContract.test.js`
+- `tests/bookingManagementOpenApiContract.test.js`
+
 ### Task 1: Lock the shared explicit User photo projection primitive
 
 **Files:**
+
 - Create: `tests/userPhotoProjection.test.js`
 - Create: `src/utils/userPhotoProjection.js`
 
 **Interfaces:**
+
 - Produces: `buildUserPhotoInclude(PhotoModel)` returning a Sequelize include object.
 - Produces: `mapUserPhotoProjection(user)` returning `{ photo, photo_updated_at }`.
-- Consumed by: Attendance query/mapper in Task 2 and Booking query/mapper in Task 3.
+- Consumed by: Attendance query/mapper in Task 2, Booking query/mapper in Task 3, and Management User read projections in Task 5.
 
-- [ ] **Step 1: Write the failing helper contract test**
+- [x] **Step 1: Write the failing helper contract test**
 
 ```js
-import {
-  buildUserPhotoInclude,
-  mapUserPhotoProjection
-} from '../src/utils/userPhotoProjection.js';
+import { buildUserPhotoInclude, mapUserPhotoProjection } from '../src/utils/userPhotoProjection.js';
 
 const Photo = { modelName: 'Photo' };
 
@@ -82,15 +110,16 @@ test('builds the explicit optional photo_file include', () => {
     required: false
   });
 });
-``````js
 test('maps persisted photo evidence without rewriting it', () => {
   const updatedAt = new Date('2026-08-10T08:30:00.000Z');
-  expect(mapUserPhotoProjection({
-    photo_file: {
-      photo_url: 'https://cdn.example.com/users/7/profile/photo.jpg',
-      photo_updated_at: updatedAt
-    }
-  })).toEqual({
+  expect(
+    mapUserPhotoProjection({
+      photo_file: {
+        photo_url: 'https://cdn.example.com/users/7/profile/photo.jpg',
+        photo_updated_at: updatedAt
+      }
+    })
+  ).toEqual({
     photo: 'https://cdn.example.com/users/7/profile/photo.jpg',
     photo_updated_at: updatedAt
   });
@@ -107,12 +136,13 @@ test.each([null, undefined, {}, { photo_file: null }])(
 );
 ```
 
-- [ ] **Step 2: Run the helper test and verify RED**
+- [x] **Step 2: Run the helper test and verify RED**
 
 Run: `node --experimental-vm-modules node_modules/jest/bin/jest.js tests/userPhotoProjection.test.js --runInBand`
 
 Expected: FAIL because `src/utils/userPhotoProjection.js` does not exist.
-- [ ] **Step 3: Implement the minimal shared helper**
+
+- [x] **Step 3: Implement the minimal shared helper**
 
 ```js
 export const buildUserPhotoInclude = (PhotoModel) => ({
@@ -130,21 +160,23 @@ export const mapUserPhotoProjection = (user) => ({
 
 Do not import `Photo` or `models/index.js` in this helper. Query builders must opt in explicitly by passing the model.
 
-- [ ] **Step 4: Run the helper test and verify GREEN**
+- [x] **Step 4: Run the helper test and verify GREEN**
 
 Run: `node --experimental-vm-modules node_modules/jest/bin/jest.js tests/userPhotoProjection.test.js --runInBand`
 
 Expected: PASS with all helper tests green.
 
-- [ ] **Step 5: Commit the helper contract**
+- [x] **Step 5: Commit the helper contract**
 
 ```powershell
 git add -- src/utils/userPhotoProjection.js tests/userPhotoProjection.test.js
 git commit -m "feat(#139): add explicit user photo projection helper"
 ```
+
 ### Task 2: Project profile photo through Management Attendance list and detail
 
 **Files:**
+
 - Modify: `tests/attendanceManagementQuery.test.js`
 - Modify: `tests/attendanceManagementMapper.test.js`
 - Modify: `tests/attendanceManagementReadService.test.js`
@@ -152,11 +184,12 @@ git commit -m "feat(#139): add explicit user photo projection helper"
 - Modify: `src/modules/attendance/attendance.mapper.js`
 
 **Interfaces:**
+
 - Consumes: `buildUserPhotoInclude(PhotoModel)` and `mapUserPhotoProjection(user)` from Task 1.
 - Produces: list/detail nested user objects containing `photo` and `photo_updated_at` on every mapped Attendance row.
 - Keeps: existing parent User required/search behavior, fields, filters, ordering, pagination, detail location semantics, and service envelope.
 
-- [ ] **Step 1: Write RED query assertions for the optional nested Photo join**
+- [x] **Step 1: Write RED query assertions for the optional nested Photo join**
 
 Change the test import to:
 
@@ -174,10 +207,11 @@ test('includes the same optional lightweight photo projection in list and detail
 
   expect(listUser.required).toBe(false);
   expect(listPhoto).toEqual({
-    model: Photo, as: 'photo_file',
-    attributes: ['photo_url', 'photo_updated_at'], required: false
+    model: Photo,
+    as: 'photo_file',
+    attributes: ['photo_url', 'photo_updated_at'],
+    required: false
   });
-``````js
   const searched = buildAttendanceListQuery({ page: 1, limit: 10, search: 'Andi' });
   expect(searched.include.find((item) => item.as === 'user').required).toBe(true);
 
@@ -186,15 +220,17 @@ test('includes the same optional lightweight photo projection in list and detail
   const detailPhoto = detailUser.include.find((item) => item.as === 'photo_file');
   expect(detailUser.required).toBe(false);
   expect(detailPhoto).toEqual({
-    model: Photo, as: 'photo_file',
-    attributes: ['photo_url', 'photo_updated_at'], required: false
+    model: Photo,
+    as: 'photo_file',
+    attributes: ['photo_url', 'photo_updated_at'],
+    required: false
   });
 });
 ```
 
 This test must not change the expected top-level include aliases, list `limit`/`offset`, or stable ordering assertions already present.
 
-- [ ] **Step 2: Extend Attendance mapper fixtures and expectations before production code**
+- [x] **Step 2: Extend Attendance mapper fixtures and expectations before production code**
 
 Add `photo_file` to the shared `row.user` fixture:
 
@@ -238,7 +274,8 @@ Update the existing `user: null` exact expectation to:
   role: null
 }
 ```
-- [ ] **Step 3: Update the Attendance read-service test fixture/mocks and verify the suite is RED**
+
+- [x] **Step 3: Update the Attendance read-service test fixture/mocks and verify the suite is RED**
 
 In `tests/attendanceManagementReadService.test.js`:
 
@@ -266,13 +303,19 @@ Run:
 `node --experimental-vm-modules node_modules/jest/bin/jest.js tests/attendanceManagementQuery.test.js tests/attendanceManagementMapper.test.js tests/attendanceManagementReadService.test.js --runInBand`
 
 Expected: FAIL because the query does not yet include Photo and the mapper does not emit the new fields.
-- [ ] **Step 4: Implement the minimal Attendance query integration**
+
+- [x] **Step 4: Implement the minimal Attendance query integration**
 
 Change the model import to include `Photo`, and import the helper:
 
 ```js
 import {
-  AttendanceCategory, AttendanceStatus, Location, Photo, Role, User
+  AttendanceCategory,
+  AttendanceStatus,
+  Location,
+  Photo,
+  Role,
+  User
 } from '../../models/index.js';
 import { buildUserPhotoInclude } from '../../utils/userPhotoProjection.js';
 ```
@@ -283,18 +326,19 @@ Change both existing User `include` arrays to contain Role plus the photo includ
 include: [
   { model: Role, as: 'role', attributes: ['role_name'], required: false },
   buildUserPhotoInclude(Photo)
-]
+];
 ```
 
 Do not change `userInclude.required`, search predicates, parent User attributes, top-level includes, ordering, limit, offset, or `distinct`.
 
-- [ ] **Step 5: Implement the minimal Attendance mapper integration**
+- [x] **Step 5: Implement the minimal Attendance mapper integration**
 
 Add:
 
 ```js
 import { mapUserPhotoProjection } from '../../utils/userPhotoProjection.js';
 ```
+
 Then extend `userOf` without changing email or role semantics:
 
 ```js
@@ -308,7 +352,7 @@ const userOf = (row, includeEmail = false) => ({
 });
 ```
 
-- [ ] **Step 6: Run the focused Attendance tests and verify GREEN**
+- [x] **Step 6: Run the focused Attendance tests and verify GREEN**
 
 Run:
 
@@ -316,26 +360,29 @@ Run:
 
 Expected: PASS. Existing assertions for search-required User joins, detail fields, pagination, modes/statuses, location semantics, and ordering remain green.
 
-- [ ] **Step 7: Commit the Attendance projection**
+- [x] **Step 7: Commit the Attendance projection**
 
 ```powershell
 git add -- src/modules/attendance/attendance.query.js src/modules/attendance/attendance.mapper.js tests/attendanceManagementQuery.test.js tests/attendanceManagementMapper.test.js tests/attendanceManagementReadService.test.js
 git commit -m "feat(#139): project profile photo in attendance reads"
 ```
+
 ### Task 3: Project applicant profile photo through Management Booking
 
 **Files:**
+
 - Modify: `tests/bookingManagementQuery.test.js`
 - Modify: `tests/bookingManagementMapper.test.js`
 - Modify: `src/modules/booking/bookingManagement.query.js`
 - Modify: `src/modules/booking/bookingManagement.mapper.js`
 
 **Interfaces:**
+
 - Consumes: `buildUserPhotoInclude(PhotoModel)` and `mapUserPhotoProjection(user)` from Task 1.
 - Produces: every Management Booking row contains nullable `user_photo` and `user_photo_updated_at` fields derived from the applicant User only.
 - Keeps: applicant search behavior, Position/Role joins, processor identity, fixed approval-first ordering, filters, pagination, WFA reason/scoring semantics.
 
-- [ ] **Step 1: Write RED Booking query assertions**
+- [x] **Step 1: Write RED Booking query assertions**
 
 Add `Photo` to the mocked model registry:
 
@@ -353,19 +400,22 @@ jest.unstable_mockModule('../src/models/index.js', () => ({
   WfaRejectionReason
 }));
 ```
+
 Extend the existing applicant include assertion:
 
 ```js
-expect(applicant.include).toEqual(expect.arrayContaining([
-  expect.objectContaining({ model: Position, as: 'position' }),
-  expect.objectContaining({ model: Role, as: 'role' }),
-  {
-    model: Photo,
-    as: 'photo_file',
-    attributes: ['photo_url', 'photo_updated_at'],
-    required: false
-  }
-]));
+expect(applicant.include).toEqual(
+  expect.arrayContaining([
+    expect.objectContaining({ model: Position, as: 'position' }),
+    expect.objectContaining({ model: Role, as: 'role' }),
+    {
+      model: Photo,
+      as: 'photo_file',
+      attributes: ['photo_url', 'photo_updated_at'],
+      required: false
+    }
+  ])
+);
 ```
 
 In the processor test, prove the photo include is absent:
@@ -376,7 +426,7 @@ expect(processor.include.some((item) => item.as === 'photo_file')).toBe(false);
 
 Keep the existing no-search applicant `required: false`, active-search `required: true`, wildcard escaping, fixed order, limit, offset, and `distinct` assertions unchanged.
 
-- [ ] **Step 2: Write RED Booking mapper assertions**
+- [x] **Step 2: Write RED Booking mapper assertions**
 
 Add to `baseRow.user`:
 
@@ -386,6 +436,7 @@ photo_file: {
   photo_updated_at: new Date('2026-08-10T08:30:00.000Z')
 }
 ```
+
 Extend the existing manual-processor mapping assertion with:
 
 ```js
@@ -411,14 +462,15 @@ test('keeps applicant photo fields present and null without linked photo evidenc
 });
 ```
 
-- [ ] **Step 3: Run the focused Booking tests and verify RED**
+- [x] **Step 3: Run the focused Booking tests and verify RED**
 
 Run:
 
 `node --experimental-vm-modules node_modules/jest/bin/jest.js tests/bookingManagementQuery.test.js tests/bookingManagementMapper.test.js tests/bookingManagementReadService.test.js --runInBand`
 
 Expected: query/mapper tests FAIL because applicant Photo is not yet included and mapped; read-service regression remains green or fails only because mapped fixture expectations were intentionally expanded.
-- [ ] **Step 4: Implement the minimal Booking query integration**
+
+- [x] **Step 4: Implement the minimal Booking query integration**
 
 Change the model import to include `Photo`, then import the helper:
 
@@ -443,11 +495,12 @@ include: [
   { model: Position, as: 'position', attributes: ['position_name'], required: false },
   { model: Role, as: 'role', attributes: ['id_roles', 'role_name'], required: false },
   buildUserPhotoInclude(Photo)
-]
+];
 ```
 
 Do not modify `buildProcessorInclude`.
-- [ ] **Step 5: Implement the minimal Booking mapper integration**
+
+- [x] **Step 5: Implement the minimal Booking mapper integration**
 
 Import the shared mapper:
 
@@ -470,7 +523,7 @@ user_photo_updated_at: photoUpdatedAt,
 
 Do not change `processed_by`, reasons, suitability, radius fallback, location conversion, status, timestamps, or raw `approved_by` compatibility.
 
-- [ ] **Step 6: Run the focused Booking tests and verify GREEN**
+- [x] **Step 6: Run the focused Booking tests and verify GREEN**
 
 Run:
 
@@ -478,25 +531,28 @@ Run:
 
 Expected: PASS with processor-photo exclusion and all existing ordering/search/pagination/scoring assertions still green.
 
-- [ ] **Step 7: Commit the Booking projection**
+- [x] **Step 7: Commit the Booking projection**
 
 ```powershell
 git add -- src/modules/booking/bookingManagement.query.js src/modules/booking/bookingManagement.mapper.js tests/bookingManagementQuery.test.js tests/bookingManagementMapper.test.js
 git commit -m "feat(#139): project applicant photo in booking reads"
 ```
+
 ### Task 4: Publish the additive photo fields in OpenAPI
 
 **Files:**
+
 - Modify: `tests/attendanceManagementOpenApiContract.test.js`
 - Modify: `tests/bookingManagementOpenApiContract.test.js`
 - Modify: `docs/openapi.yaml`
 
 **Interfaces:**
+
 - Documents runtime fields produced by Tasks 2 and 3.
 - Attendance list/detail photo fields are required keys with nullable values.
 - Booking photo fields are nullable properties on the existing `BookingManagementItem` schema; do not create a new booking schema or change its pagination schema.
 
-- [ ] **Step 1: Write RED Attendance OpenAPI assertions**
+- [x] **Step 1: Write RED Attendance OpenAPI assertions**
 
 Add:
 
@@ -508,15 +564,20 @@ test('documents nullable profile photo evidence on attendance list and detail us
   for (const user of [listUser, detailUser]) {
     expect(user.required).toEqual(expect.arrayContaining(['photo', 'photo_updated_at']));
     expect(user.properties.photo).toMatchObject({
-      type: 'string', format: 'uri', nullable: true
+      type: 'string',
+      format: 'uri',
+      nullable: true
     });
     expect(user.properties.photo_updated_at).toMatchObject({
-      type: 'string', format: 'date-time', nullable: true
+      type: 'string',
+      format: 'date-time',
+      nullable: true
     });
   }
 });
 ```
-- [ ] **Step 2: Write RED Booking OpenAPI assertions**
+
+- [x] **Step 2: Write RED Booking OpenAPI assertions**
 
 Extend the existing `BookingManagementItem` schema test:
 
@@ -535,7 +596,7 @@ expect(item.properties.user_photo_updated_at).toMatchObject({
 
 Do not add these fields to `BookingProcessor`.
 
-- [ ] **Step 3: Run only the two OpenAPI tests and verify RED**
+- [x] **Step 3: Run only the two OpenAPI tests and verify RED**
 
 Run:
 
@@ -544,7 +605,8 @@ node --experimental-vm-modules node_modules/jest/bin/jest.js tests/attendanceMan
 ```
 
 Expected: FAIL because the four new schema properties are not yet documented.
-- [ ] **Step 4: Update the Attendance OpenAPI user schemas**
+
+- [x] **Step 4: Update the Attendance OpenAPI user schemas**
 
 For both `AttendanceAuditListRow.properties.user` and `AttendanceAuditDetail.properties.user`:
 
@@ -564,7 +626,7 @@ photo_updated_at:
 
 Keep list-only/detail-only differences unchanged: list still omits email and detail still includes email.
 
-- [ ] **Step 5: Update `BookingManagementItem` only**
+- [x] **Step 5: Update `BookingManagementItem` only**
 
 Add:
 
@@ -578,9 +640,10 @@ user_photo_updated_at:
   format: date-time
   nullable: true
 ```
+
 Do not modify `BookingProcessor`, `BookingManagementPagination`, endpoint parameters, authorization descriptions, or response envelopes.
 
-- [ ] **Step 6: Run the OpenAPI contract tests and verify GREEN**
+- [x] **Step 6: Run the OpenAPI contract tests and verify GREEN**
 
 Run:
 
@@ -590,7 +653,7 @@ node --experimental-vm-modules node_modules/jest/bin/jest.js tests/attendanceMan
 
 Expected: PASS. The client-critical OpenAPI regression must remain green.
 
-- [ ] **Step 7: Commit the public contract**
+- [x] **Step 7: Commit the public contract**
 
 ```powershell
 git add -- docs/openapi.yaml tests/attendanceManagementOpenApiContract.test.js tests/bookingManagementOpenApiContract.test.js
@@ -599,23 +662,222 @@ git commit -m "docs(#139): publish management profile photo fields"
 
 ---
 
-### Task 5: Cross-feature regression and completion verification
+### Task 5: Consolidate Management User onto the canonical photo read projection
 
 **Files:**
+
+- Modify: `tests/userListProjectionContract.test.js`
+- Modify: `tests/userDetailProjectionContract.test.js`
+- Modify: `tests/userCreateUpdateProjectionContract.test.js`
+- Modify: `src/controllers/user.controller.js`
+- Regression: `tests/uploadUserPhotoController.test.js`
+- Regression: `tests/usersListPaginationContract.test.js`
+- Regression: `tests/usersPayloadContract.test.js`
+
+**Interfaces:**
+
+- Consumes: `buildUserPhotoInclude(PhotoModel)` and `mapUserPhotoProjection(user)` from Task 1.
+- Produces: no new public API fields; existing Management User `photo` / `photo_updated_at` payloads remain byte-for-byte semantically compatible.
+- Keeps: User list/detail/create/update ownership in `user.controller.js`; upload/storage/delete mutation remains explicit write-side logic.
+
+This task is a pure refactor. Do not invent a failing behavior test merely to force RED; first establish characterization tests on the current implementation, then refactor while keeping them GREEN.
+
+- [ ] **Step 1: Add list characterization for nullable photo evidence and optional join**
+
+Add to `tests/userListProjectionContract.test.js`:
+
+```js
+test('list keeps nullable photo evidence and an optional photo_file join', async () => {
+  const findAll = jest.fn().mockResolvedValue([buildUser({ photo_file: null })]);
+  const { getAllUsers } = await loadController({ findAll });
+
+  const res = buildRes();
+  await getAllUsers({ query: {} }, res, jest.fn());
+
+  expect(res.json.mock.calls[0][0].data[0]).toMatchObject({
+    photo: null,
+    photo_updated_at: null
+  });
+
+  const include = findAll.mock.calls[0][0].include;
+  const photoInclude = include.find((entry) => entry.as === 'photo_file');
+  expect(photoInclude).toMatchObject({
+    as: 'photo_file',
+    attributes: ['photo_url', 'photo_updated_at'],
+    required: false
+  });
+});
+```
+
+- [ ] **Step 2: Add detail characterization without weakening 404/409 integrity tests**
+
+Add to `tests/userDetailProjectionContract.test.js`:
+
+```js
+test('detail keeps nullable photo evidence and an optional photo_file join', async () => {
+  const findOne = jest.fn().mockResolvedValue(buildUser({ photo_file: null }));
+  const { getUserById } = await loadController({ findOne });
+
+  const res = buildRes();
+  await getUserById({ params: { id: '5' }, user: { id: 1 } }, res, jest.fn());
+
+  expect(res.json.mock.calls[0][0].data).toMatchObject({
+    photo: null,
+    photo_updated_at: null
+  });
+
+  const include = findOne.mock.calls[0][0].include;
+  expect(include.find((entry) => entry.as === 'photo_file')).toMatchObject({
+    attributes: ['photo_url', 'photo_updated_at'],
+    required: false
+  });
+});
+```
+
+Keep the existing `404 E_NOT_FOUND` and `409 E_USER_LOCATION_INTEGRITY` tests unchanged.
+
+- [ ] **Step 3: Pin create/update response photo metadata before refactoring**
+
+In the existing create response test in `tests/userCreateUpdateProjectionContract.test.js`, add:
+
+```js
+expect(payload.data.photo).toBe('https://cdn.example.com/cindy.jpg');
+expect(payload.data.photo_updated_at).toEqual(new Date('2026-07-05T00:00:00.000Z'));
+```
+
+Add the same two assertions to the existing update response test after reading its `payload`.
+
+- [ ] **Step 4: Run the Management User characterization suite and verify GREEN before refactor**
+
+Run:
+
+```powershell
+node --experimental-vm-modules node_modules/jest/bin/jest.js tests/userListProjectionContract.test.js tests/userDetailProjectionContract.test.js tests/userCreateUpdateProjectionContract.test.js --runInBand
+```
+
+Expected: PASS on the pre-refactor implementation. This proves the task changes architecture, not behavior.
+
+- [ ] **Step 5: Replace duplicated read projection code with the canonical helper**
+
+In `src/controllers/user.controller.js`, import:
+
+```js
+import { buildUserPhotoInclude, mapUserPhotoProjection } from '../utils/userPhotoProjection.js';
+```
+
+Replace the two projection pairs:
+
+```js
+photo: user.photo_file ? user.photo_file.photo_url : null,
+photo_updated_at: user.photo_file ? user.photo_file.photo_updated_at : null,
+```
+
+with:
+
+```js
+...mapUserPhotoProjection(user),
+```
+
+Do this once in `toUserDetailProjection` and once in `toUserListProjection` only.
+
+Replace each of the four read/refetch include objects:
+
+```js
+{
+  model: Photo,
+  as: 'photo_file',
+  attributes: ['photo_url', 'photo_updated_at'],
+  required: false
+}
+```
+
+with:
+
+```js
+buildUserPhotoInclude(Photo);
+```
+
+The four bounded locations are `GET /users`, update response refetch, create response refetch, and `GET /users/:id`.
+
+Do not modify `uploadUserPhoto`, Photo row create/update payloads, Spaces cleanup, Cloudinary cleanup, or `User.id_photos` synchronization.
+
+- [ ] **Step 6: Run focused Management User contracts after refactor**
+
+Run:
+
+```powershell
+node --experimental-vm-modules node_modules/jest/bin/jest.js tests/userPhotoProjection.test.js tests/userListProjectionContract.test.js tests/userDetailProjectionContract.test.js tests/userCreateUpdateProjectionContract.test.js --runInBand
+```
+
+Expected: PASS with identical public photo values and null semantics.
+
+- [ ] **Step 7: Prove write-side and directory behavior remain unchanged**
+
+Run:
+
+```powershell
+node --experimental-vm-modules node_modules/jest/bin/jest.js tests/uploadUserPhotoController.test.js tests/usersListPaginationContract.test.js tests/usersPayloadContract.test.js tests/usersListSortContract.test.js --runInBand
+```
+
+Expected: PASS. No upload/storage test may require or mock the read projection helper.
+
+- [ ] **Step 8: Verify the duplicate read implementation is actually gone**
+
+Run:
+
+```powershell
+$controller = 'src/controllers/user.controller.js'
+$manualPatterns = @(
+  'photo:\s*user\.photo_file\s*\?',
+  'photo_updated_at:\s*user\.photo_file\s*\?',
+  "attributes:\s*\['photo_url', 'photo_updated_at'\]"
+)
+foreach ($pattern in $manualPatterns) {
+  if (Select-String -Path $controller -Pattern $pattern) {
+    throw "Duplicate manual photo projection remains: $pattern"
+  }
+}
+if ((Select-String -Path $controller -Pattern 'buildUserPhotoInclude\(Photo\)').Count -ne 4) {
+  throw 'Expected exactly four Management User read/refetch photo includes'
+}
+if ((Select-String -Path $controller -Pattern 'mapUserPhotoProjection\(user\)').Count -ne 2) {
+  throw 'Expected exactly two Management User photo mapping call sites'
+}
+```
+
+Expected: command completes without throwing. This is an architecture check, not a replacement for behavior tests.
+
+- [ ] **Step 9: Commit the bounded Management User consolidation**
+
+```powershell
+git add -- src/controllers/user.controller.js tests/userListProjectionContract.test.js tests/userDetailProjectionContract.test.js tests/userCreateUpdateProjectionContract.test.js
+git commit -m "refactor(#139): consolidate user photo read projection"
+```
+
+Do not stage unrelated files from the main checkout or Auth controller.
+
+---
+
+### Task 6: Cross-feature regression and completion verification
+
+**Files:**
+
 - No new production behavior.
 - Modify only a file already listed above if fresh verification proves a scoped #139 defect.
 
 **Interfaces:**
-- Produces fresh evidence that the additive projection did not change adjacent Attendance, Booking, User, OpenAPI, architecture, or lint behavior.
+
+- Produces fresh evidence that the shared photo projection does not change adjacent Management User, Attendance, Booking, OpenAPI, architecture, upload/storage, or lint behavior.
+
 - [ ] **Step 1: Run the focused cross-feature contract suite**
 
 Run:
 
 ```powershell
-node --experimental-vm-modules node_modules/jest/bin/jest.js tests/userPhotoProjection.test.js tests/attendanceManagementQuery.test.js tests/attendanceManagementMapper.test.js tests/attendanceManagementReadService.test.js tests/attendanceManagementOpenApiContract.test.js tests/bookingManagementQuery.test.js tests/bookingManagementMapper.test.js tests/bookingManagementReadService.test.js tests/bookingManagementOpenApiContract.test.js tests/userListProjectionContract.test.js tests/architectureLayerRules.test.js --runInBand
+node --experimental-vm-modules node_modules/jest/bin/jest.js tests/userPhotoProjection.test.js tests/userListProjectionContract.test.js tests/userDetailProjectionContract.test.js tests/userCreateUpdateProjectionContract.test.js tests/uploadUserPhotoController.test.js tests/usersListPaginationContract.test.js tests/usersPayloadContract.test.js tests/attendanceManagementQuery.test.js tests/attendanceManagementMapper.test.js tests/attendanceManagementReadService.test.js tests/attendanceManagementOpenApiContract.test.js tests/bookingManagementQuery.test.js tests/bookingManagementMapper.test.js tests/bookingManagementReadService.test.js tests/bookingManagementOpenApiContract.test.js tests/clientCriticalOpenApiContract.test.js tests/architectureLayerRules.test.js --runInBand
 ```
 
-Expected: all listed suites pass with zero failures.
+Expected: all listed suites pass with zero failures. User upload/storage regression remains green while the read helper is shared by three management surfaces.
 
 - [ ] **Step 2: Run lint**
 
@@ -627,9 +889,9 @@ Expected: exit code `0` with no ESLint errors.
 
 Run: `npm test -- --runInBand`
 
-Expected: all suites/tests pass. Record the fresh counts; do not reuse the pre-implementation baseline count of `146 suites / 1426 tests` as completion evidence.
+Expected: all suites/tests pass. Record fresh counts; do not reuse the original `146 suites / 1426 tests` baseline or any earlier branch run as completion evidence.
 
-- [ ] **Step 4: Verify whitespace and exact diff scope against the unambiguous remote-tracking ref**
+- [ ] **Step 4: Verify whitespace and exact diff scope**
 
 Run:
 
@@ -639,48 +901,49 @@ git diff --stat refs/remotes/origin/develop...HEAD
 git diff --name-only refs/remotes/origin/develop...HEAD
 git status --short --branch
 ```
+
 Expected production/documentation scope is limited to:
 
 ```text
 src/utils/userPhotoProjection.js
+src/controllers/user.controller.js
 src/modules/attendance/attendance.query.js
 src/modules/attendance/attendance.mapper.js
 src/modules/booking/bookingManagement.query.js
 src/modules/booking/bookingManagement.mapper.js
 docs/openapi.yaml
-focused tests listed in Tasks 1-4
+focused User/Attendance/Booking/OpenAPI tests named in Tasks 1-5
 spec/plan documentation commits
 ```
 
-The diff must not contain migrations, route files, controllers, auth/session code, attendance mutations/jobs, booking mutations, WFA scoring, storage config, Docker files, or Web FE files.
+The diff must not contain migrations, route files, `src/controllers/auth.controller.js`, attendance mutations/jobs, booking mutations, WFA scoring, storage config, Docker files, or Web FE files. `src/controllers/user.controller.js` is allowed only for the bounded read/refetch consolidation from Task 5.
 
-- [ ] **Step 5: Verify the intended runtime contract if authenticated runtime access already exists**
+- [ ] **Step 5: Verify authenticated runtime contract when access already exists**
 
-For one Management/Admin session, inspect `GET /api/attendance?page=1&limit=10` and `GET /api/bookings?page=1&limit=10` for both a user with a linked photo and a user without one. Confirm:
+For a Management/Admin session, inspect User, Attendance, and Booking read surfaces using one user with a linked photo and one user without one. Confirm:
 
 ```text
-Attendance with photo     → user.photo != null; user.photo_updated_at != null
-Attendance without photo  → user.photo == null; user.photo_updated_at == null
-Booking with photo        → user_photo != null; user_photo_updated_at != null
-Booking without photo     → user_photo == null; user_photo_updated_at == null
+GET /api/users                 -> photo/photo_updated_at present or explicit null
+GET /api/users/:id             -> same canonical User photo fields
+GET /api/attendance            -> user.photo/user.photo_updated_at
+GET /api/bookings              -> user_photo/user_photo_updated_at
+missing photo on any surface   -> explicit nulls; parent row remains present
 ```
 
-Also confirm row counts/pagination remain consistent with the same requests before this feature. If no authenticated runtime session is already available, do not invent credentials or claim runtime evidence; record `Runtime evidence: Needs Verification` in the PR handoff.
+Also confirm User pagination/counts and Attendance/Booking pagination remain consistent with the same requests before consolidation. If no authenticated runtime session is already available, do not invent credentials or claim runtime evidence; record `Runtime evidence: Needs Verification` in the PR handoff.
 
-- [ ] **Step 6: Review commit history and final requirement coverage**
+- [ ] **Step 6: Review commit history and remaining requirement coverage**
 
 Run:
 
 ```powershell
 git log --oneline refs/remotes/origin/develop..HEAD
 ```
-Expected implementation commit sequence after the already-committed design spec:
+
+Existing implementation history must include the helper, Attendance projection, Booking projection, OpenAPI contract, compatibility mocks, and revised design. After Task 5, it must additionally include:
 
 ```text
-feat(#139): add explicit user photo projection helper
-feat(#139): project profile photo in attendance reads
-feat(#139): project applicant photo in booking reads
-docs(#139): publish management profile photo fields
+refactor(#139): consolidate user photo read projection
 ```
 
 Do not create a verification-only commit unless verification exposes and fixes a scoped defect.
@@ -691,13 +954,15 @@ Before calling GitHub #139 implementation-ready for PR:
 
 - [ ] shared include selects only `photo_url` and `photo_updated_at` and is always optional;
 - [ ] shared mapper returns persisted evidence unchanged and explicit nulls when absent;
+- [ ] Management User list/detail/create/update response refetches use the canonical helper without changing `photo` / `photo_updated_at` payloads;
+- [ ] Management User list pagination/search/sort and detail `404 E_NOT_FOUND` / `409 E_USER_LOCATION_INTEGRITY` behavior remain unchanged;
+- [ ] Management User photo upload/storage/delete mutation remains explicit and independent of the read helper;
 - [ ] Attendance list and detail both expose `user.photo` and `user.photo_updated_at`;
 - [ ] Attendance search-required User behavior and pagination remain unchanged;
 - [ ] Booking applicant exposes `user_photo` and `user_photo_updated_at`;
 - [ ] Booking processor has no photo include/fields;
 - [ ] Booking ordering/search/filter/pagination/scoring/reason behavior remains unchanged;
-- [ ] Management User regression coverage remains green without refactoring its controller;
-- [ ] OpenAPI matches the four new nullable fields exactly;
-- [ ] no route, controller, migration, storage, scheduler, auth, or mutation file enters the diff;
+- [ ] OpenAPI matches the Attendance and Booking nullable fields exactly; User OpenAPI contract is unchanged;
+- [ ] no route, migration, storage, scheduler, Auth, or unrelated controller/mutation file enters the diff;
 - [ ] focused tests, lint, full Jest suite, and `git diff --check` have fresh passing evidence;
-- [ ] runtime evidence is either captured truthfully or explicitly marked `Needs Verification`.
+- [ ] runtime evidence covers User/Attendance/Booking truthfully or is explicitly marked `Needs Verification`.

--- a/docs/superpowers/plans/2026-08-10-gh-139-profile-photo-projection.md
+++ b/docs/superpowers/plans/2026-08-10-gh-139-profile-photo-projection.md
@@ -1,0 +1,703 @@
+# GitHub #139 Management Profile Photo Projection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Backend-authored profile-photo metadata to Management Attendance list/detail and Management Booking applicant rows without adding endpoints, migrations, N+1 lookups, or implicit global photo loading.
+
+**Architecture:** Keep Photo owned by User. Add one small reusable explicit projection helper under `src/utils/`, then make the existing Attendance and Booking query builders opt into the optional `User -> photo_file` join and map the result into their existing response shapes. Preserve every existing request, filter, sorting, pagination, authorization, mutation, and storage contract.
+
+**Tech Stack:** Node.js ESM, Express 4, Sequelize 6, MySQL, Jest 29 with VM modules, OpenAPI YAML.
+
+## Global Constraints
+
+- Base branch: `develop`; implementation worktree base commit: `577793842c172018b3cb40c44853438d90c14c22`.
+- Work only on `feature/gh-139-profile-photo-projection` in the isolated worktree.
+- TDD is mandatory: each production behavior starts with a focused failing test.
+- No new route, endpoint, request parameter, status code, or response envelope.
+- No database migration or User/Photo association change.
+- No photo upload, storage, deletion, URL signing, probing, caching, or fallback behavior.
+- No global/default Sequelize scope that loads Photo implicitly.
+- No per-row database query and no User-detail HTTP lookup.
+- Attendance photo fields are exactly `user.photo` and `user.photo_updated_at` in list and detail.
+- Booking applicant photo fields are exactly `user_photo` and `user_photo_updated_at`.
+- Booking `processed_by` does not gain photo fields.
+- Missing photo evidence produces explicit `null` values and never removes the parent row.
+- Preserve Attendance search/filter/sort/pagination/detail semantics unchanged.
+- Preserve Booking search/filter/order/pagination/approval/rejection/scoring semantics unchanged.
+- Leave Management User implementation unchanged; use its tests only as regression/reference evidence.
+
+---## File Map
+
+**Create**
+- `src/utils/userPhotoProjection.js` — reusable explicit Sequelize include descriptor plus null-safe photo metadata mapper.
+- `tests/userPhotoProjection.test.js` — pins helper alias, selected attributes, optionality, persisted values, and null semantics.
+
+**Modify — Attendance**
+- `src/modules/attendance/attendance.query.js` — explicitly include `Photo` under the existing User include for list and detail.
+- `src/modules/attendance/attendance.mapper.js` — add `photo` and `photo_updated_at` to the nested user projection.
+- `tests/attendanceManagementQuery.test.js` — pin optional Photo include without changing parent User search behavior.
+- `tests/attendanceManagementMapper.test.js` — pin present/null photo fields in list and detail.
+- `tests/attendanceManagementReadService.test.js` — add the `Photo` model mock required by the real query builder and keep service behavior unchanged.
+
+**Modify — Booking**
+- `src/modules/booking/bookingManagement.query.js` — explicitly include `Photo` for applicant User only.
+- `src/modules/booking/bookingManagement.mapper.js` — add flattened `user_photo` and `user_photo_updated_at`.
+- `tests/bookingManagementQuery.test.js` — pin applicant Photo include and processor exclusion.
+- `tests/bookingManagementMapper.test.js` — pin present/null applicant photo projection.
+
+**Modify — Public contract**
+- `docs/openapi.yaml` — document Attendance list/detail nested photo fields and Booking flattened applicant photo fields.
+- `tests/attendanceManagementOpenApiContract.test.js` — pin exact nullable Attendance photo schema.
+- `tests/bookingManagementOpenApiContract.test.js` — pin exact nullable Booking photo schema.
+
+**Regression only; do not modify unless a scoped failure proves necessary**
+- `tests/bookingManagementReadService.test.js`
+- `tests/userListProjectionContract.test.js`
+### Task 1: Lock the shared explicit User photo projection primitive
+
+**Files:**
+- Create: `tests/userPhotoProjection.test.js`
+- Create: `src/utils/userPhotoProjection.js`
+
+**Interfaces:**
+- Produces: `buildUserPhotoInclude(PhotoModel)` returning a Sequelize include object.
+- Produces: `mapUserPhotoProjection(user)` returning `{ photo, photo_updated_at }`.
+- Consumed by: Attendance query/mapper in Task 2 and Booking query/mapper in Task 3.
+
+- [ ] **Step 1: Write the failing helper contract test**
+
+```js
+import {
+  buildUserPhotoInclude,
+  mapUserPhotoProjection
+} from '../src/utils/userPhotoProjection.js';
+
+const Photo = { modelName: 'Photo' };
+
+test('builds the explicit optional photo_file include', () => {
+  expect(buildUserPhotoInclude(Photo)).toEqual({
+    model: Photo,
+    as: 'photo_file',
+    attributes: ['photo_url', 'photo_updated_at'],
+    required: false
+  });
+});
+``````js
+test('maps persisted photo evidence without rewriting it', () => {
+  const updatedAt = new Date('2026-08-10T08:30:00.000Z');
+  expect(mapUserPhotoProjection({
+    photo_file: {
+      photo_url: 'https://cdn.example.com/users/7/profile/photo.jpg',
+      photo_updated_at: updatedAt
+    }
+  })).toEqual({
+    photo: 'https://cdn.example.com/users/7/profile/photo.jpg',
+    photo_updated_at: updatedAt
+  });
+});
+
+test.each([null, undefined, {}, { photo_file: null }])(
+  'maps absent photo evidence to explicit nulls',
+  (user) => {
+    expect(mapUserPhotoProjection(user)).toEqual({
+      photo: null,
+      photo_updated_at: null
+    });
+  }
+);
+```
+
+- [ ] **Step 2: Run the helper test and verify RED**
+
+Run: `node --experimental-vm-modules node_modules/jest/bin/jest.js tests/userPhotoProjection.test.js --runInBand`
+
+Expected: FAIL because `src/utils/userPhotoProjection.js` does not exist.
+- [ ] **Step 3: Implement the minimal shared helper**
+
+```js
+export const buildUserPhotoInclude = (PhotoModel) => ({
+  model: PhotoModel,
+  as: 'photo_file',
+  attributes: ['photo_url', 'photo_updated_at'],
+  required: false
+});
+
+export const mapUserPhotoProjection = (user) => ({
+  photo: user?.photo_file?.photo_url ?? null,
+  photo_updated_at: user?.photo_file?.photo_updated_at ?? null
+});
+```
+
+Do not import `Photo` or `models/index.js` in this helper. Query builders must opt in explicitly by passing the model.
+
+- [ ] **Step 4: Run the helper test and verify GREEN**
+
+Run: `node --experimental-vm-modules node_modules/jest/bin/jest.js tests/userPhotoProjection.test.js --runInBand`
+
+Expected: PASS with all helper tests green.
+
+- [ ] **Step 5: Commit the helper contract**
+
+```powershell
+git add -- src/utils/userPhotoProjection.js tests/userPhotoProjection.test.js
+git commit -m "feat(#139): add explicit user photo projection helper"
+```
+### Task 2: Project profile photo through Management Attendance list and detail
+
+**Files:**
+- Modify: `tests/attendanceManagementQuery.test.js`
+- Modify: `tests/attendanceManagementMapper.test.js`
+- Modify: `tests/attendanceManagementReadService.test.js`
+- Modify: `src/modules/attendance/attendance.query.js`
+- Modify: `src/modules/attendance/attendance.mapper.js`
+
+**Interfaces:**
+- Consumes: `buildUserPhotoInclude(PhotoModel)` and `mapUserPhotoProjection(user)` from Task 1.
+- Produces: list/detail nested user objects containing `photo` and `photo_updated_at` on every mapped Attendance row.
+- Keeps: existing parent User required/search behavior, fields, filters, ordering, pagination, detail location semantics, and service envelope.
+
+- [ ] **Step 1: Write RED query assertions for the optional nested Photo join**
+
+Change the test import to:
+
+```js
+import { AttendanceStatus, Photo, User } from '../src/models/index.js';
+```
+
+Add:
+
+```js
+test('includes the same optional lightweight photo projection in list and detail', () => {
+  const list = buildAttendanceListQuery({ page: 1, limit: 10 });
+  const listUser = list.include.find((item) => item.as === 'user');
+  const listPhoto = listUser.include.find((item) => item.as === 'photo_file');
+
+  expect(listUser.required).toBe(false);
+  expect(listPhoto).toEqual({
+    model: Photo, as: 'photo_file',
+    attributes: ['photo_url', 'photo_updated_at'], required: false
+  });
+``````js
+  const searched = buildAttendanceListQuery({ page: 1, limit: 10, search: 'Andi' });
+  expect(searched.include.find((item) => item.as === 'user').required).toBe(true);
+
+  const detail = buildAttendanceDetailQuery();
+  const detailUser = detail.include.find((item) => item.as === 'user');
+  const detailPhoto = detailUser.include.find((item) => item.as === 'photo_file');
+  expect(detailUser.required).toBe(false);
+  expect(detailPhoto).toEqual({
+    model: Photo, as: 'photo_file',
+    attributes: ['photo_url', 'photo_updated_at'], required: false
+  });
+});
+```
+
+This test must not change the expected top-level include aliases, list `limit`/`offset`, or stable ordering assertions already present.
+
+- [ ] **Step 2: Extend Attendance mapper fixtures and expectations before production code**
+
+Add `photo_file` to the shared `row.user` fixture:
+
+```js
+photo_file: {
+  photo_url: 'https://cdn.example.com/users/7/profile/photo.jpg',
+  photo_updated_at: new Date('2026-08-10T08:30:00.000Z')
+}
+```
+
+Update the exact list-user expectation to include those two projected values.
+Add a null-evidence mapper test:
+
+```js
+test('keeps photo fields present and null when the user has no linked photo', () => {
+  const noPhoto = {
+    ...row,
+    user: { ...row.user, photo_file: null }
+  };
+
+  expect(mapAttendanceListRow(noPhoto).user).toMatchObject({
+    photo: null,
+    photo_updated_at: null
+  });
+  expect(mapAttendanceDetail(noPhoto).user).toMatchObject({
+    photo: null,
+    photo_updated_at: null
+  });
+});
+```
+
+Update the existing `user: null` exact expectation to:
+
+```js
+{
+  id: null,
+  full_name: null,
+  nip_nim: null,
+  photo: null,
+  photo_updated_at: null,
+  role: null
+}
+```
+- [ ] **Step 3: Update the Attendance read-service test fixture/mocks and verify the suite is RED**
+
+In `tests/attendanceManagementReadService.test.js`:
+
+```js
+jest.unstable_mockModule('../src/models/index.js', () => ({
+  Attendance: { findAndCountAll, findByPk },
+  User: {},
+  Role: {},
+  Photo: {},
+  Location: {},
+  AttendanceStatus: {},
+  AttendanceCategory: {}
+}));
+```
+
+Add the same `photo_file` fixture under `row.user`, then update the list result expectation to include:
+
+```js
+photo: 'https://cdn.example.com/users/7/profile/photo.jpg',
+photo_updated_at: new Date('2026-08-10T08:30:00.000Z')
+```
+
+Run:
+
+`node --experimental-vm-modules node_modules/jest/bin/jest.js tests/attendanceManagementQuery.test.js tests/attendanceManagementMapper.test.js tests/attendanceManagementReadService.test.js --runInBand`
+
+Expected: FAIL because the query does not yet include Photo and the mapper does not emit the new fields.
+- [ ] **Step 4: Implement the minimal Attendance query integration**
+
+Change the model import to include `Photo`, and import the helper:
+
+```js
+import {
+  AttendanceCategory, AttendanceStatus, Location, Photo, Role, User
+} from '../../models/index.js';
+import { buildUserPhotoInclude } from '../../utils/userPhotoProjection.js';
+```
+
+Change both existing User `include` arrays to contain Role plus the photo include:
+
+```js
+include: [
+  { model: Role, as: 'role', attributes: ['role_name'], required: false },
+  buildUserPhotoInclude(Photo)
+]
+```
+
+Do not change `userInclude.required`, search predicates, parent User attributes, top-level includes, ordering, limit, offset, or `distinct`.
+
+- [ ] **Step 5: Implement the minimal Attendance mapper integration**
+
+Add:
+
+```js
+import { mapUserPhotoProjection } from '../../utils/userPhotoProjection.js';
+```
+Then extend `userOf` without changing email or role semantics:
+
+```js
+const userOf = (row, includeEmail = false) => ({
+  id: row.user?.id_users ?? null,
+  full_name: row.user?.full_name ?? null,
+  nip_nim: row.user?.nip_nim ?? null,
+  ...(includeEmail ? { email: row.user?.email ?? null } : {}),
+  ...mapUserPhotoProjection(row.user),
+  role: row.user?.role?.role_name ?? null
+});
+```
+
+- [ ] **Step 6: Run the focused Attendance tests and verify GREEN**
+
+Run:
+
+`node --experimental-vm-modules node_modules/jest/bin/jest.js tests/attendanceManagementQuery.test.js tests/attendanceManagementMapper.test.js tests/attendanceManagementReadService.test.js --runInBand`
+
+Expected: PASS. Existing assertions for search-required User joins, detail fields, pagination, modes/statuses, location semantics, and ordering remain green.
+
+- [ ] **Step 7: Commit the Attendance projection**
+
+```powershell
+git add -- src/modules/attendance/attendance.query.js src/modules/attendance/attendance.mapper.js tests/attendanceManagementQuery.test.js tests/attendanceManagementMapper.test.js tests/attendanceManagementReadService.test.js
+git commit -m "feat(#139): project profile photo in attendance reads"
+```
+### Task 3: Project applicant profile photo through Management Booking
+
+**Files:**
+- Modify: `tests/bookingManagementQuery.test.js`
+- Modify: `tests/bookingManagementMapper.test.js`
+- Modify: `src/modules/booking/bookingManagement.query.js`
+- Modify: `src/modules/booking/bookingManagement.mapper.js`
+
+**Interfaces:**
+- Consumes: `buildUserPhotoInclude(PhotoModel)` and `mapUserPhotoProjection(user)` from Task 1.
+- Produces: every Management Booking row contains nullable `user_photo` and `user_photo_updated_at` fields derived from the applicant User only.
+- Keeps: applicant search behavior, Position/Role joins, processor identity, fixed approval-first ordering, filters, pagination, WFA reason/scoring semantics.
+
+- [ ] **Step 1: Write RED Booking query assertions**
+
+Add `Photo` to the mocked model registry:
+
+```js
+const Photo = { modelName: 'Photo' };
+
+jest.unstable_mockModule('../src/models/index.js', () => ({
+  User,
+  Position,
+  Role,
+  Photo,
+  Location,
+  BookingStatus,
+  WfaRequestReason,
+  WfaRejectionReason
+}));
+```
+Extend the existing applicant include assertion:
+
+```js
+expect(applicant.include).toEqual(expect.arrayContaining([
+  expect.objectContaining({ model: Position, as: 'position' }),
+  expect.objectContaining({ model: Role, as: 'role' }),
+  {
+    model: Photo,
+    as: 'photo_file',
+    attributes: ['photo_url', 'photo_updated_at'],
+    required: false
+  }
+]));
+```
+
+In the processor test, prove the photo include is absent:
+
+```js
+expect(processor.include.some((item) => item.as === 'photo_file')).toBe(false);
+```
+
+Keep the existing no-search applicant `required: false`, active-search `required: true`, wildcard escaping, fixed order, limit, offset, and `distinct` assertions unchanged.
+
+- [ ] **Step 2: Write RED Booking mapper assertions**
+
+Add to `baseRow.user`:
+
+```js
+photo_file: {
+  photo_url: 'https://cdn.example.com/users/7/profile/photo.jpg',
+  photo_updated_at: new Date('2026-08-10T08:30:00.000Z')
+}
+```
+Extend the existing manual-processor mapping assertion with:
+
+```js
+user_photo: 'https://cdn.example.com/users/7/profile/photo.jpg',
+user_photo_updated_at: new Date('2026-08-10T08:30:00.000Z')
+```
+
+Add a null-evidence mapper test:
+
+```js
+test('keeps applicant photo fields present and null without linked photo evidence', () => {
+  const result = mapBookingManagementRow({
+    ...baseRow,
+    user: { ...baseRow.user, photo_file: null },
+    processor: null,
+    request_reason: null,
+    rejection_reason_detail: null,
+    radius_snapshot: 100
+  });
+
+  expect(result.user_photo).toBeNull();
+  expect(result.user_photo_updated_at).toBeNull();
+});
+```
+
+- [ ] **Step 3: Run the focused Booking tests and verify RED**
+
+Run:
+
+`node --experimental-vm-modules node_modules/jest/bin/jest.js tests/bookingManagementQuery.test.js tests/bookingManagementMapper.test.js tests/bookingManagementReadService.test.js --runInBand`
+
+Expected: query/mapper tests FAIL because applicant Photo is not yet included and mapped; read-service regression remains green or fails only because mapped fixture expectations were intentionally expanded.
+- [ ] **Step 4: Implement the minimal Booking query integration**
+
+Change the model import to include `Photo`, then import the helper:
+
+```js
+import {
+  BookingStatus,
+  Location,
+  Photo,
+  Position,
+  Role,
+  User,
+  WfaRejectionReason,
+  WfaRequestReason
+} from '../../models/index.js';
+import { buildUserPhotoInclude } from '../../utils/userPhotoProjection.js';
+```
+
+Append the photo include only inside `buildApplicantInclude`:
+
+```js
+include: [
+  { model: Position, as: 'position', attributes: ['position_name'], required: false },
+  { model: Role, as: 'role', attributes: ['id_roles', 'role_name'], required: false },
+  buildUserPhotoInclude(Photo)
+]
+```
+
+Do not modify `buildProcessorInclude`.
+- [ ] **Step 5: Implement the minimal Booking mapper integration**
+
+Import the shared mapper:
+
+```js
+import { mapUserPhotoProjection } from '../../utils/userPhotoProjection.js';
+```
+
+Inside `mapBookingManagementRow`, derive the applicant photo once:
+
+```js
+const { photo, photo_updated_at: photoUpdatedAt } = mapUserPhotoProjection(row.user);
+```
+
+Add these fields next to the existing applicant identity projection:
+
+```js
+user_photo: photo,
+user_photo_updated_at: photoUpdatedAt,
+```
+
+Do not change `processed_by`, reasons, suitability, radius fallback, location conversion, status, timestamps, or raw `approved_by` compatibility.
+
+- [ ] **Step 6: Run the focused Booking tests and verify GREEN**
+
+Run:
+
+`node --experimental-vm-modules node_modules/jest/bin/jest.js tests/bookingManagementQuery.test.js tests/bookingManagementMapper.test.js tests/bookingManagementReadService.test.js --runInBand`
+
+Expected: PASS with processor-photo exclusion and all existing ordering/search/pagination/scoring assertions still green.
+
+- [ ] **Step 7: Commit the Booking projection**
+
+```powershell
+git add -- src/modules/booking/bookingManagement.query.js src/modules/booking/bookingManagement.mapper.js tests/bookingManagementQuery.test.js tests/bookingManagementMapper.test.js
+git commit -m "feat(#139): project applicant photo in booking reads"
+```
+### Task 4: Publish the additive photo fields in OpenAPI
+
+**Files:**
+- Modify: `tests/attendanceManagementOpenApiContract.test.js`
+- Modify: `tests/bookingManagementOpenApiContract.test.js`
+- Modify: `docs/openapi.yaml`
+
+**Interfaces:**
+- Documents runtime fields produced by Tasks 2 and 3.
+- Attendance list/detail photo fields are required keys with nullable values.
+- Booking photo fields are nullable properties on the existing `BookingManagementItem` schema; do not create a new booking schema or change its pagination schema.
+
+- [ ] **Step 1: Write RED Attendance OpenAPI assertions**
+
+Add:
+
+```js
+test('documents nullable profile photo evidence on attendance list and detail users', () => {
+  const listUser = api.components.schemas.AttendanceAuditListRow.properties.user;
+  const detailUser = api.components.schemas.AttendanceAuditDetail.properties.user;
+
+  for (const user of [listUser, detailUser]) {
+    expect(user.required).toEqual(expect.arrayContaining(['photo', 'photo_updated_at']));
+    expect(user.properties.photo).toMatchObject({
+      type: 'string', format: 'uri', nullable: true
+    });
+    expect(user.properties.photo_updated_at).toMatchObject({
+      type: 'string', format: 'date-time', nullable: true
+    });
+  }
+});
+```
+- [ ] **Step 2: Write RED Booking OpenAPI assertions**
+
+Extend the existing `BookingManagementItem` schema test:
+
+```js
+expect(item.properties.user_photo).toMatchObject({
+  type: 'string',
+  format: 'uri',
+  nullable: true
+});
+expect(item.properties.user_photo_updated_at).toMatchObject({
+  type: 'string',
+  format: 'date-time',
+  nullable: true
+});
+```
+
+Do not add these fields to `BookingProcessor`.
+
+- [ ] **Step 3: Run only the two OpenAPI tests and verify RED**
+
+Run:
+
+```powershell
+node --experimental-vm-modules node_modules/jest/bin/jest.js tests/attendanceManagementOpenApiContract.test.js tests/bookingManagementOpenApiContract.test.js --runInBand
+```
+
+Expected: FAIL because the four new schema properties are not yet documented.
+- [ ] **Step 4: Update the Attendance OpenAPI user schemas**
+
+For both `AttendanceAuditListRow.properties.user` and `AttendanceAuditDetail.properties.user`:
+
+1. add `photo` and `photo_updated_at` to the nested `required` array;
+2. add these exact properties:
+
+```yaml
+photo:
+  type: string
+  format: uri
+  nullable: true
+photo_updated_at:
+  type: string
+  format: date-time
+  nullable: true
+```
+
+Keep list-only/detail-only differences unchanged: list still omits email and detail still includes email.
+
+- [ ] **Step 5: Update `BookingManagementItem` only**
+
+Add:
+
+```yaml
+user_photo:
+  type: string
+  format: uri
+  nullable: true
+user_photo_updated_at:
+  type: string
+  format: date-time
+  nullable: true
+```
+Do not modify `BookingProcessor`, `BookingManagementPagination`, endpoint parameters, authorization descriptions, or response envelopes.
+
+- [ ] **Step 6: Run the OpenAPI contract tests and verify GREEN**
+
+Run:
+
+```powershell
+node --experimental-vm-modules node_modules/jest/bin/jest.js tests/attendanceManagementOpenApiContract.test.js tests/bookingManagementOpenApiContract.test.js tests/clientCriticalOpenApiContract.test.js --runInBand
+```
+
+Expected: PASS. The client-critical OpenAPI regression must remain green.
+
+- [ ] **Step 7: Commit the public contract**
+
+```powershell
+git add -- docs/openapi.yaml tests/attendanceManagementOpenApiContract.test.js tests/bookingManagementOpenApiContract.test.js
+git commit -m "docs(#139): publish management profile photo fields"
+```
+
+---
+
+### Task 5: Cross-feature regression and completion verification
+
+**Files:**
+- No new production behavior.
+- Modify only a file already listed above if fresh verification proves a scoped #139 defect.
+
+**Interfaces:**
+- Produces fresh evidence that the additive projection did not change adjacent Attendance, Booking, User, OpenAPI, architecture, or lint behavior.
+- [ ] **Step 1: Run the focused cross-feature contract suite**
+
+Run:
+
+```powershell
+node --experimental-vm-modules node_modules/jest/bin/jest.js tests/userPhotoProjection.test.js tests/attendanceManagementQuery.test.js tests/attendanceManagementMapper.test.js tests/attendanceManagementReadService.test.js tests/attendanceManagementOpenApiContract.test.js tests/bookingManagementQuery.test.js tests/bookingManagementMapper.test.js tests/bookingManagementReadService.test.js tests/bookingManagementOpenApiContract.test.js tests/userListProjectionContract.test.js tests/architectureLayerRules.test.js --runInBand
+```
+
+Expected: all listed suites pass with zero failures.
+
+- [ ] **Step 2: Run lint**
+
+Run: `npm run lint`
+
+Expected: exit code `0` with no ESLint errors.
+
+- [ ] **Step 3: Run the complete non-integration Jest baseline**
+
+Run: `npm test -- --runInBand`
+
+Expected: all suites/tests pass. Record the fresh counts; do not reuse the pre-implementation baseline count of `146 suites / 1426 tests` as completion evidence.
+
+- [ ] **Step 4: Verify whitespace and exact diff scope against the unambiguous remote-tracking ref**
+
+Run:
+
+```powershell
+git diff --check refs/remotes/origin/develop...HEAD
+git diff --stat refs/remotes/origin/develop...HEAD
+git diff --name-only refs/remotes/origin/develop...HEAD
+git status --short --branch
+```
+Expected production/documentation scope is limited to:
+
+```text
+src/utils/userPhotoProjection.js
+src/modules/attendance/attendance.query.js
+src/modules/attendance/attendance.mapper.js
+src/modules/booking/bookingManagement.query.js
+src/modules/booking/bookingManagement.mapper.js
+docs/openapi.yaml
+focused tests listed in Tasks 1-4
+spec/plan documentation commits
+```
+
+The diff must not contain migrations, route files, controllers, auth/session code, attendance mutations/jobs, booking mutations, WFA scoring, storage config, Docker files, or Web FE files.
+
+- [ ] **Step 5: Verify the intended runtime contract if authenticated runtime access already exists**
+
+For one Management/Admin session, inspect `GET /api/attendance?page=1&limit=10` and `GET /api/bookings?page=1&limit=10` for both a user with a linked photo and a user without one. Confirm:
+
+```text
+Attendance with photo     → user.photo != null; user.photo_updated_at != null
+Attendance without photo  → user.photo == null; user.photo_updated_at == null
+Booking with photo        → user_photo != null; user_photo_updated_at != null
+Booking without photo     → user_photo == null; user_photo_updated_at == null
+```
+
+Also confirm row counts/pagination remain consistent with the same requests before this feature. If no authenticated runtime session is already available, do not invent credentials or claim runtime evidence; record `Runtime evidence: Needs Verification` in the PR handoff.
+
+- [ ] **Step 6: Review commit history and final requirement coverage**
+
+Run:
+
+```powershell
+git log --oneline refs/remotes/origin/develop..HEAD
+```
+Expected implementation commit sequence after the already-committed design spec:
+
+```text
+feat(#139): add explicit user photo projection helper
+feat(#139): project profile photo in attendance reads
+feat(#139): project applicant photo in booking reads
+docs(#139): publish management profile photo fields
+```
+
+Do not create a verification-only commit unless verification exposes and fixes a scoped defect.
+
+## Completion Checklist
+
+Before calling GitHub #139 implementation-ready for PR:
+
+- [ ] shared include selects only `photo_url` and `photo_updated_at` and is always optional;
+- [ ] shared mapper returns persisted evidence unchanged and explicit nulls when absent;
+- [ ] Attendance list and detail both expose `user.photo` and `user.photo_updated_at`;
+- [ ] Attendance search-required User behavior and pagination remain unchanged;
+- [ ] Booking applicant exposes `user_photo` and `user_photo_updated_at`;
+- [ ] Booking processor has no photo include/fields;
+- [ ] Booking ordering/search/filter/pagination/scoring/reason behavior remains unchanged;
+- [ ] Management User regression coverage remains green without refactoring its controller;
+- [ ] OpenAPI matches the four new nullable fields exactly;
+- [ ] no route, controller, migration, storage, scheduler, auth, or mutation file enters the diff;
+- [ ] focused tests, lint, full Jest suite, and `git diff --check` have fresh passing evidence;
+- [ ] runtime evidence is either captured truthfully or explicitly marked `Needs Verification`.

--- a/docs/superpowers/specs/2026-08-10-gh-139-profile-photo-projection-design.md
+++ b/docs/superpowers/specs/2026-08-10-gh-139-profile-photo-projection-design.md
@@ -1,0 +1,359 @@
+# GitHub #139 Management Profile Photo Projection Design
+
+**Date:** 2026-08-10
+**Issue:** `Infinite-LearningV1/Infinit_Track_BE#139`
+**Coordination:** `Infinite-LearningV1/Infinit_Track_BE#138`
+**Downstream:** `Infinite-LearningV1/Infinite_Track_Fe#64`
+**Repository:** `Infinite-LearningV1/Infinit_Track_BE`
+**Base branch:** `develop`
+**Base commit:** `577793842c172018b3cb40c44853438d90c14c22`
+**Working branch:** `feature/gh-139-profile-photo-projection`
+
+## Purpose
+
+Expose the existing User profile photo as lightweight identity metadata in Management Attendance and Management Booking responses.
+
+The Backend remains the source of truth for photo identity. Attendance and Booking do not own photo state; they only project the photo metadata needed by their management read surfaces.
+
+This is an additive read-contract change. It does not add a photo endpoint, database migration, upload behavior, storage policy, or client-side lookup requirement.
+
+## Verified baseline
+
+The isolated worktree starts from the merged `develop` commit `5777938`.
+
+Fresh baseline verification:
+
+```text
+Test Suites: 146 passed, 146 total
+Tests:       1426 passed, 1426 total
+npm run lint: PASS
+```
+
+## Current verified contract
+
+The photo source already exists and needs no schema work:
+
+- `Photo.photo_url` stores the persisted profile-photo URL.
+- `Photo.photo_updated_at` records when that photo record was last replaced.
+- `User.belongsTo(Photo, { as: 'photo_file', foreignKey: 'id_photos' })` is already registered.
+- a user may have no linked `photo_file`; therefore every client-facing photo projection is nullable even though `photo_url` is non-null on an existing Photo row.
+
+Management User is the reference behavior. Its list/detail queries explicitly LEFT JOIN `photo_file` with only `photo_url` and `photo_updated_at`, then expose `photo` and `photo_updated_at`.
+
+Management Attendance currently joins `User -> Role` but not `Photo`. Its list/detail mapper therefore cannot expose profile-photo metadata.
+
+Management Booking currently joins applicant `User -> Position/Role` but not `Photo`. Its mapper exposes applicant identity as flattened `user_*` fields but has no photo fields.
+
+The dashboard today-locations snapshot independently proves that a nested optional `User -> photo_file` include already works in this repository without changing the User association.
+
+## Product and architecture decisions
+
+Profile photo remains User-owned identity evidence. Attendance and Booking only consume it for presentation-oriented management reads.
+
+The change must remain explicit at each query boundary: an endpoint receives photo metadata only when its own projection asks for it. No query-wide or model-wide implicit photo loading is introduced.
+
+## Scope
+
+This issue covers:
+
+- a small reusable profile-photo projection primitive;
+- explicit optional Photo includes in Management Attendance list/detail queries;
+- explicit optional Photo include in the Management Booking applicant query;
+- additive Attendance and Booking response fields;
+- OpenAPI updates for the new nullable fields;
+- focused query, mapper, read-service regression, and OpenAPI contract tests.
+
+Out of scope:
+
+- new photo-read endpoints;
+- changes to `POST /users/:id/photo` or user creation/update uploads;
+- changes to Spaces/Cloudinary storage, URL generation, deletion, or cache policy;
+- database migrations or association changes;
+- adding photo data to the Booking processor identity;
+- changing Attendance search/filter/sort/pagination/detail ownership;
+- changing Booking search/filter/order/pagination/approval/rejection semantics;
+- refactoring the legacy Management User controller merely to adopt the new helper;
+- Web FE implementation from `Infinite_Track_Fe#64`.
+
+## Approaches considered
+
+### A. Duplicate Photo include and null mapping in both features
+
+Smallest file count, but repeats the same association alias, selected attributes, optional-join rule, and null semantics. Future identity surfaces could drift again.
+
+### B. Reusable explicit photo projection primitive — selected
+
+Create a focused helper under `src/utils/userPhotoProjection.js`. Query builders still opt in explicitly by passing the `Photo` model; response mappers reuse one null-safe projection rule.
+
+Benefits:
+
+- preserves explicit data ownership at each query;
+- avoids a global ORM scope;
+- keeps Attendance and Booking mapping semantics aligned;
+- stays small enough for this bounded contract change;
+- can be adopted by future identity projections without forcing a refactor of existing consumers.
+
+### C. Dedicated photo endpoint or global User photo scope
+
+Rejected. A dedicated endpoint encourages N+1 HTTP calls for paginated tables. A global User scope makes every User read pay for or depend on Photo implicitly, including flows that do not need presentation identity.
+
+## Shared projection primitive
+
+The selected helper has two responsibilities only:
+
+```js
+buildUserPhotoInclude(PhotoModel)
+mapUserPhotoProjection(user)
+```
+
+`buildUserPhotoInclude` returns an optional `photo_file` include selecting exactly `photo_url` and `photo_updated_at`. It receives the model as a dependency rather than importing the model registry itself.
+
+`mapUserPhotoProjection` is ORM-agnostic and returns exactly `{ photo, photo_updated_at }`, with both values `null` when `user.photo_file` is absent.
+
+The conceptual shape is:
+
+```js
+export const buildUserPhotoInclude = (PhotoModel) => ({
+  model: PhotoModel,
+  as: 'photo_file',
+  attributes: ['photo_url', 'photo_updated_at'],
+  required: false
+});
+
+export const mapUserPhotoProjection = (user) => ({
+  photo: user?.photo_file?.photo_url ?? null,
+  photo_updated_at: user?.photo_file?.photo_updated_at ?? null
+});
+```
+
+The helper does not fetch, upload, transform, validate, sign, or cache image URLs. It only describes the existing association projection and null-safe output.
+
+Management User remains unchanged in this issue. Its current explicit implementation is regression/reference evidence, not a mandatory migration target.
+
+## Management Attendance query contract
+
+Both list and detail User includes add the optional photo include next to the existing Role include.
+
+The parent User join keeps its current `required` behavior: list search may require User; detail remains optional. The nested Photo join is always `required: false`, so a missing photo never removes an attendance row or changes pagination totals.
+
+No Attendance top-level attributes, where conditions, order, limit, offset, or location joins change.
+
+## Management Attendance response contract
+
+The existing nested user object is extended additively in both list and detail:
+
+```json
+{
+  "user": {
+    "id": 7,
+    "full_name": "Andi Saputra",
+    "nip_nim": "EMP-007",
+    "role": "User",
+    "photo": "https://cdn.example.com/users/7/profile/photo.jpg",
+    "photo_updated_at": "2026-08-10T08:30:00.000Z"
+  }
+}
+```
+
+Detail continues to include `email` in the same user object; the photo field names remain identical between list and detail.
+
+When no photo exists:
+
+```json
+{
+  "photo": null,
+  "photo_updated_at": null
+}
+```
+
+The mapper always emits both keys. Nullable values distinguish missing identity evidence from an omitted/undocumented contract field.
+
+No default URL is synthesized and no User profile lookup is attempted after the attendance query returns.
+
+## Management Booking query contract
+
+Only the applicant User include receives the optional Photo include. The existing applicant Position and Role joins remain unchanged.
+
+The processor include intentionally does not load Photo: `processed_by` identifies the decision actor but the current Management Booking presentation does not require a processor avatar.
+
+Applicant search behavior is unchanged. When `search` is active, the applicant User include remains required; its nested Photo include remains optional. Therefore a user without a profile photo can still match search and return a booking row.
+
+No Booking where condition, fixed approval-first order, limit, offset, `distinct`, location/reason joins, or pagination envelope changes.
+
+## Management Booking response contract
+
+The existing flattened applicant projection is preserved and extended with:
+
+```json
+{
+  "user_id": 7,
+  "user_full_name": "Andi Saputra",
+  "user_nip_nim": "EMP-007",
+  "user_photo": "https://cdn.example.com/users/7/profile/photo.jpg",
+  "user_photo_updated_at": "2026-08-10T08:30:00.000Z"
+}
+```
+
+Both new fields are always present and nullable. For an applicant without a photo:
+
+```json
+{
+  "user_photo": null,
+  "user_photo_updated_at": null
+}
+```
+
+The issue does not convert Booking to a nested User object. Existing fields such as `user_email`, `user_position_name`, and `user_role_name` remain compatible.
+
+## Data flow
+
+```text
+GET /api/attendance or GET /api/bookings
+        ↓
+existing validation/controller/read service
+        ↓
+feature query builder explicitly includes applicant/employee User
+        ↓
+optional User.photo_file LEFT JOIN
+        ↓
+Sequelize row
+        ↓
+feature mapper uses shared null-safe photo projection
+        ↓
+existing response envelope + additive photo fields
+        ↓
+Web FE #64 renders photo or initials
+```
+
+There is still one list/detail database query per existing use case. No additional HTTP request is introduced and no per-row database query is executed by application code.
+
+## Truthfulness and error semantics
+
+A missing `photo_file` is normal nullable identity evidence, not an API error. It must not cause a 404, drop the parent row, or generate a warning/error response.
+
+A persisted `photo_url` is returned as stored. This issue does not probe the remote object or replace an unreachable URL; broken-image recovery belongs to Web FE presentation.
+
+`photo_updated_at` is returned from persisted Photo evidence and is not replaced by the current time, User `updated_at`, or Booking/Attendance timestamps.
+
+Existing database/service failures continue through the current error path. The helper does not introduce a new error envelope.
+
+## OpenAPI contract
+
+`docs/openapi.yaml` must document the runtime additions explicitly.
+
+`AttendanceAuditListRow.user` adds required-but-nullable properties:
+
+```text
+photo
+photo_updated_at
+```
+
+`AttendanceAuditDetail.user` adds the same properties while retaining detail-only `email`.
+
+`BookingManagementItem` adds nullable applicant properties to its existing schema:
+
+```text
+user_photo
+user_photo_updated_at
+```
+
+`photo`/`user_photo` are strings with URI format when present. `photo_updated_at`/`user_photo_updated_at` are date-time strings when present.
+
+No endpoint, request parameter, pagination schema, authorization rule, or status code is added or changed.
+
+A new ADR is not required. This change follows the existing explicit User-photo projection pattern and the bounded read modules already established by INF-267 and INF-274.
+
+## Test strategy
+
+Implementation uses TDD in small red-green-refactor cycles.
+
+Focused coverage must prove:
+
+1. the shared include selects only `photo_url` and `photo_updated_at`, uses alias `photo_file`, and is optional;
+2. the shared mapper preserves persisted URL/timestamp and returns two nulls when photo evidence is absent;
+3. Attendance list User include contains optional Role and Photo children without changing search-required behavior;
+4. Attendance detail User include contains the same Photo child without changing detail attributes;
+5. Attendance list and detail mappers emit photo fields for present and absent photos;
+6. Attendance read-service fixtures/mocks remain compatible with the expanded query model dependency;
+7. Booking applicant include contains Photo while processor include does not;
+8. Booking mapper exposes `user_photo` and `user_photo_updated_at` for present and absent photos;
+9. Booking fixed ordering, search, filters, and canonical/deprecated pagination fields remain unchanged;
+10. OpenAPI publishes the exact nullable fields on Attendance list/detail and Booking management items;
+11. Management User photo projection remains green as reference regression coverage.
+
+Likely focused tests:
+
+```text
+tests/userPhotoProjection.test.js
+tests/attendanceManagementQuery.test.js
+tests/attendanceManagementMapper.test.js
+tests/attendanceManagementReadService.test.js
+tests/attendanceManagementOpenApiContract.test.js
+tests/bookingManagementQuery.test.js
+tests/bookingManagementMapper.test.js
+tests/bookingManagementReadService.test.js
+tests/bookingManagementOpenApiContract.test.js
+tests/userListProjectionContract.test.js
+```
+
+Final implementation gates:
+
+```text
+npm run lint
+npm test -- --runInBand
+git diff --check refs/remotes/origin/develop...HEAD
+```
+
+Runtime evidence should verify authenticated Management/Admin responses for an employee with a photo and an employee without one on both Attendance and Booking. If compatible authenticated runtime evidence is unavailable, the PR must say `Needs Verification` rather than inventing it.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Optional photo join accidentally removes rows | Nested Photo include is always `required: false`; query tests pin this |
+| Attendance pagination/search changes through join behavior | Preserve the existing parent User `required` rule, `distinct`, filters, order, limit, and offset |
+| Booking processor unnecessarily loads applicant photo semantics | Add Photo only to the applicant include; processor remains unchanged |
+| Null photo becomes a fabricated default | Shared mapper returns explicit `null`; no fallback URL exists in Backend |
+| Timestamp semantics drift | Return only persisted `photo_updated_at`; do not synthesize timestamps |
+| Contract fields differ between Attendance list/detail | Both use the same shared photo projection and exact field names |
+| Broad User controller refactor creates unrelated risk | Leave Management User implementation unchanged in #139 |
+| New helper becomes implicit global behavior | Queries must call `buildUserPhotoInclude(Photo)` explicitly |
+| OpenAPI drifts from runtime | Focused OpenAPI tests require fields and nullable semantics |
+
+## Definition of done
+
+GitHub #139 is complete when the additive photo projection is implemented and verified without changing existing Attendance/Booking business semantics.
+
+Specifically:
+
+- Attendance list returns `user.photo` and `user.photo_updated_at` on every row, nullable when evidence is absent;
+- Attendance detail returns the same two fields in its user identity object;
+- Booking management rows return `user_photo` and `user_photo_updated_at`, nullable when absent;
+- persisted photo URL/timestamp values are preserved without rewriting or fabrication;
+- both feature query builders opt into the same optional lightweight Photo projection;
+- missing photos do not remove Attendance or Booking rows;
+- no new API route, DB migration, global User scope, per-row query, or photo-storage change exists;
+- existing Attendance query/detail/pagination semantics remain unchanged;
+- existing Booking search/filter/order/decision/pagination semantics remain unchanged;
+- OpenAPI matches runtime and focused contract tests cover present/null cases;
+- `npm run lint`, the full Jest suite, and `git diff --check` pass with fresh evidence;
+- downstream Web FE #64 can consume Backend-authored photo metadata without User-detail lookup workarounds.
+
+## Implementation boundary summary
+
+```text
+Change:
+shared explicit user-photo projection helper
+Management Attendance User query include + mapper output
+Management Booking applicant query include + mapper output
+OpenAPI + focused tests
+
+Do not change:
+Photo/User schema or associations
+photo upload/storage/delete behavior
+Attendance mutations/jobs/business rules
+Booking decisions/scoring/business rules
+search/filter/sort/pagination semantics
+Management User implementation
+Web FE code
+```

--- a/docs/superpowers/specs/2026-08-10-gh-139-profile-photo-projection-design.md
+++ b/docs/superpowers/specs/2026-08-10-gh-139-profile-photo-projection-design.md
@@ -1,6 +1,7 @@
 # GitHub #139 Management Profile Photo Projection Design
 
 **Date:** 2026-08-10
+**Revised:** 2026-08-11 — Management User canonical read-projection consolidation
 **Issue:** `Infinite-LearningV1/Infinit_Track_BE#139`
 **Coordination:** `Infinite-LearningV1/Infinit_Track_BE#138`
 **Downstream:** `Infinite-LearningV1/Infinite_Track_Fe#64`
@@ -11,11 +12,11 @@
 
 ## Purpose
 
-Expose the existing User profile photo as lightweight identity metadata in Management Attendance and Management Booking responses.
+Expose the existing User profile photo as lightweight identity metadata in Management Attendance and Management Booking responses, and consolidate Management User read projections onto the same canonical photo helper without changing its API contract.
 
-The Backend remains the source of truth for photo identity. Attendance and Booking do not own photo state; they only project the photo metadata needed by their management read surfaces.
+The Backend remains the source of truth for photo identity. Management User, Attendance, and Booking share one explicit read-projection primitive, while each feature remains the owner of its surrounding response shape and business semantics.
 
-This is an additive read-contract change. It does not add a photo endpoint, database migration, upload behavior, storage policy, or client-side lookup requirement.
+For Attendance and Booking this remains an additive read-contract change. For Management User it is a behavior-preserving internal consolidation only. The design does not add a photo endpoint, database migration, upload behavior, storage policy, or client-side lookup requirement.
 
 ## Verified baseline
 
@@ -38,7 +39,7 @@ The photo source already exists and needs no schema work:
 - `User.belongsTo(Photo, { as: 'photo_file', foreignKey: 'id_photos' })` is already registered.
 - a user may have no linked `photo_file`; therefore every client-facing photo projection is nullable even though `photo_url` is non-null on an existing Photo row.
 
-Management User is the reference behavior. Its list/detail queries explicitly LEFT JOIN `photo_file` with only `photo_url` and `photo_updated_at`, then expose `photo` and `photo_updated_at`.
+Management User already exposes the correct public contract: list/detail and create/update response refetches LEFT JOIN `photo_file` with only `photo_url` and `photo_updated_at`, then expose `photo` and `photo_updated_at`. However, those includes and mappings are duplicated locally in `user.controller.js` instead of using the canonical helper introduced by this issue.
 
 Management Attendance currently joins `User -> Role` but not `Photo`. Its list/detail mapper therefore cannot expose profile-photo metadata.
 
@@ -61,7 +62,8 @@ This issue covers:
 - explicit optional Photo include in the Management Booking applicant query;
 - additive Attendance and Booking response fields;
 - OpenAPI updates for the new nullable fields;
-- focused query, mapper, read-service regression, and OpenAPI contract tests.
+- focused query, mapper, read-service regression, and OpenAPI contract tests;
+- behavior-preserving Management User adoption of the same explicit photo include/mapping helper for list, detail, and create/update response refetches.
 
 Out of scope:
 
@@ -72,7 +74,8 @@ Out of scope:
 - adding photo data to the Booking processor identity;
 - changing Attendance search/filter/sort/pagination/detail ownership;
 - changing Booking search/filter/order/pagination/approval/rejection semantics;
-- refactoring the legacy Management User controller merely to adopt the new helper;
+- broader Management User modularization beyond the bounded photo read-projection consolidation;
+- Auth controller photo projection consolidation;
 - Web FE implementation from `Infinite_Track_Fe#64`.
 
 ## Approaches considered
@@ -91,7 +94,7 @@ Benefits:
 - avoids a global ORM scope;
 - keeps Attendance and Booking mapping semantics aligned;
 - stays small enough for this bounded contract change;
-- can be adopted by future identity projections without forcing a refactor of existing consumers.
+- can be adopted by existing identity projections where the contract already matches without forcing a broader controller/module refactor.
 
 ### C. Dedicated photo endpoint or global User photo scope
 
@@ -102,8 +105,8 @@ Rejected. A dedicated endpoint encourages N+1 HTTP calls for paginated tables. A
 The selected helper has two responsibilities only:
 
 ```js
-buildUserPhotoInclude(PhotoModel)
-mapUserPhotoProjection(user)
+buildUserPhotoInclude(PhotoModel);
+mapUserPhotoProjection(user);
 ```
 
 `buildUserPhotoInclude` returns an optional `photo_file` include selecting exactly `photo_url` and `photo_updated_at`. It receives the model as a dependency rather than importing the model registry itself.
@@ -128,7 +131,33 @@ export const mapUserPhotoProjection = (user) => ({
 
 The helper does not fetch, upload, transform, validate, sign, or cache image URLs. It only describes the existing association projection and null-safe output.
 
-Management User remains unchanged in this issue. Its current explicit implementation is regression/reference evidence, not a mandatory migration target.
+Management User adopts this helper only at its existing read-projection boundaries. `user.controller.js` keeps ownership of User list/detail/create/update behavior; only the duplicated optional Photo include and `{ photo, photo_updated_at }` mapping are consolidated. Photo upload/create/update persistence remains explicit write-side logic and does not use this read-projection helper.
+
+## Management User consolidation contract
+
+Management User already publishes the canonical public fields required by Web FE: `photo` and `photo_updated_at` on list/detail projections and on the refetched payload returned after create/update.
+
+This issue must not change those payloads. It only replaces duplicated read-side implementation with the same explicit helper used by Attendance and Booking:
+
+```js
+buildUserPhotoInclude(Photo);
+mapUserPhotoProjection(user);
+```
+
+The bounded read paths are:
+
+- `GET /users` list query;
+- `GET /users/:id` detail query;
+- the full-user refetch used to build the create response;
+- the full-user refetch used to build the update response.
+
+`toUserListProjection` and `toUserDetailProjection` keep ownership of their existing User-specific fields and spread only the shared photo projection. The helper must not gain knowledge of phone, location, role, program, position, timestamps, pagination, or User integrity rules.
+
+The `Photo` include remains `required: false`. A missing photo therefore yields `{ photo: null, photo_updated_at: null }` without removing a User row or changing User list pagination/count behavior.
+
+The following write-side paths remain explicit and unchanged by this consolidation: `POST /users/:id/photo`, Photo row create/update, Spaces upload/delete, legacy Cloudinary cleanup, and `User.id_photos` synchronization.
+
+Existing User error semantics also remain unchanged: a missing user returns `404 E_NOT_FOUND`, while an active user missing its required WFH location returns `409 E_USER_LOCATION_INTEGRITY`. Missing photo evidence is never either error.
 
 ## Management Attendance query contract
 
@@ -208,28 +237,28 @@ The issue does not convert Booking to a nested User object. Existing fields such
 ## Data flow
 
 ```text
-GET /api/attendance or GET /api/bookings
+GET /api/users, GET /api/attendance, or GET /api/bookings
         ↓
-existing validation/controller/read service
+existing validation/controller/read service or User controller read/refetch path
         ↓
-feature query builder explicitly includes applicant/employee User
+read boundary explicitly opts into the existing User.photo_file association
         ↓
 optional User.photo_file LEFT JOIN
         ↓
 Sequelize row
         ↓
-feature mapper uses shared null-safe photo projection
+owning projection uses shared null-safe photo mapping
         ↓
-existing response envelope + additive photo fields
+existing User response shape or additive Attendance/Booking photo fields
         ↓
-Web FE #64 renders photo or initials
+Web FE #64 renders photo or initials across Management User/Attendance/Booking
 ```
 
 There is still one list/detail database query per existing use case. No additional HTTP request is introduced and no per-row database query is executed by application code.
 
 ## Truthfulness and error semantics
 
-A missing `photo_file` is normal nullable identity evidence, not an API error. It must not cause a 404, drop the parent row, or generate a warning/error response.
+A missing `photo_file` is normal nullable identity evidence, not an API error. It must not cause a 404, 409, drop the parent row, or generate a warning/error response. Management User keeps its existing unrelated `404 E_NOT_FOUND` and `409 E_USER_LOCATION_INTEGRITY` semantics.
 
 A persisted `photo_url` is returned as stored. This issue does not probe the remote object or replace an unreachable URL; broken-image recovery belongs to Web FE presentation.
 
@@ -279,7 +308,9 @@ Focused coverage must prove:
 8. Booking mapper exposes `user_photo` and `user_photo_updated_at` for present and absent photos;
 9. Booking fixed ordering, search, filters, and canonical/deprecated pagination fields remain unchanged;
 10. OpenAPI publishes the exact nullable fields on Attendance list/detail and Booking management items;
-11. Management User photo projection remains green as reference regression coverage.
+11. Management User list/detail/create/update response projections preserve the exact existing `photo` and `photo_updated_at` contract while adopting the same helper;
+12. Management User `photo_file` joins remain optional and do not change pagination, `404 E_NOT_FOUND`, or `409 E_USER_LOCATION_INTEGRITY` behavior;
+13. Management User photo upload/storage mutation tests remain green without adopting the read helper.
 
 Likely focused tests:
 
@@ -294,6 +325,9 @@ tests/bookingManagementMapper.test.js
 tests/bookingManagementReadService.test.js
 tests/bookingManagementOpenApiContract.test.js
 tests/userListProjectionContract.test.js
+tests/userDetailProjectionContract.test.js
+tests/userCreateUpdateProjectionContract.test.js
+tests/uploadUserPhotoController.test.js
 ```
 
 Final implementation gates:
@@ -304,37 +338,40 @@ npm test -- --runInBand
 git diff --check refs/remotes/origin/develop...HEAD
 ```
 
-Runtime evidence should verify authenticated Management/Admin responses for an employee with a photo and an employee without one on both Attendance and Booking. If compatible authenticated runtime evidence is unavailable, the PR must say `Needs Verification` rather than inventing it.
+Runtime evidence should verify authenticated Management/Admin responses for a user with a photo and a user without one on Management User, Attendance, and Booking read surfaces. If compatible authenticated runtime evidence is unavailable, the PR must say `Needs Verification` rather than inventing it.
 
 ## Risks and mitigations
 
-| Risk | Mitigation |
-| --- | --- |
-| Optional photo join accidentally removes rows | Nested Photo include is always `required: false`; query tests pin this |
-| Attendance pagination/search changes through join behavior | Preserve the existing parent User `required` rule, `distinct`, filters, order, limit, and offset |
-| Booking processor unnecessarily loads applicant photo semantics | Add Photo only to the applicant include; processor remains unchanged |
-| Null photo becomes a fabricated default | Shared mapper returns explicit `null`; no fallback URL exists in Backend |
-| Timestamp semantics drift | Return only persisted `photo_updated_at`; do not synthesize timestamps |
-| Contract fields differ between Attendance list/detail | Both use the same shared photo projection and exact field names |
-| Broad User controller refactor creates unrelated risk | Leave Management User implementation unchanged in #139 |
-| New helper becomes implicit global behavior | Queries must call `buildUserPhotoInclude(Photo)` explicitly |
-| OpenAPI drifts from runtime | Focused OpenAPI tests require fields and nullable semantics |
+| Risk                                                            | Mitigation                                                                                                                               |
+| --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| Optional photo join accidentally removes rows                   | Nested Photo include is always `required: false`; query tests pin this                                                                   |
+| Attendance pagination/search changes through join behavior      | Preserve the existing parent User `required` rule, `distinct`, filters, order, limit, and offset                                         |
+| Booking processor unnecessarily loads applicant photo semantics | Add Photo only to the applicant include; processor remains unchanged                                                                     |
+| Null photo becomes a fabricated default                         | Shared mapper returns explicit `null`; no fallback URL exists in Backend                                                                 |
+| Timestamp semantics drift                                       | Return only persisted `photo_updated_at`; do not synthesize timestamps                                                                   |
+| Contract fields differ between Attendance list/detail           | Both use the same shared photo projection and exact field names                                                                          |
+| User consolidation expands into a broad controller refactor     | Change only the duplicated photo include/mapping at existing read/refetch boundaries; preserve controller ownership and unrelated fields |
+| New helper becomes implicit global behavior                     | Every read boundary must call `buildUserPhotoInclude(Photo)` explicitly; no model default scope or hidden auto-include                   |
+| Read helper leaks into write-side photo mutation                | Keep upload/create/update persistence explicit and verify existing mutation tests remain green                                           |
+| OpenAPI drifts from runtime                                     | Focused OpenAPI tests require fields and nullable semantics                                                                              |
 
 ## Definition of done
 
-GitHub #139 is complete when the additive photo projection is implemented and verified without changing existing Attendance/Booking business semantics.
+GitHub #139 is complete when the additive Attendance/Booking photo projection and behavior-preserving Management User consolidation are implemented and verified without changing existing business semantics.
 
 Specifically:
 
 - Attendance list returns `user.photo` and `user.photo_updated_at` on every row, nullable when evidence is absent;
 - Attendance detail returns the same two fields in its user identity object;
 - Booking management rows return `user_photo` and `user_photo_updated_at`, nullable when absent;
+- Management User list/detail/create/update responses keep their existing `photo` and `photo_updated_at` contract while using the same canonical read helper internally;
 - persisted photo URL/timestamp values are preserved without rewriting or fabrication;
-- both feature query builders opt into the same optional lightweight Photo projection;
-- missing photos do not remove Attendance or Booking rows;
+- Management User, Attendance, and Booking read boundaries opt into the same optional lightweight Photo projection explicitly;
+- missing photos do not remove Management User, Attendance, or Booking rows;
 - no new API route, DB migration, global User scope, per-row query, or photo-storage change exists;
 - existing Attendance query/detail/pagination semantics remain unchanged;
 - existing Booking search/filter/order/decision/pagination semantics remain unchanged;
+- existing Management User search/filter/sort/pagination, 404/409 integrity semantics, and photo write/storage behavior remain unchanged;
 - OpenAPI matches runtime and focused contract tests cover present/null cases;
 - `npm run lint`, the full Jest suite, and `git diff --check` pass with fresh evidence;
 - downstream Web FE #64 can consume Backend-authored photo metadata without User-detail lookup workarounds.
@@ -344,16 +381,18 @@ Specifically:
 ```text
 Change:
 shared explicit user-photo projection helper
+Management User read/refetch photo include + projection mapping
 Management Attendance User query include + mapper output
 Management Booking applicant query include + mapper output
-OpenAPI + focused tests
+Attendance/Booking OpenAPI + focused tests
 
 Do not change:
 Photo/User schema or associations
 photo upload/storage/delete behavior
+Management User business logic outside bounded read projection
+Auth photo projection
 Attendance mutations/jobs/business rules
 Booking decisions/scoring/business rules
 search/filter/sort/pagination semantics
-Management User implementation
 Web FE code
 ```

--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -13,6 +13,7 @@ import {
   sequelize
 } from '../models/index.js';
 import logger from '../utils/logger.js';
+import { buildUserPhotoInclude, mapUserPhotoProjection } from '../utils/userPhotoProjection.js';
 import { buildUserProfilePhotoKey, uploadBufferToSpaces, deleteSpacesObject } from '../config/spaces.js';
 
 const deleteLegacyCloudinaryPhoto = async (publicId) => {
@@ -61,8 +62,7 @@ const toUserDetailProjection = (user) => ({
   division_name: user.division ? user.division.division_name : null,
   nip_nim: user.nip_nim,
   phone: user.phone,
-  photo: user.photo_file ? user.photo_file.photo_url : null,
-  photo_updated_at: user.photo_file ? user.photo_file.photo_updated_at : null,
+  ...mapUserPhotoProjection(user),
   location: toWfhLocationProjection(user.wfh_location),
   created_at: user.created_at,
   updated_at: user.updated_at
@@ -80,8 +80,7 @@ const toUserListProjection = (user) => ({
   program_name: user.program ? user.program.program_name : null,
   division_name: user.division ? user.division.division_name : null,
   nip_nim: user.nip_nim,
-  photo: user.photo_file ? user.photo_file.photo_url : null,
-  photo_updated_at: user.photo_file ? user.photo_file.photo_updated_at : null,
+  ...mapUserPhotoProjection(user),
   location_status: user.wfh_location ? 'configured' : 'integrity_error',
   created_at: user.created_at,
   updated_at: user.updated_at
@@ -195,12 +194,7 @@ export const getAllUsers = async (req, res, next) => {
         attributes: ['division_name'],
         required: false
       },
-      {
-        model: Photo,
-        as: 'photo_file',
-        attributes: ['photo_url', 'photo_updated_at'],
-        required: false
-      },
+      buildUserPhotoInclude(Photo),
       {
         model: Location,
         as: 'wfh_location',
@@ -499,12 +493,7 @@ export const updateUser = async (req, res, next) => {
           attributes: ['division_name'],
           required: false
         },
-        {
-          model: Photo,
-          as: 'photo_file',
-          attributes: ['photo_url', 'photo_updated_at'],
-          required: false
-        },
+        buildUserPhotoInclude(Photo),
         {
           model: Location,
           as: 'wfh_location',
@@ -723,12 +712,7 @@ export const createUser = async (req, res, next) => {
           attributes: ['division_name'],
           required: false
         },
-        {
-          model: Photo,
-          as: 'photo_file',
-          attributes: ['photo_url', 'photo_updated_at'],
-          required: false
-        },
+        buildUserPhotoInclude(Photo),
         {
           model: Location,
           as: 'wfh_location',
@@ -802,12 +786,7 @@ export const getUserById = async (req, res, next) => {
           attributes: ['division_name'],
           required: false
         },
-        {
-          model: Photo,
-          as: 'photo_file',
-          attributes: ['photo_url', 'photo_updated_at'],
-          required: false
-        },
+        buildUserPhotoInclude(Photo),
         {
           model: Location,
           as: 'wfh_location',

--- a/src/modules/attendance/attendance.mapper.js
+++ b/src/modules/attendance/attendance.mapper.js
@@ -1,4 +1,5 @@
 import { formatTimeOnly, formatWorkHour } from '../../utils/workHourFormatter.js';
+import { mapUserPhotoProjection } from '../../utils/userPhotoProjection.js';
 
 const MODES = {
   1: { key: 'wfo', label: 'WFO' },
@@ -34,6 +35,7 @@ const userOf = (row, includeEmail = false) => ({
   full_name: row.user?.full_name ?? null,
   nip_nim: row.user?.nip_nim ?? null,
   ...(includeEmail ? { email: row.user?.email ?? null } : {}),
+  ...mapUserPhotoProjection(row.user),
   role: row.user?.role?.role_name ?? null
 });
 

--- a/src/modules/attendance/attendance.query.js
+++ b/src/modules/attendance/attendance.query.js
@@ -1,7 +1,8 @@
 import { Op } from 'sequelize';
 import {
-  AttendanceCategory, AttendanceStatus, Location, Role, User
+  AttendanceCategory, AttendanceStatus, Location, Photo, Role, User
 } from '../../models/index.js';
+import { buildUserPhotoInclude } from '../../utils/userPhotoProjection.js';
 
 const MODE_IDS = { wfo: 1, wfh: 2, wfa: 3 };
 const STATUS_IDS = { ontime: 1, late: 2, alpha: 3, early: 4 };
@@ -47,7 +48,10 @@ export const buildAttendanceListQuery = (query = {}) => {
     as: 'user',
     attributes: ['id_users', 'full_name', 'nip_nim'],
     required: Boolean(like),
-    include: [{ model: Role, as: 'role', attributes: ['role_name'], required: false }]
+    include: [
+      { model: Role, as: 'role', attributes: ['role_name'], required: false },
+      buildUserPhotoInclude(Photo)
+    ]
   };
 
   if (like) {
@@ -105,7 +109,10 @@ export const buildAttendanceDetailQuery = () => ({
       as: 'user',
       attributes: ['id_users', 'full_name', 'nip_nim', 'email'],
       required: false,
-      include: [{ model: Role, as: 'role', attributes: ['role_name'], required: false }]
+      include: [
+        { model: Role, as: 'role', attributes: ['role_name'], required: false },
+        buildUserPhotoInclude(Photo)
+      ]
     },
     {
       model: Location,

--- a/src/modules/booking/bookingManagement.mapper.js
+++ b/src/modules/booking/bookingManagement.mapper.js
@@ -1,3 +1,5 @@
+import { mapUserPhotoProjection } from '../../utils/userPhotoProjection.js';
+
 const numberOrNull = (value) => {
   if (value === null || value === undefined || value === '') return null;
   const parsed = Number(value);
@@ -41,6 +43,7 @@ const mapLocation = (row) => row.location
 
 export const mapBookingManagementRow = (row) => {
   const location = mapLocation(row);
+  const { photo, photo_updated_at: photoUpdatedAt } = mapUserPhotoProjection(row.user);
   const radiusSnapshot = row.radius_snapshot != null
     ? numberOrNull(row.radius_snapshot)
     : location?.radius ?? null;
@@ -52,6 +55,8 @@ export const mapBookingManagementRow = (row) => {
     user_role_name: row.user?.role?.role_name ?? null,
     user_email: row.user?.email ?? null,
     user_nip_nim: row.user?.nip_nim ?? null,
+    user_photo: photo,
+    user_photo_updated_at: photoUpdatedAt,
     user_position_name: row.user?.position?.position_name ?? null,
     schedule_date: row.schedule_date,
     status: row.booking_status?.name_status ?? null,

--- a/src/modules/booking/bookingManagement.query.js
+++ b/src/modules/booking/bookingManagement.query.js
@@ -4,12 +4,14 @@ import sequelize from '../../config/database.js';
 import {
   BookingStatus,
   Location,
+  Photo,
   Position,
   Role,
   User,
   WfaRejectionReason,
   WfaRequestReason
 } from '../../models/index.js';
+import { buildUserPhotoInclude } from '../../utils/userPhotoProjection.js';
 
 const STATUS_IDS = Object.freeze({
   approved: 1,
@@ -39,7 +41,8 @@ const buildApplicantInclude = (search) => {
         as: 'role',
         attributes: ['id_roles', 'role_name'],
         required: false
-      }
+      },
+      buildUserPhotoInclude(Photo)
     ]
   };
 

--- a/src/utils/userPhotoProjection.js
+++ b/src/utils/userPhotoProjection.js
@@ -1,0 +1,11 @@
+export const buildUserPhotoInclude = (PhotoModel) => ({
+  model: PhotoModel,
+  as: 'photo_file',
+  attributes: ['photo_url', 'photo_updated_at'],
+  required: false
+});
+
+export const mapUserPhotoProjection = (user) => ({
+  photo: user?.photo_file?.photo_url ?? null,
+  photo_updated_at: user?.photo_file?.photo_updated_at ?? null
+});

--- a/tests/attendanceManagementMapper.test.js
+++ b/tests/attendanceManagementMapper.test.js
@@ -7,7 +7,17 @@ const row = {
   id_attendance: 42, attendance_date: '2026-07-28',
   time_in: new Date(2026, 6, 28, 8, 2), time_out: new Date(2026, 6, 28, 17, 5),
   work_hour: 9.05, category_id: 1, status_id: 1, notes: 'Verified', booking_id: 55,
-  user: { id_users: 7, full_name: 'Andi Saputra', nip_nim: 'EMP-007', email: 'andi@example.com', role: { role_name: 'User' } },
+  user: {
+    id_users: 7,
+    full_name: 'Andi Saputra',
+    nip_nim: 'EMP-007',
+    email: 'andi@example.com',
+    role: { role_name: 'User' },
+    photo_file: {
+      photo_url: 'https://cdn.example.com/users/7/profile/photo.jpg',
+      photo_updated_at: new Date('2026-08-10T08:30:00.000Z')
+    }
+  },
   attendance_category: { category_name: 'Work From Office' },
   status: { attendance_status_name: 'Tepat Waktu' },
   location: { location_id: 1, description: 'Palu Office', latitude: '-0.900291', longitude: '119.877998', radius: '100' }
@@ -17,7 +27,14 @@ test('maps only audit-table fields in the list row', () => {
   const result = mapAttendanceListRow(row);
   expect(result).toEqual({
     id_attendance: 42, attendance_date: '2026-07-28',
-    user: { id: 7, full_name: 'Andi Saputra', nip_nim: 'EMP-007', role: 'User' },
+    user: {
+      id: 7,
+      full_name: 'Andi Saputra',
+      nip_nim: 'EMP-007',
+      photo: 'https://cdn.example.com/users/7/profile/photo.jpg',
+      photo_updated_at: new Date('2026-08-10T08:30:00.000Z'),
+      role: 'User'
+    },
     time_in: '08:02', time_out: '17:05', work_duration: '09:03',
     mode: { key: 'wfo', label: 'WFO' },
     status: { key: 'ontime', label: 'On Time' },
@@ -43,6 +60,22 @@ test('does not fabricate time, duration, or location', () => {
   expect(result.location).toBeNull();
 });
 
+test('keeps photo fields present and null when the user has no linked photo', () => {
+  const noPhoto = {
+    ...row,
+    user: { ...row.user, photo_file: null }
+  };
+
+  expect(mapAttendanceListRow(noPhoto).user).toMatchObject({
+    photo: null,
+    photo_updated_at: null
+  });
+  expect(mapAttendanceDetail(noPhoto).user).toMatchObject({
+    photo: null,
+    photo_updated_at: null
+  });
+});
+
 test.each([
   [2, { key: 'wfh', label: 'WFH' }],
   [3, { key: 'wfa', label: 'WFA' }]
@@ -66,5 +99,12 @@ test('keeps unknown database labels without inventing canonical keys', () => {
   });
   expect(result.mode).toEqual({ key: null, label: 'Field Work' });
   expect(result.status).toEqual({ key: null, label: 'Reviewed' });
-  expect(result.user).toEqual({ id: null, full_name: null, nip_nim: null, role: null });
+  expect(result.user).toEqual({
+    id: null,
+    full_name: null,
+    nip_nim: null,
+    photo: null,
+    photo_updated_at: null,
+    role: null
+  });
 });

--- a/tests/attendanceManagementOpenApiContract.test.js
+++ b/tests/attendanceManagementOpenApiContract.test.js
@@ -56,3 +56,22 @@ test('documents the exact attendance validator error envelope', () => {
     location: { type: 'string', enum: ['query', 'params'] }
   });
 });
+
+test('documents nullable profile photo evidence on attendance list and detail users', () => {
+  const listUser = api.components.schemas.AttendanceAuditListRow.properties.user;
+  const detailUser = api.components.schemas.AttendanceAuditDetail.properties.user;
+
+  for (const user of [listUser, detailUser]) {
+    expect(user.required).toEqual(expect.arrayContaining(['photo', 'photo_updated_at']));
+    expect(user.properties.photo).toMatchObject({
+      type: 'string',
+      format: 'uri',
+      nullable: true
+    });
+    expect(user.properties.photo_updated_at).toMatchObject({
+      type: 'string',
+      format: 'date-time',
+      nullable: true
+    });
+  }
+});

--- a/tests/attendanceManagementQuery.test.js
+++ b/tests/attendanceManagementQuery.test.js
@@ -1,5 +1,5 @@
 import { Op } from 'sequelize';
-import { AttendanceStatus, User } from '../src/models/index.js';
+import { AttendanceStatus, Photo, User } from '../src/models/index.js';
 import {
   buildAttendanceDetailQuery,
   buildAttendanceListQuery,
@@ -92,4 +92,33 @@ test('builds a detail projection with its related attendance metadata', () => {
   expect(options.include.map((item) => item.as)).toEqual([
     'user', 'location', 'status', 'attendance_category'
   ]);
+});
+
+test('includes the same optional lightweight photo projection in list and detail', () => {
+  const list = buildAttendanceListQuery({ page: 1, limit: 10 });
+  const listUser = list.include.find((item) => item.as === 'user');
+  const listPhoto = listUser.include.find((item) => item.as === 'photo_file');
+
+  expect(listUser.required).toBe(false);
+  expect(listPhoto).toEqual({
+    model: Photo,
+    as: 'photo_file',
+    attributes: ['photo_url', 'photo_updated_at'],
+    required: false
+  });
+
+  const searched = buildAttendanceListQuery({ page: 1, limit: 10, search: 'Andi' });
+  expect(searched.include.find((item) => item.as === 'user').required).toBe(true);
+
+  const detail = buildAttendanceDetailQuery();
+  const detailUser = detail.include.find((item) => item.as === 'user');
+  const detailPhoto = detailUser.include.find((item) => item.as === 'photo_file');
+
+  expect(detailUser.required).toBe(false);
+  expect(detailPhoto).toEqual({
+    model: Photo,
+    as: 'photo_file',
+    attributes: ['photo_url', 'photo_updated_at'],
+    required: false
+  });
 });

--- a/tests/attendanceManagementReadService.test.js
+++ b/tests/attendanceManagementReadService.test.js
@@ -7,6 +7,7 @@ jest.unstable_mockModule('../src/models/index.js', () => ({
   Attendance: { findAndCountAll, findByPk },
   User: {},
   Role: {},
+  Photo: {},
   Location: {},
   AttendanceStatus: {},
   AttendanceCategory: {}
@@ -33,7 +34,11 @@ describe('attendance management read service', () => {
       full_name: 'Andi Saputra',
       nip_nim: 'EMP-007',
       email: 'andi@example.com',
-      role: { role_name: 'User' }
+      role: { role_name: 'User' },
+      photo_file: {
+        photo_url: 'https://cdn.example.com/users/7/profile/photo.jpg',
+        photo_updated_at: new Date('2026-08-10T08:30:00.000Z')
+      }
     },
     attendance_category: { category_name: 'Work From Office' },
     status: { attendance_status_name: 'Tepat Waktu' },
@@ -62,7 +67,14 @@ describe('attendance management read service', () => {
     }));
     expect(result.data).toEqual([expect.objectContaining({
       id_attendance: 42,
-      user: { id: 7, full_name: 'Andi Saputra', nip_nim: 'EMP-007', role: 'User' },
+      user: {
+        id: 7,
+        full_name: 'Andi Saputra',
+        nip_nim: 'EMP-007',
+        photo: 'https://cdn.example.com/users/7/profile/photo.jpg',
+        photo_updated_at: new Date('2026-08-10T08:30:00.000Z'),
+        role: 'User'
+      },
       time_in: '08:02',
       time_out: '17:05',
       mode: { key: 'wfo', label: 'WFO' },

--- a/tests/bookingManagementMapper.test.js
+++ b/tests/bookingManagementMapper.test.js
@@ -8,7 +8,11 @@ const baseRow = {
     nip_nim: 'EMP-007',
     email: 'andi@example.com',
     position: { position_name: 'Backend Engineer' },
-    role: { role_name: 'Employee' }
+    role: { role_name: 'Employee' },
+    photo_file: {
+      photo_url: 'https://cdn.example.com/users/7/profile/photo.jpg',
+      photo_updated_at: new Date('2026-08-10T08:30:00.000Z')
+    }
   },
   schedule_date: '2026-08-12',
   booking_status: { name_status: 'approved' },
@@ -46,6 +50,8 @@ test('projects a manual processor identity and canonical nested WFA reason data'
     user_id: 7,
     user_full_name: 'Andi Saputra',
     user_nip_nim: 'EMP-007',
+    user_photo: 'https://cdn.example.com/users/7/profile/photo.jpg',
+    user_photo_updated_at: new Date('2026-08-10T08:30:00.000Z'),
     user_position_name: 'Backend Engineer',
     status: 'approved',
     radius_snapshot: 150,
@@ -125,4 +131,18 @@ test('preserves numeric zero as a real suitability score', () => {
 
   expect(result.suitability_score).toBe(0);
   expect(result.suitability_label).toBe('Tidak Direkomendasikan');
+});
+
+test('keeps applicant photo fields present and null without linked photo evidence', () => {
+  const result = mapBookingManagementRow({
+    ...baseRow,
+    user: { ...baseRow.user, photo_file: null },
+    processor: null,
+    request_reason: null,
+    rejection_reason_detail: null,
+    radius_snapshot: 100
+  });
+
+  expect(result.user_photo).toBeNull();
+  expect(result.user_photo_updated_at).toBeNull();
 });

--- a/tests/bookingManagementOpenApiContract.test.js
+++ b/tests/bookingManagementOpenApiContract.test.js
@@ -49,6 +49,16 @@ test('publishes the Management Booking list item instead of the legacy Booking s
   expect(item.properties).toHaveProperty('rejection_reason');
   expect(item.properties).toHaveProperty('location');
   expect(item.properties).toHaveProperty('approved_by');
+  expect(item.properties.user_photo).toMatchObject({
+    type: 'string',
+    format: 'uri',
+    nullable: true
+  });
+  expect(item.properties.user_photo_updated_at).toMatchObject({
+    type: 'string',
+    format: 'date-time',
+    nullable: true
+  });
   expect(item.properties.processed_by.$ref).toBe('#/components/schemas/BookingProcessor');
 });
 test('documents processor identity and truthful nullable suitability semantics', () => {

--- a/tests/bookingManagementQuery.test.js
+++ b/tests/bookingManagementQuery.test.js
@@ -4,6 +4,7 @@ import { Op } from 'sequelize';
 const User = { modelName: 'User' };
 const Position = { modelName: 'Position' };
 const Role = { modelName: 'Role' };
+const Photo = { modelName: 'Photo' };
 const Location = { modelName: 'Location' };
 const BookingStatus = { modelName: 'BookingStatus' };
 const WfaRequestReason = { modelName: 'WfaRequestReason' };
@@ -18,6 +19,7 @@ jest.unstable_mockModule('../src/models/index.js', () => ({
   User,
   Position,
   Role,
+  Photo,
   Location,
   BookingStatus,
   WfaRequestReason,
@@ -67,7 +69,13 @@ test('builds combined applicant search, booking filters, and pagination in one q
   });
   expect(applicant.include).toEqual(expect.arrayContaining([
     expect.objectContaining({ model: Position, as: 'position' }),
-    expect.objectContaining({ model: Role, as: 'role' })
+    expect.objectContaining({ model: Role, as: 'role' }),
+    {
+      model: Photo,
+      as: 'photo_file',
+      attributes: ['photo_url', 'photo_updated_at'],
+      required: false
+    }
   ]));
 });
 
@@ -87,6 +95,7 @@ test('keeps applicant optional without search and includes an optional processor
   expect(processor.include).toEqual([
     expect.objectContaining({ model: Role, as: 'role', required: false })
   ]);
+  expect(processor.include.some((item) => item.as === 'photo_file')).toBe(false);
   expect(query.include).toEqual(expect.arrayContaining([
     expect.objectContaining({ model: Location, as: 'location' }),
     expect.objectContaining({ model: BookingStatus, as: 'booking_status' }),

--- a/tests/bookingWfaPolicyContract.test.js
+++ b/tests/bookingWfaPolicyContract.test.js
@@ -40,6 +40,7 @@ jest.unstable_mockModule('../src/models/index.js', () => ({
   },
   BookingStatus: {},
   User: { findByPk: mockUserFindByPk },
+  Photo: {},
   Position: {},
   Role: {},
   WfaRequestReason: {},

--- a/tests/bookingWfaProjectionContract.test.js
+++ b/tests/bookingWfaProjectionContract.test.js
@@ -17,6 +17,7 @@ jest.unstable_mockModule('../src/models/index.js', () => ({
   Location: {},
   BookingStatus: {},
   User: {},
+  Photo: {},
   Position: {},
   Role: {},
   WfaRequestReason,

--- a/tests/bookingWfaRejectionContract.test.js
+++ b/tests/bookingWfaRejectionContract.test.js
@@ -20,6 +20,7 @@ jest.unstable_mockModule('../src/models/index.js', () => ({
   Location: {},
   BookingStatus: {},
   User: {},
+  Photo: {},
   Position: {},
   Role: {},
   WfaRequestReason: {},

--- a/tests/bookingsControllerReadiness.test.js
+++ b/tests/bookingsControllerReadiness.test.js
@@ -40,6 +40,7 @@ describe('booking controller readiness regressions', () => {
       },
       BookingStatus: {},
       User: {},
+      Photo: {},
       Position: {},
       Role: {},
       WfaRequestReason: {},

--- a/tests/userCreateUpdateProjectionContract.test.js
+++ b/tests/userCreateUpdateProjectionContract.test.js
@@ -171,6 +171,8 @@ describe('POST /users create contract (INF-251)', () => {
     const payload = res.json.mock.calls[0][0];
     expect(payload.data.created_at).toEqual(new Date('2026-07-05T10:00:00.000Z'));
     expect(payload.data.updated_at).toEqual(new Date('2026-07-05T10:00:00.000Z'));
+    expect(payload.data.photo).toBe('https://cdn.example.com/cindy.jpg');
+    expect(payload.data.photo_updated_at).toEqual(new Date('2026-07-05T00:00:00.000Z'));
   });
 
   test('failed WFH location write rolls back the whole user transaction', async () => {
@@ -230,5 +232,7 @@ describe('PATCH /users/:id update contract (INF-251)', () => {
     const payload = res.json.mock.calls[0][0];
     expect(payload.data.created_at).toEqual(new Date('2026-07-05T10:00:00.000Z'));
     expect(payload.data.updated_at).toEqual(new Date('2026-07-05T10:00:00.000Z'));
+    expect(payload.data.photo).toBe('https://cdn.example.com/cindy.jpg');
+    expect(payload.data.photo_updated_at).toEqual(new Date('2026-07-05T00:00:00.000Z'));
   });
 });

--- a/tests/userDetailProjectionContract.test.js
+++ b/tests/userDetailProjectionContract.test.js
@@ -102,6 +102,25 @@ describe('GET /users/:id detail projection contract (INF-261 + INF-251)', () => 
     });
   });
 
+  test('detail keeps nullable photo evidence and an optional photo_file join', async () => {
+    const findOne = jest.fn().mockResolvedValue(buildUser({ photo_file: null }));
+    const { getUserById } = await loadController({ findOne });
+
+    const res = buildRes();
+    await getUserById({ params: { id: '5' }, user: { id: 1 } }, res, jest.fn());
+
+    expect(res.json.mock.calls[0][0].data).toMatchObject({
+      photo: null,
+      photo_updated_at: null
+    });
+
+    const include = findOne.mock.calls[0][0].include;
+    expect(include.find((entry) => entry.as === 'photo_file')).toMatchObject({
+      attributes: ['photo_url', 'photo_updated_at'],
+      required: false
+    });
+  });
+
   test('existing user without WFH location returns explicit 409 integrity error, not 404', async () => {
     const findOne = jest.fn().mockResolvedValue(buildUser({ wfh_location: null }));
     const { getUserById } = await loadController({ findOne });

--- a/tests/userListProjectionContract.test.js
+++ b/tests/userListProjectionContract.test.js
@@ -96,6 +96,27 @@ describe('GET /users list projection contract (INF-261 + INF-251)', () => {
     });
   });
 
+  test('list keeps nullable photo evidence and an optional photo_file join', async () => {
+    const findAll = jest.fn().mockResolvedValue([buildUser({ photo_file: null })]);
+    const { getAllUsers } = await loadController({ findAll });
+
+    const res = buildRes();
+    await getAllUsers({ query: {} }, res, jest.fn());
+
+    expect(res.json.mock.calls[0][0].data[0]).toMatchObject({
+      photo: null,
+      photo_updated_at: null
+    });
+
+    const include = findAll.mock.calls[0][0].include;
+    const photoInclude = include.find((entry) => entry.as === 'photo_file');
+    expect(photoInclude).toMatchObject({
+      as: 'photo_file',
+      attributes: ['photo_url', 'photo_updated_at'],
+      required: false
+    });
+  });
+
   test('list row never leaks phone or raw coordinate fields', async () => {
     const findAll = jest.fn().mockResolvedValue([buildUser()]);
     const { getAllUsers } = await loadController({ findAll });

--- a/tests/userPhotoProjection.test.js
+++ b/tests/userPhotoProjection.test.js
@@ -1,0 +1,40 @@
+import {
+  buildUserPhotoInclude,
+  mapUserPhotoProjection
+} from '../src/utils/userPhotoProjection.js';
+
+const Photo = { modelName: 'Photo' };
+
+test('builds an explicit optional lightweight photo include', () => {
+  expect(buildUserPhotoInclude(Photo)).toEqual({
+    model: Photo,
+    as: 'photo_file',
+    attributes: ['photo_url', 'photo_updated_at'],
+    required: false
+  });
+});
+
+test('maps persisted photo evidence without rewriting it', () => {
+  const photoUpdatedAt = new Date('2026-08-10T08:30:00.000Z');
+
+  expect(mapUserPhotoProjection({
+    photo_file: {
+      photo_url: 'https://cdn.example.com/users/7/profile/photo.jpg',
+      photo_updated_at: photoUpdatedAt
+    }
+  })).toEqual({
+    photo: 'https://cdn.example.com/users/7/profile/photo.jpg',
+    photo_updated_at: photoUpdatedAt
+  });
+});
+
+test('returns explicit nulls when photo evidence is absent', () => {
+  expect(mapUserPhotoProjection(null)).toEqual({
+    photo: null,
+    photo_updated_at: null
+  });
+  expect(mapUserPhotoProjection({ photo_file: null })).toEqual({
+    photo: null,
+    photo_updated_at: null
+  });
+});


### PR DESCRIPTION
## Summary
- add canonical nullable user photo projection helper
- expose photo metadata in Management Attendance user projections
- expose applicant photo metadata in Management Booking projections
- consolidate existing Management User read projections onto the same helper
- update OpenAPI contracts and regression tests

## Verification
- 
pm run lint ✅
- focused projection contracts ✅
- non-integration Jest: 156 suites / 1487 tests passed ✅
- full Jest: 156 suites passed; 1 integration suite / 4 tests blocked by local MySQL credential rejection (oot access denied)
- git diff --check ✅
- runtime evidence: **Needs Verification**; no authenticated session and worktree compose requires BACKEND_IMAGE_TAG

## Scope
No migrations, routes, auth changes, jobs, Docker files, storage changes, or Web FE changes.

Related: #138, #139

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Attendance records now include nullable profile photo URLs and update timestamps for associated users.
  * Booking management results now include applicant profile photo URLs and update timestamps.
  * User list and detail views consistently expose photo metadata, including explicit null values when no photo exists.
* **Documentation**
  * Updated API documentation to describe the new photo fields, formats, and nullable behavior.
* **Tests**
  * Added coverage for photo metadata, missing photos, query behavior, and API contract validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->