### PR TITLE
test(#139): pin user photo refetch projection

### DIFF
--- a/tests/userCreateUpdateProjectionContract.test.js
+++ b/tests/userCreateUpdateProjectionContract.test.js
@@ -34,6 +34,15 @@ const fullUserRecord = (overrides = {}) => ({
   ...overrides
 });
 
+const expectPhotoRefetchInclude = (options) => {
+  const photoInclude = options.include.find((entry) => entry.as === 'photo_file');
+  expect(photoInclude).toMatchObject({
+    as: 'photo_file',
+    attributes: ['photo_url', 'photo_updated_at'],
+    required: false
+  });
+};
+
 const loadController = async (models) => {
   jest.unstable_mockModule('../src/models/index.js', () => ({
     Photo: {},
@@ -173,6 +182,7 @@ describe('POST /users create contract (INF-251)', () => {
     expect(payload.data.updated_at).toEqual(new Date('2026-07-05T10:00:00.000Z'));
     expect(payload.data.photo).toBe('https://cdn.example.com/cindy.jpg');
     expect(payload.data.photo_updated_at).toEqual(new Date('2026-07-05T00:00:00.000Z'));
+    expectPhotoRefetchInclude(models.User.findByPk.mock.calls[0][1]);
   });
 
   test('failed WFH location write rolls back the whole user transaction', async () => {
@@ -234,5 +244,6 @@ describe('PATCH /users/:id update contract (INF-251)', () => {
     expect(payload.data.updated_at).toEqual(new Date('2026-07-05T10:00:00.000Z'));
     expect(payload.data.photo).toBe('https://cdn.example.com/cindy.jpg');
     expect(payload.data.photo_updated_at).toEqual(new Date('2026-07-05T00:00:00.000Z'));
+    expectPhotoRefetchInclude(findByPk.mock.calls[1][1]);
   });
 });


### PR DESCRIPTION
## Summary
- strengthen the Management User create/update projection contract tests after #140
- explicitly assert response refetches keep the canonical `photo_file` include
- pin `photo_url` + `photo_updated_at` selection and `required: false`
- test-only change; no production/runtime behavior changes

## Contract impact
- API response shape: unchanged
- User photo read projection: unchanged; coverage now detects accidental refetch drift
- Upload/storage/auth/attendance/booking behavior: unchanged

## Verification
- mutation check: the new assertions fail when `photo_updated_at` is removed and the join is changed to `required: true`
- focused User contracts: **8 suites / 54 tests passed**
- `npm run lint`: **PASS**
- `npm test -- --runInBand`: **156 suites / 1487 tests passed**
- `git diff --check`: **PASS**
- diff scope: **1 test file, +11 lines**

Related: #139
Follow-up to: #140

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify that user creation and update responses include photo URL and photo update timestamp data when refetching user records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->