### PR TITLE
feat(#142): add WFA date-range dashboard FAHP analysis

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1187,17 +1187,33 @@ paths:
       tags:
         - Analysis
       summary: Get dashboard recap for Fuzzy AHP analysis
-      description: Retrieve a dashboard-specific monthly recap for discipline or Smart AC and does not expose the full dedicated detail payloads. `type=wfa` is retired and returns 410 WFA_ANALYSIS_MOVED so clients use the dedicated WFA facility-scoring endpoint with a schedule date.
+      description: Retrieve a dashboard-specific FAHP recap. Discipline and Smart AC use the existing dashboard monthly recap semantics. `type=wfa` reuses this dashboard endpoint with explicit `from/to` date boundaries; both are required for WFA, scoped to `Booking.schedule_date` in Asia/Jakarta semantics, and the maximum inclusive window is 31 days. WFA dashboard requests accept only `type`, `from`, and `to`; live latitude/longitude/schedule-date/radius analysis remains on `/api/analysis/fuzzy-ahp/wfa`.
       security:
         - bearerAuth: []
       parameters:
         - in: query
           name: type
           required: true
-          description: Required dashboard recap type selector. `wfa` is accepted only to return the migration response.
+          description: Required dashboard recap type selector. Use `from` and `to` when `type=wfa`.
           schema:
             type: string
             enum: [discipline, wfa, smart_ac]
+        - in: query
+          name: from
+          required: false
+          description: Required when `type=wfa`. Inclusive WFA dashboard start date in `YYYY-MM-DD` format.
+          schema:
+            type: string
+            format: date
+            pattern: '^\d{4}-\d{2}-\d{2}$'
+        - in: query
+          name: to
+          required: false
+          description: Required when `type=wfa`. Inclusive WFA dashboard end date in `YYYY-MM-DD` format. The inclusive WFA range must not exceed 31 days.
+          schema:
+            type: string
+            format: date
+            pattern: '^\d{4}-\d{2}-\d{2}$'
       responses:
         '200':
           description: Fuzzy AHP dashboard recap retrieved successfully
@@ -1214,7 +1230,7 @@ paths:
                     properties:
                       type:
                         type: string
-                        enum: [discipline, smart_ac]
+                        enum: [discipline, wfa, smart_ac]
                       type_label:
                         type: string
                         example: Discipline
@@ -1229,7 +1245,18 @@ paths:
                         properties:
                           period:
                             type: string
+                            nullable: true
                             example: monthly
+                          from:
+                            type: string
+                            format: date
+                            nullable: true
+                            example: '2026-08-01'
+                          to:
+                            type: string
+                            format: date
+                            nullable: true
+                            example: '2026-08-15'
                       executed_window:
                         type: object
                         properties:
@@ -1241,6 +1268,7 @@ paths:
                             format: date-time
                       status:
                         type: string
+                        enum: [ready, empty, needs_data]
                         example: ready
                       needs_data:
                         type: boolean
@@ -1266,14 +1294,26 @@ paths:
                           properties:
                             key:
                               type: string
+                              enum: [alpha_rate, lateness_severity, lateness_frequency, work_focus, attendance, location_type, distance_factor, facility_score, history, checkin_pattern, context, transition]
                             label:
                               type: string
+                              nullable: true
                             display_label:
                               type: string
                               example: Disiplin Kehadiran
                             value:
                               type: number
                               format: float
+                      methodology:
+                        type: object
+                        description: Present for WFA dashboard analysis; values are Backend-authored by the canonical WFA FAHP engine.
+                        properties:
+                          version:
+                            type: string
+                            example: wfa_fahp_v1
+                          weighting_method:
+                            type: string
+                            example: row_geometric_mean_fallback
                       ranking_preview:
                         type: object
                         properties:
@@ -1287,6 +1327,18 @@ paths:
                               properties:
                                 rank:
                                   type: integer
+                                location_label:
+                                  type: string
+                                  nullable: true
+                                  example: Cafe Merdeka
+                                latitude:
+                                  type: number
+                                  format: float
+                                  nullable: true
+                                longitude:
+                                  type: number
+                                  format: float
+                                  nullable: true
                                 id:
                                   type: integer
                                   nullable: true
@@ -1300,6 +1352,49 @@ paths:
                                 label:
                                   type: string
                                   nullable: true
+                                criteria_summary:
+                                  type: object
+                                  nullable: true
+                                  properties:
+                                    location_type_score:
+                                      type: number
+                                      format: float
+                                    distance_factor_score:
+                                      type: number
+                                      format: float
+                                    facility_score:
+                                      type: number
+                                      format: float
+                                approved_booking_count:
+                                  type: integer
+                                  minimum: 0
+                                  nullable: true
+                                analyzable_booking_count:
+                                  type: integer
+                                  minimum: 0
+                                  nullable: true
+                      evidence:
+                        type: object
+                        description: Present for WFA dashboard analysis; counts Approved WFA rows, analyzable snapshot evidence, and exclusions.
+                        properties:
+                          approved_booking_count:
+                            type: integer
+                            minimum: 0
+                          analyzable_booking_count:
+                            type: integer
+                            minimum: 0
+                          excluded_missing_snapshot_count:
+                            type: integer
+                            minimum: 0
+                          excluded_incompatible_snapshot_count:
+                            type: integer
+                            minimum: 0
+                          unique_location_count:
+                            type: integer
+                            minimum: 0
+                          ranked_location_count:
+                            type: integer
+                            minimum: 0
                       distribution:
                         type: object
                         additionalProperties:
@@ -1313,28 +1408,6 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
-        '410':
-          description: '`type=wfa` has moved to the dedicated facility-scoring analysis endpoint.'
-          content:
-            application/json:
-              schema:
-                type: object
-                required: [success, code, message]
-                properties:
-                  success:
-                    type: boolean
-                    example: false
-                  code:
-                    type: string
-                    example: WFA_ANALYSIS_MOVED
-                  message:
-                    type: string
-                    example: 'Use /api/analysis/fuzzy-ahp/wfa with lat, lon, and schedule_date.'
-              example:
-                success: false
-                code: WFA_ANALYSIS_MOVED
-                message: 'Use /api/analysis/fuzzy-ahp/wfa with lat, lon, and schedule_date.'
-
   # Attendance Endpoints
   /api/attendance/today-locations:
     get:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1327,6 +1327,9 @@ paths:
                               properties:
                                 rank:
                                   type: integer
+                                location_key:
+                                  type: string
+                                  description: Backend-authored deterministic physical-location cluster key.
                                 location_label:
                                   type: string
                                   nullable: true

--- a/src/analytics/config.fahp.js
+++ b/src/analytics/config.fahp.js
@@ -24,6 +24,7 @@ export const TFN = {
 };
 
 export const FACILITY_MATRIX_VERSION = 'facility_equal_v1';
+export const WFA_MATRIX_VERSION = 'wfa_fahp_v1';
 
 export const FACILITY_CRITERIA = Object.freeze([
   'internet_access',

--- a/src/controllers/analysis.controller.js
+++ b/src/controllers/analysis.controller.js
@@ -68,10 +68,9 @@ export const getSmartAcFahp = async (_req, res, next) => {
 
 export const getFuzzyAhpDashboardRecap = async (req, res, next) => {
   try {
-    const { type } = req.query;
-    if (type === 'wfa') return sendWfaAnalysisMoved(res);
+    const { type, from, to } = req.query;
 
-    const data = await buildFuzzyAhpDashboardRecapPayload({ type });
+    const data = await buildFuzzyAhpDashboardRecapPayload({ type, from, to });
 
     return res.status(200).json({
       success: true,

--- a/src/controllers/booking.controller.js
+++ b/src/controllers/booking.controller.js
@@ -196,7 +196,8 @@ export const createBooking = async (req, res, next) => {
     const {
       status: suitabilityStatus,
       suitabilityScore: suitability_score,
-      suitabilityLabel: suitability_label
+      suitabilityLabel: suitability_label,
+      scoringSnapshot
     } = scoreResult;
     logger.info(
       `Calculated canonical suitability for user ${userId}: ${suitabilityStatus}, ${suitability_score} (${suitability_label})`
@@ -291,6 +292,7 @@ export const createBooking = async (req, res, next) => {
         status: 3, // pending
         suitability_score,
         suitability_label,
+        wfa_scoring_snapshot: scoringSnapshot,
         request_reason_id: reason.id,
         request_other_reason: normalizedOtherReason,
         radius_snapshot: radiusMeters,

--- a/src/middlewares/validator.js
+++ b/src/middlewares/validator.js
@@ -739,13 +739,32 @@ export const fuzzyAhpDashboardRecapValidation = [
       throw new Error('type is required');
     }
 
+    if (!['discipline', 'wfa', 'smart_ac'].includes(req.query.type)) {
+      throw new Error('type must be one of discipline, wfa, smart_ac');
+    }
+
+    if (req.query.type === 'wfa') {
+      const unsupportedQueryKey = queryKeys.find((key) => !['type', 'from', 'to'].includes(key));
+      if (unsupportedQueryKey) {
+        throw new Error('only type, from, and to query parameters are allowed for wfa dashboard');
+      }
+
+      const validationMessage = validateHistoricalDateWindowQuery({
+        period: 'custom',
+        from: req.query.from ?? null,
+        to: req.query.to ?? null
+      });
+
+      if (validationMessage) {
+        throw new Error(validationMessage);
+      }
+
+      return true;
+    }
+
     const unsupportedQueryKey = queryKeys.find((key) => key !== 'type');
     if (unsupportedQueryKey) {
       throw new Error('only type query parameter is allowed');
-    }
-
-    if (!['discipline', 'wfa', 'smart_ac'].includes(req.query.type)) {
-      throw new Error('type must be one of discipline, wfa, smart_ac');
     }
 
     return true;

--- a/src/models/booking.model.js
+++ b/src/models/booking.model.js
@@ -94,6 +94,10 @@ const Booking = sequelize.define(
       type: DataTypes.INTEGER,
       allowNull: true
     },
+    wfa_scoring_snapshot: {
+      type: DataTypes.JSON,
+      allowNull: true
+    },
     rejection_reason: {
       type: DataTypes.INTEGER,
       allowNull: true

--- a/src/models/migrations/20260815010000-add-wfa-scoring-snapshot.cjs
+++ b/src/models/migrations/20260815010000-add-wfa-scoring-snapshot.cjs
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('bookings', 'wfa_scoring_snapshot', {
+      type: Sequelize.JSON,
+      allowNull: true
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn('bookings', 'wfa_scoring_snapshot');
+  }
+};

--- a/src/services/fuzzyAhpAnalysis.service.js
+++ b/src/services/fuzzyAhpAnalysis.service.js
@@ -674,12 +674,10 @@ const buildDashboardRankingPreview = (ranking) => ({
   items: Array.isArray(ranking) ? ranking.slice(0, 5).map(buildDashboardRecapRankingItem) : []
 });
 
-export const buildFuzzyAhpDashboardRecapPayload = async ({ type }) => {
+export const buildFuzzyAhpDashboardRecapPayload = async ({ type, from, to }) => {
   if (type === 'wfa') {
-    const error = new Error('Use /api/analysis/fuzzy-ahp/wfa with lat, lon, and schedule_date.');
-    error.code = 'WFA_ANALYSIS_MOVED';
-    error.status = 410;
-    throw error;
+    const { buildWfaDashboardAnalysis } = await import('./wfaDashboardAnalysis.service.js');
+    return buildWfaDashboardAnalysis({ from, to });
   }
 
   let { startAt, endAt } = getAnalysisWindow('monthly');

--- a/src/services/wfaDashboardAnalysis.service.js
+++ b/src/services/wfaDashboardAnalysis.service.js
@@ -10,6 +10,7 @@ const RANKING_LIMIT = 5;
 const WFA_APPROVED_STATUS = 1;
 const WFA_TIMEZONE = 'Asia/Jakarta';
 const CONSISTENCY_THRESHOLD = 0.1;
+const SUPPORTED_SNAPSHOT_SCHEMA_VERSION = 1;
 
 const CRITERION_KEYS = [
   'location_type_score',
@@ -61,6 +62,10 @@ export const validateWfaScoringSnapshot = (snapshot, methodologyVersion) => {
 
   if (snapshot.methodology_version !== methodologyVersion) {
     return { valid: false, reason: 'INCOMPATIBLE_METHODOLOGY' };
+  }
+
+  if (snapshot.schema_version !== SUPPORTED_SNAPSHOT_SCHEMA_VERSION) {
+    return { valid: false, reason: 'UNSUPPORTED_SNAPSHOT_SCHEMA' };
   }
 
   const criteria = snapshot.criteria;
@@ -254,7 +259,12 @@ export const buildWfaDashboardRanking = async (
     });
   }
 
-  return ranked.sort(compareRankedLocations).slice(0, RANKING_LIMIT);
+  return ranked
+    .sort(compareRankedLocations)
+    .map((item, index) => ({
+      ...item,
+      rank: index + 1
+    }));
 };
 
 const countEvidence = (approvedRows, clusters, rankedLocations) => {

--- a/src/services/wfaDashboardAnalysis.service.js
+++ b/src/services/wfaDashboardAnalysis.service.js
@@ -1,9 +1,15 @@
+import { Op } from 'sequelize';
+
 import { WFA_MATRIX_VERSION } from '../analytics/config.fahp.js';
+import { Booking as BookingModel } from '../models/index.js';
 import { calculateDistance } from '../utils/geofence.js';
 import fuzzyEngine from '../utils/fuzzyAhpEngine.js';
 
 const PHYSICAL_CLUSTER_RADIUS_METERS = 25;
 const RANKING_LIMIT = 5;
+const WFA_APPROVED_STATUS = 1;
+const WFA_TIMEZONE = 'Asia/Jakarta';
+const CONSISTENCY_THRESHOLD = 0.1;
 
 const CRITERION_KEYS = [
   'location_type_score',
@@ -248,3 +254,102 @@ export const buildWfaDashboardRanking = async (
 
   return ranked.sort(compareRankedLocations).slice(0, RANKING_LIMIT);
 };
+
+const countEvidence = (approvedRows, clusters, rankedLocations) => {
+  const clusterRows = (clusters ?? []).flatMap((cluster) => cluster.rows ?? []);
+
+  return {
+    approved_booking_count: approvedRows.length,
+    analyzable_booking_count: clusterRows.filter((row) => row.snapshotValidation.valid).length,
+    excluded_missing_snapshot_count: clusterRows.filter(
+      (row) => row.snapshotValidation.reason === 'MISSING_SNAPSHOT'
+    ).length,
+    excluded_incompatible_snapshot_count: clusterRows.filter(
+      (row) => row.snapshotValidation.valid === false && row.snapshotValidation.reason !== 'MISSING_SNAPSHOT'
+    ).length,
+    unique_location_count: clusters.length,
+    ranked_location_count: rankedLocations.length
+  };
+};
+
+const resolveStatus = ({ approvedCount, rankedCount }) => {
+  if (approvedCount === 0) {
+    return 'empty';
+  }
+
+  if (rankedCount === 0) {
+    return 'needs_data';
+  }
+
+  return 'ready';
+};
+
+const buildCanonicalResponse = ({ from, to, weights, ranking, evidence }) => {
+  const isConsistent = weights.consistency_ratio <= CONSISTENCY_THRESHOLD;
+
+  return {
+    type: 'wfa',
+    type_label: 'WFA',
+    status: resolveStatus({
+      approvedCount: evidence.approved_booking_count,
+      rankedCount: evidence.ranked_location_count
+    }),
+    timezone: WFA_TIMEZONE,
+    requested_window: { from, to },
+    criteria_weights: [
+      { key: 'location_type', display_label: 'Tipe Lokasi', value: weights.location_type },
+      { key: 'distance_factor', display_label: 'Faktor Jarak', value: weights.distance_factor },
+      { key: 'facility_score', display_label: 'Skor Fasilitas', value: weights.facility_score }
+    ],
+    consistency: {
+      CR: weights.consistency_ratio,
+      threshold: CONSISTENCY_THRESHOLD,
+      is_consistent: isConsistent,
+      summary_label: isConsistent ? 'Konsistensi dapat diterima' : 'Konsistensi perlu ditinjau'
+    },
+    methodology: {
+      version: weights.version,
+      weighting_method: weights.weighting_method
+    },
+    ranking_preview: { top_n: RANKING_LIMIT, items: ranking.slice(0, RANKING_LIMIT) },
+    evidence
+  };
+};
+
+export const createWfaDashboardAnalysisService = ({
+  Booking = BookingModel,
+  fuzzyEngine: fuzzyEngineDependency = fuzzyEngine,
+  distanceCalculator = calculateDistance
+} = {}) => ({
+  async buildAnalysis({ from, to }) {
+    const weights = fuzzyEngineDependency.getWfaAhpWeights();
+    const approvedRows = await Booking.findAll({
+      where: {
+        status: WFA_APPROVED_STATUS,
+        schedule_date: { [Op.between]: [from, to] }
+      },
+      include: [
+        {
+          association: 'location',
+          required: true
+        }
+      ]
+    });
+    const clusters = clusterWfaDashboardRows(approvedRows, {
+      distanceCalculator,
+      methodologyVersion: weights.version
+    });
+    const ranking = await buildWfaDashboardRanking(clusters, {
+      weights,
+      scoreCalculator: fuzzyEngineDependency.calculateWfaScore
+    });
+    const evidence = countEvidence(approvedRows, clusters, ranking);
+
+    return buildCanonicalResponse({ from, to, weights, ranking, evidence });
+  }
+});
+
+const wfaDashboardAnalysisService = createWfaDashboardAnalysisService();
+
+export const buildWfaDashboardAnalysis = ({ from, to }) =>
+  wfaDashboardAnalysisService.buildAnalysis({ from, to });

--- a/src/services/wfaDashboardAnalysis.service.js
+++ b/src/services/wfaDashboardAnalysis.service.js
@@ -151,6 +151,7 @@ const createCluster = (row) => ({
   anchor: row,
   normalizedDescription: row.normalizedDescription,
   description: row.description,
+  location_key: `wfa-cluster:location:${row.locationId ?? 'unknown'}:booking:${row.bookingId ?? 'unknown'}`,
   location_label: row.description ?? `Location ${row.locationId ?? row.bookingId ?? 'Unknown'}`,
   latitude: row.latitude,
   longitude: row.longitude,
@@ -241,6 +242,7 @@ export const buildWfaDashboardRanking = async (
     );
 
     ranked.push({
+      location_key: cluster.location_key,
       location_label: cluster.location_label ?? cluster.description ?? 'Unknown WFA Location',
       score: result.score,
       label: result.label,

--- a/src/services/wfaDashboardAnalysis.service.js
+++ b/src/services/wfaDashboardAnalysis.service.js
@@ -1,0 +1,250 @@
+import { WFA_MATRIX_VERSION } from '../analytics/config.fahp.js';
+import { calculateDistance } from '../utils/geofence.js';
+import fuzzyEngine from '../utils/fuzzyAhpEngine.js';
+
+const PHYSICAL_CLUSTER_RADIUS_METERS = 25;
+const RANKING_LIMIT = 5;
+
+const CRITERION_KEYS = [
+  'location_type_score',
+  'distance_factor_score',
+  'facility_score'
+];
+
+const asFiniteNumber = (value) => {
+  const numericValue = Number(value);
+  return Number.isFinite(numericValue) ? numericValue : null;
+};
+
+const compareNullableText = (left, right) => {
+  if (left == null && right == null) return 0;
+  if (left == null) return 1;
+  if (right == null) return -1;
+  return left.localeCompare(right);
+};
+
+const compareValue = (left, right) => {
+  if (left == null && right == null) return 0;
+  if (left == null) return 1;
+  if (right == null) return -1;
+  if (typeof left === 'number' && typeof right === 'number') return left - right;
+  return String(left).localeCompare(String(right), undefined, { numeric: true });
+};
+
+export const normalizeWfaDashboardDescription = (value) => {
+  const normalized = String(value ?? '')
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, ' ');
+
+  return normalized === '' ? null : normalized;
+};
+
+const displayDescription = (value) => {
+  const normalized = String(value ?? '')
+    .trim()
+    .replace(/\s+/g, ' ');
+
+  return normalized === '' ? null : normalized;
+};
+
+export const validateWfaScoringSnapshot = (snapshot, methodologyVersion) => {
+  if (!snapshot) {
+    return { valid: false, reason: 'MISSING_SNAPSHOT' };
+  }
+
+  if (snapshot.methodology_version !== methodologyVersion) {
+    return { valid: false, reason: 'INCOMPATIBLE_METHODOLOGY' };
+  }
+
+  const criteria = snapshot.criteria;
+  const parsedCriteria = {};
+
+  if (!criteria || typeof criteria !== 'object') {
+    return { valid: false, reason: 'INVALID_CRITERIA' };
+  }
+
+  for (const key of CRITERION_KEYS) {
+    const value = criteria[key];
+    if (typeof value !== 'number' || !Number.isFinite(value) || value < 0 || value > 100) {
+      return { valid: false, reason: 'INVALID_CRITERIA' };
+    }
+    parsedCriteria[key] = value;
+  }
+
+  return { valid: true, criteria: parsedCriteria };
+};
+
+const extractSnapshot = (row) => row?.wfa_scoring_snapshot ?? row?.wfaScoringSnapshot ?? row?.snapshot ?? null;
+
+const extractLocation = (row) => row?.location ?? row?.Location ?? {};
+
+const normalizeRow = (row, methodologyVersion) => {
+  const location = extractLocation(row);
+  const description =
+    row?.description ??
+    row?.location_description ??
+    row?.locationDescription ??
+    location.description ??
+    location.location_description ??
+    location.name ??
+    null;
+  const latitude = asFiniteNumber(row?.latitude ?? row?.lat ?? location.latitude ?? location.lat);
+  const longitude = asFiniteNumber(
+    row?.longitude ?? row?.lng ?? row?.lon ?? location.longitude ?? location.lng ?? location.lon
+  );
+  const snapshot = extractSnapshot(row);
+  const snapshotValidation = validateWfaScoringSnapshot(snapshot, methodologyVersion);
+
+  return {
+    bookingId: row?.bookingId ?? row?.booking_id ?? row?.id ?? null,
+    locationId: row?.locationId ?? row?.location_id ?? location.location_id ?? location.id ?? null,
+    description: displayDescription(description),
+    normalizedDescription: normalizeWfaDashboardDescription(description),
+    latitude,
+    longitude,
+    snapshot,
+    snapshotValidation,
+    criteria: snapshotValidation.valid ? snapshotValidation.criteria : null,
+    originalRow: row
+  };
+};
+
+const compareRowsForClustering = (left, right) =>
+  compareNullableText(left.normalizedDescription, right.normalizedDescription) ||
+  compareValue(left.latitude, right.latitude) ||
+  compareValue(left.longitude, right.longitude) ||
+  compareValue(left.locationId, right.locationId) ||
+  compareValue(left.bookingId, right.bookingId);
+
+const rowDistanceFromAnchor = (row, anchor, distanceCalculator) => {
+  if (
+    row.latitude == null ||
+    row.longitude == null ||
+    anchor.latitude == null ||
+    anchor.longitude == null
+  ) {
+    return Number.POSITIVE_INFINITY;
+  }
+
+  return distanceCalculator(anchor.latitude, anchor.longitude, row.latitude, row.longitude);
+};
+
+const isCompatibleWithCluster = (row, cluster, distanceCalculator) => {
+  const anchor = cluster.anchor;
+  const hasDescriptionPair = row.normalizedDescription != null && anchor.normalizedDescription != null;
+
+  if (hasDescriptionPair && row.normalizedDescription !== anchor.normalizedDescription) {
+    return false;
+  }
+
+  return rowDistanceFromAnchor(row, anchor, distanceCalculator) <= PHYSICAL_CLUSTER_RADIUS_METERS;
+};
+
+const createCluster = (row) => ({
+  anchor: row,
+  normalizedDescription: row.normalizedDescription,
+  description: row.description,
+  location_label: row.description ?? `Location ${row.locationId ?? row.bookingId ?? 'Unknown'}`,
+  latitude: row.latitude,
+  longitude: row.longitude,
+  rows: [row]
+});
+
+export const clusterWfaDashboardRows = (
+  rows,
+  {
+    distanceCalculator = calculateDistance,
+    methodologyVersion = WFA_MATRIX_VERSION
+  } = {}
+) => {
+  const normalizedRows = [...(rows ?? [])]
+    .map((row) => normalizeRow(row, methodologyVersion))
+    .sort(compareRowsForClustering);
+  const clusters = [];
+
+  for (const row of normalizedRows) {
+    const compatibleCluster = clusters.find((cluster) =>
+      isCompatibleWithCluster(row, cluster, distanceCalculator)
+    );
+
+    if (compatibleCluster) {
+      compatibleCluster.rows.push(row);
+    } else {
+      clusters.push(createCluster(row));
+    }
+  }
+
+  return clusters;
+};
+
+const average = (values) => values.reduce((total, value) => total + value, 0) / values.length;
+
+const averageCriteria = (rows) => ({
+  location_type_score: average(rows.map((row) => row.criteria.location_type_score)),
+  distance_factor_score: average(rows.map((row) => row.criteria.distance_factor_score)),
+  facility_score: average(rows.map((row) => row.criteria.facility_score))
+});
+
+const normalizeClusterRowForRanking = (row, methodologyVersion) => {
+  const normalized =
+    row?.bookingId !== undefined && row?.snapshotValidation
+      ? { ...row }
+      : normalizeRow(row, methodologyVersion);
+  const snapshotValidation = validateWfaScoringSnapshot(normalized.snapshot, methodologyVersion);
+
+  return {
+    ...normalized,
+    snapshotValidation,
+    criteria: snapshotValidation.valid ? snapshotValidation.criteria : null
+  };
+};
+
+const compareRankedLocations = (left, right) =>
+  right.score - left.score ||
+  right.analyzable_booking_count - left.analyzable_booking_count ||
+  right.approved_booking_count - left.approved_booking_count ||
+  left.location_label.localeCompare(right.location_label);
+
+export const buildWfaDashboardRanking = async (
+  clusters,
+  {
+    weights = fuzzyEngine.getWfaAhpWeights(),
+    scoreCalculator = fuzzyEngine.calculateWfaScore
+  } = {}
+) => {
+  const methodologyVersion = weights.version ?? WFA_MATRIX_VERSION;
+  const ranked = [];
+
+  for (const cluster of clusters ?? []) {
+    const rows = (cluster.rows ?? []).map((row) => normalizeClusterRowForRanking(row, methodologyVersion));
+    const analyzableRows = rows.filter((row) => row.snapshotValidation.valid);
+
+    if (analyzableRows.length === 0) {
+      continue;
+    }
+
+    const criteriaSummary = averageCriteria(analyzableRows);
+    const result = await scoreCalculator(
+      {
+        locationTypeScore: criteriaSummary.location_type_score,
+        distanceScore: criteriaSummary.distance_factor_score,
+        facilityScore: criteriaSummary.facility_score
+      },
+      weights
+    );
+
+    ranked.push({
+      location_label: cluster.location_label ?? cluster.description ?? 'Unknown WFA Location',
+      score: result.score,
+      label: result.label,
+      latitude: cluster.latitude,
+      longitude: cluster.longitude,
+      criteria_summary: criteriaSummary,
+      approved_booking_count: rows.length,
+      analyzable_booking_count: analyzableRows.length
+    });
+  }
+
+  return ranked.sort(compareRankedLocations).slice(0, RANKING_LIMIT);
+};

--- a/src/services/wfaRecommendation.service.js
+++ b/src/services/wfaRecommendation.service.js
@@ -52,6 +52,9 @@ const compareStableId = (left, right) => {
 const compareDistanceAndId = (left, right) =>
   left.distanceMeters - right.distanceMeters || compareStableId(left, right);
 
+const isFiniteScoreDomain = (value) =>
+  typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 100;
+
 const emptyFacilities = () =>
   Object.fromEntries(FACILITY_KEYS.map((key) => [key, null]));
 
@@ -122,7 +125,7 @@ const publicCandidate = (candidate, {
   finalScore,
   finalLabel,
   rank = null
-}) => ({
+}, extra = {}) => ({
   place_id: candidate.placeId,
   name: candidate.name,
   address: candidate.address,
@@ -136,7 +139,8 @@ const publicCandidate = (candidate, {
   facilities,
   final_score: finalScore,
   final_label: finalLabel,
-  rank
+  rank,
+  ...extra
 });
 
 const recommendationSearchCriteria = ({
@@ -156,7 +160,12 @@ const recommendationSearchCriteria = ({
 
 const recommendationMethodology = (wfaWeights, facilityWeights) => ({
   approach: 'Fuzzy AHP facility-evidence scoring',
-  criteria_weights: { ...wfaWeights },
+  criteria_weights: {
+    location_type: wfaWeights.location_type,
+    distance_factor: wfaWeights.distance_factor,
+    facility_score: wfaWeights.facility_score,
+    consistency_ratio: wfaWeights.consistency_ratio
+  },
   facility_matrix: {
     version: facilityWeights.version,
     criteria: [...facilityWeights.criteria],
@@ -165,6 +174,44 @@ const recommendationMethodology = (wfaWeights, facilityWeights) => ({
     weighting_method: facilityWeights.weighting_method
   }
 });
+
+const buildScoringSnapshot = ({ candidate, evidence, wfaWeights, final }) => {
+  const criteria = {
+    location_type_score: candidate.locationTypeScore,
+    distance_factor_score: candidate.distanceScore,
+    facility_score: evidence.facilityScore
+  };
+
+  if (Object.values(criteria).some((value) => !isFiniteScoreDomain(value))) {
+    return null;
+  }
+
+  return {
+    schema_version: 1,
+    methodology_version: wfaWeights.version,
+    captured_at: new Date().toISOString(),
+    criteria,
+    methodology: {
+      weights: {
+        location_type: wfaWeights.location_type,
+        distance_factor: wfaWeights.distance_factor,
+        facility_score: wfaWeights.facility_score
+      },
+      consistency_ratio: wfaWeights.consistency_ratio,
+      weighting_method: wfaWeights.weighting_method
+    },
+    evidence: {
+      place_id: candidate.placeId,
+      location_type: candidate.locationType,
+      distance_meters: candidate.distanceMeters,
+      facility_confidence: evidence.facilityConfidence
+    },
+    result: {
+      score: final.score,
+      label: final.label
+    }
+  };
+};
 
 const compareFinalCandidates = (left, right) => {
   const statusDifference = STATUS_ORDER[left.status] - STATUS_ORDER[right.status];
@@ -241,7 +288,13 @@ export const createWfaRecommendationService = (dependencies = {}) => {
     });
   };
 
-  const enrichCandidate = async ({ candidate, scheduleDate, checkinWindow, wfaWeights }) => {
+  const enrichCandidate = async ({
+    candidate,
+    scheduleDate,
+    checkinWindow,
+    wfaWeights,
+    includeScoringSnapshot = false
+  }) => {
     let details;
     try {
       details = await resolved.geoapifyClient.fetchPlaceDetails(candidate.placeId);
@@ -253,7 +306,7 @@ export const createWfaRecommendationService = (dependencies = {}) => {
         facilities: emptyFacilities(),
         finalScore: null,
         finalLabel: null
-      });
+      }, includeScoringSnapshot ? { scoringSnapshot: null } : undefined);
     }
 
     const evidence = resolved.facility.scoreFacilityEvidence({
@@ -271,7 +324,7 @@ export const createWfaRecommendationService = (dependencies = {}) => {
         facilities,
         finalScore: null,
         finalLabel: null
-      });
+      }, includeScoringSnapshot ? { scoringSnapshot: null } : undefined);
     }
 
     const final = await resolved.fuzzyEngine.calculateWfaScore(
@@ -290,7 +343,16 @@ export const createWfaRecommendationService = (dependencies = {}) => {
       facilities,
       finalScore: final.score,
       finalLabel: final.label
-    });
+    }, includeScoringSnapshot
+      ? {
+          scoringSnapshot: buildScoringSnapshot({
+            candidate,
+            evidence,
+            wfaWeights,
+            final
+          })
+        }
+      : undefined);
   };
 
   const runPipeline = async ({
@@ -299,7 +361,8 @@ export const createWfaRecommendationService = (dependencies = {}) => {
     scheduleDate,
     radiusMeters,
     candidateLimit,
-    nearestOnly = false
+    nearestOnly = false,
+    includeScoringSnapshot = false
   }) => {
     const features = await resolved.geoapifyClient.searchPlaces({
       latitude,
@@ -335,7 +398,7 @@ export const createWfaRecommendationService = (dependencies = {}) => {
 
     const checkinWindow = await resolved.facility.readStrictWfaCheckinWindow();
     const enriched = await mapWithConcurrency(shortlist, DETAILS_CONCURRENCY, (candidate) =>
-      enrichCandidate({ candidate, scheduleDate, checkinWindow, wfaWeights })
+      enrichCandidate({ candidate, scheduleDate, checkinWindow, wfaWeights, includeScoringSnapshot })
     );
     let rank = 0;
     const ranked = enriched.sort(compareFinalCandidates).map((candidate) => ({
@@ -410,7 +473,8 @@ export const createWfaRecommendationService = (dependencies = {}) => {
         scheduleDate: eligibleDate,
         radiusMeters,
         candidateLimit: 1,
-        nearestOnly: true
+        nearestOnly: true,
+        includeScoringSnapshot: true
       });
     } catch (error) {
       if (error?.code === 'WFA_PROVIDER_UNAVAILABLE') {
@@ -428,15 +492,19 @@ export const createWfaRecommendationService = (dependencies = {}) => {
         status: 'insufficient_facility_data',
         suitabilityScore: null,
         suitabilityLabel: null,
+        scoringSnapshot: null,
         candidate
       };
     }
 
+    const { scoringSnapshot = null, ...publicCandidateResult } = candidate;
+
     return {
       status: 'ranked',
-      suitabilityScore: candidate.final_score,
-      suitabilityLabel: candidate.final_label,
-      candidate
+      suitabilityScore: publicCandidateResult.final_score,
+      suitabilityLabel: publicCandidateResult.final_label,
+      scoringSnapshot,
+      candidate: publicCandidateResult
     };
   };
 

--- a/src/utils/fuzzyAhpEngine.js
+++ b/src/utils/fuzzyAhpEngine.js
@@ -7,6 +7,7 @@ import {
   FACILITY_MATRIX_VERSION,
   FACILITY_CRITERIA,
   FACILITY_PAIRWISE_TFN,
+  WFA_MATRIX_VERSION,
   WFA_PAIRWISE_TFN,
   DISC_PAIRWISE_TFN,
   SMART_AC_PAIRWISE_TFN
@@ -92,6 +93,7 @@ function weightedPrediction(candidates, weights, targetDate, timeIn, fallbackEnd
 function getWfaAhpWeights() {
   if (cachedWfaWeights && cachedWfaCR != null) {
     return {
+      version: WFA_MATRIX_VERSION,
       location_type: cachedWfaWeights[0],
       distance_factor: cachedWfaWeights[1],
       facility_score: cachedWfaWeights[2],
@@ -106,6 +108,7 @@ function getWfaAhpWeights() {
   cachedWfaCR = CR;
   cachedWfaWeightingMethod = method;
   return {
+    version: WFA_MATRIX_VERSION,
     location_type: weights[0],
     distance_factor: weights[1],
     facility_score: weights[2],

--- a/tests/analysisFuzzyAhpContract.test.js
+++ b/tests/analysisFuzzyAhpContract.test.js
@@ -649,14 +649,19 @@ describe('analysis fuzzy ahp contract', () => {
     jest.useRealTimers();
   });
 
-  it('returns the exact move contract for the retired wfa dashboard recap', async () => {
+  it('requires an explicit date range for the WFA dashboard recap', async () => {
     const res = await request(scopedApp).get('/api/analysis/fuzzy-ahp/dashboard?type=wfa');
 
-    expect(res.status).toBe(410);
+    expect(res.status).toBe(400);
     expect(res.body).toEqual({
       success: false,
-      code: 'WFA_ANALYSIS_MOVED',
-      message: 'Use /api/analysis/fuzzy-ahp/wfa with lat, lon, and schedule_date.'
+      code: 'E_VALIDATION',
+      message: 'Parameter from dan to wajib diisi saat period=range atau custom',
+      errors: [
+        expect.objectContaining({
+          msg: 'Parameter from dan to wajib diisi saat period=range atau custom'
+        })
+      ]
     });
     expect(mockLocation.findAll).not.toHaveBeenCalled();
   });

--- a/tests/analysisFuzzyAhpControllerValidation.test.js
+++ b/tests/analysisFuzzyAhpControllerValidation.test.js
@@ -33,10 +33,44 @@ const {
   getFuzzyAhpAnalysis,
   getFuzzyAhpDashboardRecap
 } = await import('../src/controllers/analysis.controller.js');
+const {
+  fuzzyAhpDashboardRecapValidation,
+  validate
+} = await import('../src/middlewares/validator.js');
+
+const createDashboardValidatorHarness = async (query) => {
+  const req = { query };
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis()
+  };
+  const next = jest.fn();
+
+  for (const middleware of [...fuzzyAhpDashboardRecapValidation, validate]) {
+    await new Promise((resolve) => {
+      middleware(req, res, () => {
+        next();
+        resolve();
+      });
+
+      if (res.status.mock.calls.length > 0) {
+        resolve();
+      }
+    });
+
+    if (res.status.mock.calls.length > 0) break;
+  }
+
+  return { req, res, next };
+};
 
 describe('analysis fuzzy ahp controller validation', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetAnalysisWindow.mockReturnValue({
+      startAt: new Date('2026-08-01T00:00:00.000Z'),
+      endAt: new Date('2026-08-15T00:00:00.000Z')
+    });
   });
 
   it('returns 400 for invalid type values', async () => {
@@ -141,15 +175,70 @@ describe('analysis fuzzy ahp controller validation', () => {
     });
   });
 
-  it('returns the exact move contract instead of a fabricated empty wfa recap', async () => {
-    const req = { query: { type: 'wfa' } };
+  it('delegates WFA dashboard recap with explicit from/to and preserves the success envelope', async () => {
+    const req = {
+      query: { type: 'wfa', from: '2026-08-01', to: '2026-08-15' },
+      user: { id: 12, role_name: 'Admin' }
+    };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis()
+    };
+    const next = jest.fn();
+    const payload = {
+      type: 'wfa',
+      type_label: 'WFA',
+      status: 'ready',
+      timezone: 'Asia/Jakarta',
+      requested_window: { from: '2026-08-01', to: '2026-08-15' },
+      criteria_weights: [
+        { key: 'location_type', display_label: 'Tipe Lokasi', value: 0.6335 }
+      ],
+      consistency: {
+        CR: 0.0576,
+        threshold: 0.1,
+        is_consistent: true,
+        summary_label: 'Konsistensi dapat diterima'
+      },
+      methodology: { version: 'wfa_fahp_v1', weighting_method: 'row_geometric_mean_fallback' },
+      ranking_preview: { top_n: 5, items: [] },
+      evidence: {
+        approved_booking_count: 1,
+        analyzable_booking_count: 1,
+        excluded_missing_snapshot_count: 0,
+        excluded_incompatible_snapshot_count: 0,
+        unique_location_count: 1,
+        ranked_location_count: 1
+      }
+    };
+
+    mockBuildFuzzyAhpDashboardRecapPayload.mockResolvedValue(payload);
+
+    await getFuzzyAhpDashboardRecap(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(mockBuildFuzzyAhpDashboardRecapPayload).toHaveBeenCalledWith({
+      type: 'wfa',
+      from: '2026-08-01',
+      to: '2026-08-15'
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      data: payload,
+      message: 'Fuzzy AHP dashboard recap retrieved successfully'
+    });
+  });
+
+  it('keeps the generic fuzzy-ahp type=wfa route retired with the exact move contract', async () => {
+    const req = { query: { type: 'wfa', period: 'monthly' } };
     const res = {
       status: jest.fn().mockReturnThis(),
       json: jest.fn().mockReturnThis()
     };
     const next = jest.fn();
 
-    await getFuzzyAhpDashboardRecap(req, res, next);
+    await getFuzzyAhpAnalysis(req, res, next);
 
     expect(next).not.toHaveBeenCalled();
     expect(mockBuildFuzzyAhpDashboardRecapPayload).not.toHaveBeenCalled();
@@ -159,6 +248,41 @@ describe('analysis fuzzy ahp controller validation', () => {
       code: 'WFA_ANALYSIS_MOVED',
       message: 'Use /api/analysis/fuzzy-ahp/wfa with lat, lon, and schedule_date.'
     });
+  });
+
+  it.each([
+    [{ type: 'wfa', to: '2026-08-15' }, 'Parameter from dan to wajib diisi saat period=range atau custom'],
+    [{ type: 'wfa', from: '2026-08-01' }, 'Parameter from dan to wajib diisi saat period=range atau custom'],
+    [{ type: 'wfa', from: '2026-02-30', to: '2026-08-15' }, 'Parameter from harus menggunakan format YYYY-MM-DD'],
+    [{ type: 'wfa', from: '2026-08-15', to: '2026-08-01' }, 'Parameter from tidak boleh lebih besar dari to'],
+    [{ type: 'wfa', from: '2026-08-01', to: '2026-09-01' }, 'Rentang tanggal custom maksimal 31 hari'],
+    [{ type: 'wfa', period: 'monthly', from: '2026-08-01', to: '2026-08-15' }, 'only type, from, and to query parameters are allowed for wfa dashboard'],
+    [{ type: 'wfa', lat: '-0.9', from: '2026-08-01', to: '2026-08-15' }, 'only type, from, and to query parameters are allowed for wfa dashboard'],
+    [{ type: 'wfa', lon: '119.8', from: '2026-08-01', to: '2026-08-15' }, 'only type, from, and to query parameters are allowed for wfa dashboard'],
+    [{ type: 'wfa', schedule_date: '2026-08-15', from: '2026-08-01', to: '2026-08-15' }, 'only type, from, and to query parameters are allowed for wfa dashboard'],
+    [{ type: 'wfa', radius_meters: '5000', from: '2026-08-01', to: '2026-08-15' }, 'only type, from, and to query parameters are allowed for wfa dashboard']
+  ])('rejects invalid WFA dashboard query %#', async (query, expectedMessage) => {
+    const { res } = await createDashboardValidatorHarness(query);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        code: 'E_VALIDATION',
+        message: expectedMessage
+      })
+    );
+  });
+
+  it('accepts only type/from/to for a valid WFA dashboard query', async () => {
+    const { res, next } = await createDashboardValidatorHarness({
+      type: 'wfa',
+      from: '2026-08-01',
+      to: '2026-08-15'
+    });
+
+    expect(res.status).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
   });
 
   it('logs and forwards dashboard recap builder errors', async () => {

--- a/tests/analysisFuzzyAhpDashboardRecapRoute.test.js
+++ b/tests/analysisFuzzyAhpDashboardRecapRoute.test.js
@@ -74,6 +74,7 @@ const mockLocationFindAll = jest.fn();
 const mockLocationFindByPk = jest.fn();
 const mockLocationEventFindOne = jest.fn();
 const mockLocationEventFindAll = jest.fn();
+const mockBuildWfaDashboardAnalysis = jest.fn();
 
 const mockGetDisciplineAhpWeights = jest.fn(() => ({
   alpha_rate: 0.4,
@@ -127,13 +128,38 @@ const mockFuzzyAhpDashboardRecapValidation = jest.fn((req, _res, next) => {
     return next();
   }
 
-  if (queryKeys.some((key) => key !== 'type')) {
-    req.validationError = 'only type query parameter is allowed';
+  if (!ALLOWED_TYPES.includes(req.query.type)) {
+    req.validationError = 'type must be one of discipline, wfa, smart_ac';
     return next();
   }
 
-  if (!ALLOWED_TYPES.includes(req.query.type)) {
-    req.validationError = 'type must be one of discipline, wfa, smart_ac';
+  if (req.query.type === 'wfa') {
+    const unsupportedQueryKey = queryKeys.find((key) => !['type', 'from', 'to'].includes(key));
+    if (unsupportedQueryKey) {
+      req.validationError = 'only type, from, and to query parameters are allowed for wfa dashboard';
+      return next();
+    }
+
+    if (!req.query.from || !req.query.to) {
+      req.validationError = 'Parameter from dan to wajib diisi saat period=range atau custom';
+      return next();
+    }
+
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(req.query.from)) {
+      req.validationError = 'Parameter from harus menggunakan format YYYY-MM-DD';
+      return next();
+    }
+
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(req.query.to)) {
+      req.validationError = 'Parameter to harus menggunakan format YYYY-MM-DD';
+      return next();
+    }
+
+    return next();
+  }
+
+  if (queryKeys.some((key) => key !== 'type')) {
+    req.validationError = 'only type query parameter is allowed';
     return next();
   }
 
@@ -197,6 +223,10 @@ jest.unstable_mockModule('../src/utils/fuzzyAhpEngine.js', () => ({
     categorizePlace: mockCategorizePlace,
     getSmartAcAhpWeights: mockGetSmartAcAhpWeights
   }
+}));
+
+jest.unstable_mockModule('../src/services/wfaDashboardAnalysis.service.js', () => ({
+  buildWfaDashboardAnalysis: mockBuildWfaDashboardAnalysis
 }));
 
 const { default: analysisRoutes } = await import('../src/routes/analysis.routes.js');
@@ -279,7 +309,7 @@ describe('analysis fuzzy ahp dashboard recap route validation scaffold', () => {
     await expectValidationFailure(app, path, 'only type query parameter is allowed');
   });
 
-  it('returns 200 success response for a valid type query', async () => {
+  it('returns 200 success response for a valid discipline type query', async () => {
     const app = createDashboardRecapHarnessApp();
 
     const res = await request(app).get('/api/analysis/fuzzy-ahp/dashboard?type=discipline');
@@ -338,6 +368,23 @@ describe('analysis fuzzy ahp dashboard recap route validation scaffold', () => {
       message: 'Fuzzy AHP dashboard recap retrieved successfully'
     });
     expect(mockGetFuzzyAhpDashboardRecap).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows WFA dashboard explicit from/to and preserves those query values for the handler', async () => {
+    const app = createDashboardRecapHarnessApp();
+
+    const res = await request(app).get(
+      '/api/analysis/fuzzy-ahp/dashboard?type=wfa&from=2026-08-01&to=2026-08-15'
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.type).toBe('wfa');
+    expect(mockGetFuzzyAhpDashboardRecap).toHaveBeenCalledTimes(1);
+    expect(mockGetFuzzyAhpDashboardRecap.mock.calls[0][0].query).toMatchObject({
+      type: 'wfa',
+      from: '2026-08-01',
+      to: '2026-08-15'
+    });
   });
 
   it('returns 403 for callers outside Admin and Management before validation or handler execution', async () => {
@@ -434,5 +481,44 @@ describe('fuzzy ahp dashboard recap service behavior', () => {
     expect(payload.status).toBe('empty');
     expect(payload.needs_data).toBe(true);
     expect(payload.ranking_preview.items).toEqual([]);
+  });
+
+  it('dispatches WFA dashboard recap to the date-range WFA analysis service', async () => {
+    mockBuildWfaDashboardAnalysis.mockResolvedValue({
+      type: 'wfa',
+      type_label: 'WFA',
+      status: 'ready',
+      requested_window: { from: '2026-08-01', to: '2026-08-15' },
+      criteria_weights: [],
+      consistency: {
+        CR: 0.0576,
+        threshold: 0.1,
+        is_consistent: true,
+        summary_label: 'Konsistensi dapat diterima'
+      },
+      methodology: { version: 'wfa_fahp_v1', weighting_method: 'row_geometric_mean_fallback' },
+      ranking_preview: { top_n: 5, items: [] },
+      evidence: {
+        approved_booking_count: 1,
+        analyzable_booking_count: 1,
+        excluded_missing_snapshot_count: 0,
+        excluded_incompatible_snapshot_count: 0,
+        unique_location_count: 1,
+        ranked_location_count: 1
+      }
+    });
+
+    const payload = await buildFuzzyAhpDashboardRecapPayload({
+      type: 'wfa',
+      from: '2026-08-01',
+      to: '2026-08-15'
+    });
+
+    expect(mockBuildWfaDashboardAnalysis).toHaveBeenCalledWith({
+      from: '2026-08-01',
+      to: '2026-08-15'
+    });
+    expect(payload.type).toBe('wfa');
+    expect(payload.requested_window).toEqual({ from: '2026-08-01', to: '2026-08-15' });
   });
 });

--- a/tests/clientCriticalOpenApiContract.test.js
+++ b/tests/clientCriticalOpenApiContract.test.js
@@ -1417,20 +1417,18 @@ describe('client-critical OpenAPI contract', () => {
       .toEqual(expect.objectContaining({ internet_access: null }));
   });
 
-  test('documents exact 410 migration bodies for retired WFA analysis variants', () => {
-    for (const pathName of ['/api/analysis/fuzzy-ahp', '/api/analysis/fuzzy-ahp/dashboard']) {
-      const operation = openapi.paths[pathName].get;
-      const movedSchema = schemaAt(operation, '410');
+  test('documents exact 410 migration body for the retired generic WFA analysis variant', () => {
+    const operation = openapi.paths['/api/analysis/fuzzy-ahp'].get;
+    const movedSchema = schemaAt(operation, '410');
 
-      expect(movedSchema.properties).toMatchObject({
-        success: { type: 'boolean', example: false },
-        code: { type: 'string', example: 'WFA_ANALYSIS_MOVED' },
-        message: {
-          type: 'string',
-          example: 'Use /api/analysis/fuzzy-ahp/wfa with lat, lon, and schedule_date.'
-        }
-      });
-    }
+    expect(movedSchema.properties).toMatchObject({
+      success: { type: 'boolean', example: false },
+      code: { type: 'string', example: 'WFA_ANALYSIS_MOVED' },
+      message: {
+        type: 'string',
+        example: 'Use /api/analysis/fuzzy-ahp/wfa with lat, lon, and schedule_date.'
+      }
+    });
   });
 
   test('documents Smart AC evidence sufficiency fields', () => {
@@ -1449,32 +1447,56 @@ describe('client-critical OpenAPI contract', () => {
     const responseSchema = schemaAt(operation);
     const dataSchema = responseSchema.properties.data;
     const typeParameter = operation.parameters.find((parameter) => parameter.name === 'type');
+    const fromParameter = operation.parameters.find((parameter) => parameter.name === 'from');
+    const toParameter = operation.parameters.find((parameter) => parameter.name === 'to');
 
     expect(typeParameter.required).toBe(true);
     expect(typeParameter.schema.enum).toEqual(['discipline', 'wfa', 'smart_ac']);
+    expect(fromParameter).toMatchObject({
+      in: 'query',
+      name: 'from',
+      required: false,
+      schema: { type: 'string', format: 'date', pattern: '^\\d{4}-\\d{2}-\\d{2}$' }
+    });
+    expect(toParameter).toMatchObject({
+      in: 'query',
+      name: 'to',
+      required: false,
+      schema: { type: 'string', format: 'date', pattern: '^\\d{4}-\\d{2}-\\d{2}$' }
+    });
     expect(operation.parameters).not.toEqual(
       expect.arrayContaining([
         expect.objectContaining({ name: 'period' }),
-        expect.objectContaining({ name: 'from' }),
-        expect.objectContaining({ name: 'to' })
+        expect.objectContaining({ name: 'lat' }),
+        expect.objectContaining({ name: 'lon' }),
+        expect.objectContaining({ name: 'schedule_date' }),
+        expect.objectContaining({ name: 'radius_meters' })
       ])
     );
     expect(operation.description.toLowerCase()).toContain('dashboard-specific');
-    expect(operation.description.toLowerCase()).toContain('monthly');
-    expect(operation.description.toLowerCase()).toContain('not expose the full dedicated detail payloads');
+    expect(operation.description).toContain('type=wfa');
+    expect(operation.description).toContain('from/to');
+    expect(operation.responses).not.toHaveProperty('410');
     expect(dataSchema.properties).toMatchObject({
-      type: { type: 'string' },
+      type: { type: 'string', enum: ['discipline', 'wfa', 'smart_ac'] },
       type_label: { type: 'string', example: 'Discipline' },
       generated_at: { type: 'string', format: 'date-time' },
       timezone: { type: 'string', example: 'Asia/Jakarta' },
       requested_window: { type: 'object' },
       executed_window: { type: 'object' },
-      status: { type: 'string', example: 'ready' },
+      status: { type: 'string', enum: ['ready', 'empty', 'needs_data'], example: 'ready' },
       needs_data: { type: 'boolean', example: false },
       consistency: { type: 'object' },
       criteria_weights: { type: 'array' },
       ranking_preview: { type: 'object' },
+      methodology: { type: 'object' },
+      evidence: { type: 'object' },
       distribution: { type: 'object' }
+    });
+    expect(dataSchema.properties.requested_window.properties).toMatchObject({
+      period: { type: 'string', example: 'monthly' },
+      from: { type: 'string', format: 'date', nullable: true },
+      to: { type: 'string', format: 'date', nullable: true }
     });
     expect(dataSchema.properties.consistency.properties).toMatchObject({
       CR: { type: 'number', format: 'float' },
@@ -1490,6 +1512,35 @@ describe('client-critical OpenAPI contract', () => {
       label: { type: 'string' },
       display_label: { type: 'string', example: 'Disiplin Kehadiran' },
       value: { type: 'number', format: 'float' }
+    });
+    expect(dataSchema.properties.methodology.properties).toMatchObject({
+      version: { type: 'string', example: 'wfa_fahp_v1' },
+      weighting_method: { type: 'string', example: 'row_geometric_mean_fallback' }
+    });
+    expect(dataSchema.properties.ranking_preview.properties.items.items.properties).toMatchObject({
+      rank: { type: 'integer' },
+      location_label: { type: 'string' },
+      latitude: { type: 'number', format: 'float', nullable: true },
+      longitude: { type: 'number', format: 'float', nullable: true },
+      score: { type: 'number', format: 'float', nullable: true },
+      label: { type: 'string', nullable: true },
+      criteria_summary: { type: 'object' },
+      approved_booking_count: { type: 'integer', minimum: 0 },
+      analyzable_booking_count: { type: 'integer', minimum: 0 }
+    });
+    expect(dataSchema.properties.ranking_preview.properties.items.items.properties.criteria_summary.properties)
+      .toMatchObject({
+        location_type_score: { type: 'number', format: 'float' },
+        distance_factor_score: { type: 'number', format: 'float' },
+        facility_score: { type: 'number', format: 'float' }
+      });
+    expect(dataSchema.properties.evidence.properties).toMatchObject({
+      approved_booking_count: { type: 'integer', minimum: 0 },
+      analyzable_booking_count: { type: 'integer', minimum: 0 },
+      excluded_missing_snapshot_count: { type: 'integer', minimum: 0 },
+      excluded_incompatible_snapshot_count: { type: 'integer', minimum: 0 },
+      unique_location_count: { type: 'integer', minimum: 0 },
+      ranked_location_count: { type: 'integer', minimum: 0 }
     });
     expect(dataSchema.properties).not.toHaveProperty('ranking');
     expect(dataSchema.properties).not.toHaveProperty('weights');

--- a/tests/clientCriticalOpenApiContract.test.js
+++ b/tests/clientCriticalOpenApiContract.test.js
@@ -1519,6 +1519,7 @@ describe('client-critical OpenAPI contract', () => {
     });
     expect(dataSchema.properties.ranking_preview.properties.items.items.properties).toMatchObject({
       rank: { type: 'integer' },
+      location_key: { type: 'string' },
       location_label: { type: 'string' },
       latitude: { type: 'number', format: 'float', nullable: true },
       longitude: { type: 'number', format: 'float', nullable: true },

--- a/tests/openApiRuntimeDriftContract.test.js
+++ b/tests/openApiRuntimeDriftContract.test.js
@@ -171,13 +171,36 @@ describe('WFA facility scoring contract versus runtime', () => {
     expect(operationBlock('/api/analysis/fuzzy-ahp/wfa', 'get')).toContain('name: schedule_date');
   });
 
-  it('documents the migration response instead of the retired combined WFA payload', () => {
+  it('documents the migration response only for the retired generic WFA payload', () => {
     const combined = operationBlock('/api/analysis/fuzzy-ahp', 'get');
     const dashboard = operationBlock('/api/analysis/fuzzy-ahp/dashboard', 'get');
 
     expect(combined).toContain("'410':");
-    expect(dashboard).toContain("'410':");
     expect(combined).toContain('WFA_ANALYSIS_MOVED');
-    expect(dashboard).toContain('WFA_ANALYSIS_MOVED');
+    expect(dashboard).not.toContain("'410':");
+    expect(dashboard).not.toContain('WFA_ANALYSIS_MOVED');
+  });
+
+  it('documents dashboard WFA as explicit date range on the reused dashboard route', () => {
+    const dashboard = operationBlock('/api/analysis/fuzzy-ahp/dashboard', 'get');
+
+    expect(dashboard).toContain('name: type');
+    expect(dashboard).toContain('enum: [discipline, wfa, smart_ac]');
+    expect(dashboard).toContain('name: from');
+    expect(dashboard).toContain('name: to');
+    expect(dashboard).toContain('type=wfa');
+    expect(dashboard).toContain('maximum inclusive window is 31 days');
+    expect(dashboard).toContain('requested_window:');
+    expect(dashboard).toContain('criteria_weights:');
+    expect(dashboard).toContain('consistency:');
+    expect(dashboard).toContain('methodology:');
+    expect(dashboard).toContain('ranking_preview:');
+    expect(dashboard).toContain('criteria_summary:');
+    expect(dashboard).toContain('evidence:');
+    expect(dashboard).not.toContain('name: period');
+    expect(dashboard).not.toContain('name: lat');
+    expect(dashboard).not.toContain('name: lon');
+    expect(dashboard).not.toContain('name: schedule_date');
+    expect(dashboard).not.toContain('name: radius_meters');
   });
 });

--- a/tests/openApiRuntimeDriftContract.test.js
+++ b/tests/openApiRuntimeDriftContract.test.js
@@ -195,6 +195,7 @@ describe('WFA facility scoring contract versus runtime', () => {
     expect(dashboard).toContain('consistency:');
     expect(dashboard).toContain('methodology:');
     expect(dashboard).toContain('ranking_preview:');
+    expect(dashboard).toContain('location_key:');
     expect(dashboard).toContain('criteria_summary:');
     expect(dashboard).toContain('evidence:');
     expect(dashboard).not.toContain('name: period');

--- a/tests/wfaControllerContract.test.js
+++ b/tests/wfaControllerContract.test.js
@@ -11,7 +11,9 @@ const canonicalWeights = {
   location_type: 0.5,
   facility_score: 0.3,
   distance_factor: 0.2,
-  consistency_ratio: 0.05
+  consistency_ratio: 0.05,
+  weighting_method: 'chang_extent',
+  version: 'wfa_fahp_v1'
 };
 const methodology = {
   approach: 'Fuzzy AHP facility-evidence scoring',
@@ -44,6 +46,132 @@ const loadWfa = async ({ recommendForUser = jest.fn(), weights = canonicalWeight
   }));
 
   return import('../src/controllers/wfa.controller.js');
+};
+
+const loadBookingController = async ({
+  scoreResult = {
+    status: 'ranked',
+    suitabilityScore: 82.4,
+    suitabilityLabel: 'Sangat Baik',
+    scoringSnapshot: {
+      schema_version: 1,
+      methodology_version: 'wfa_fahp_v1',
+      captured_at: '2026-08-15T01:02:03.000Z',
+      criteria: {
+        location_type_score: 40,
+        distance_factor_score: 95,
+        facility_score: 75
+      },
+      methodology: {
+        weights: {
+          location_type: 0.5,
+          distance_factor: 0.3,
+          facility_score: 0.2
+        },
+        consistency_ratio: 0.05,
+        weighting_method: 'chang_extent'
+      },
+      evidence: {
+        place_id: 'nearest',
+        location_type: 'cafe',
+        distance_meters: 5,
+        facility_confidence: 80
+      },
+      result: { score: 82.4, label: 'Sangat Baik' }
+    },
+    candidate: {
+      place_id: 'nearest',
+      status: 'ranked'
+    }
+  }
+} = {}) => {
+  jest.resetModules();
+
+  const transaction = {
+    LOCK: { UPDATE: 'UPDATE' },
+    commit: jest.fn().mockResolvedValue(undefined),
+    rollback: jest.fn().mockResolvedValue(undefined)
+  };
+  const mockBookingFindOne = jest.fn().mockResolvedValue(null);
+  const mockBookingCreate = jest.fn(async (payload) => ({
+    booking_id: 30,
+    ...payload
+  }));
+  const mockLocationFindOne = jest.fn().mockResolvedValue(null);
+  const mockLocationCreate = jest.fn().mockResolvedValue({
+    location_id: 20,
+    latitude: -0.9,
+    longitude: 119.87,
+    radius: 150,
+    description: 'Lokasi klien'
+  });
+  const mockUserFindByPk = jest.fn().mockResolvedValue({ id_users: 9 });
+  const mockReadWfaRequestConfig = jest.fn().mockResolvedValue({ radiusMeters: 150, reasons: [] });
+  const mockResolveActiveWfaRequestReason = jest.fn().mockResolvedValue({
+    reason: { id: 1, label: 'Pertemuan dengan klien', is_other: false },
+    normalizedOtherReason: null
+  });
+  const mockAssertWfaEligibility = jest.fn().mockResolvedValue('2026-08-20');
+  const mockScoreBookingLocation = jest.fn().mockResolvedValue(scoreResult);
+  const mockTransaction = jest.fn().mockResolvedValue(transaction);
+
+  jest.unstable_mockModule('../src/config/database.js', () => ({
+    default: {
+      transaction: mockTransaction,
+      fn: jest.fn(),
+      col: jest.fn()
+    }
+  }));
+  jest.unstable_mockModule('../src/models/index.js', () => ({
+    Booking: { findOne: mockBookingFindOne, create: mockBookingCreate },
+    Location: {
+      findOne: mockLocationFindOne,
+      create: mockLocationCreate
+    },
+    BookingStatus: {},
+    User: { findByPk: mockUserFindByPk },
+    Position: {},
+    Role: {},
+    WfaRequestReason: {},
+    WfaRejectionReason: {}
+  }));
+  jest.unstable_mockModule('../src/services/wfaSettings.service.js', () => ({
+    readWfaRequestConfig: mockReadWfaRequestConfig,
+    resolveActiveWfaRequestReason: mockResolveActiveWfaRequestReason,
+    resolveActiveWfaRejectionReason: jest.fn()
+  }));
+  jest.unstable_mockModule('../src/services/wfaEligibility.service.js', () => ({
+    assertWfaEligibility: mockAssertWfaEligibility
+  }));
+  jest.unstable_mockModule('../src/services/wfaRecommendation.service.js', () => ({
+    scoreBookingLocation: mockScoreBookingLocation
+  }));
+  jest.unstable_mockModule('../src/modules/booking/bookingManagementRead.service.js', () => ({
+    listManagementBookings: jest.fn()
+  }));
+  jest.unstable_mockModule('../src/utils/logger.js', () => ({
+    default: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn()
+    }
+  }));
+
+  const { createBooking } = await import('../src/controllers/booking.controller.js');
+
+  return {
+    createBooking,
+    transaction,
+    scoreResult,
+    mocks: {
+      mockBookingCreate,
+      mockReadWfaRequestConfig,
+      mockResolveActiveWfaRequestReason,
+      mockAssertWfaEligibility,
+      mockScoreBookingLocation
+    }
+  };
 };
 
 describe('getWfaRecommendations', () => {
@@ -175,5 +303,105 @@ describe('testFuzzyAhp', () => {
 
     expect(res.status).toHaveBeenCalledWith(400);
     expect(res.json.mock.calls[0][0]).toMatchObject({ success: false, code: 'E_VALIDATION' });
+  });
+});
+
+describe('createBooking snapshot persistence', () => {
+  it('persists the server-authored scoring snapshot and never accepts a client-authored one', async () => {
+    const { createBooking, transaction, scoreResult, mocks } = await loadBookingController();
+    const res = buildRes();
+    const next = jest.fn();
+    const clientSnapshot = { schema_version: 999, forged: true };
+
+    await createBooking(
+      {
+        user: { id: 9 },
+        body: {
+          schedule_date: '2026-08-20',
+          request_reason_id: 1,
+          request_other_reason: null,
+          latitude: -0.9,
+          longitude: 119.87,
+          description: 'Lokasi klien',
+          notes: '  Pertemuan project  ',
+          wfa_scoring_snapshot: clientSnapshot
+        }
+      },
+      res,
+      next
+    );
+
+    expect(mocks.mockAssertWfaEligibility).toHaveBeenCalledWith({
+      userId: 9,
+      scheduleDate: '2026-08-20',
+      checkDuplicate: true
+    });
+    expect(mocks.mockScoreBookingLocation).toHaveBeenCalledWith({
+      userId: 9,
+      latitude: -0.9,
+      longitude: 119.87,
+      scheduleDate: '2026-08-20'
+    });
+    expect(mocks.mockBookingCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: 9,
+        notes: 'Pertemuan project',
+        suitability_score: 82.4,
+        suitability_label: 'Sangat Baik',
+        wfa_scoring_snapshot: scoreResult.scoringSnapshot
+      }),
+      { transaction }
+    );
+    expect(mocks.mockBookingCreate.mock.calls[0][0].wfa_scoring_snapshot).not.toBe(clientSnapshot);
+    expect(res.json.mock.calls[0][0].data).not.toHaveProperty('wfa_scoring_snapshot');
+    expect(transaction.commit).toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('persists a null scoring snapshot when booking evidence is insufficient', async () => {
+    const { createBooking, transaction, mocks } = await loadBookingController({
+      scoreResult: {
+        status: 'insufficient_facility_data',
+        suitabilityScore: null,
+        suitabilityLabel: null,
+        scoringSnapshot: null,
+        candidate: null
+      }
+    });
+    const res = buildRes();
+
+    await createBooking(
+      {
+        user: { id: 9 },
+        body: {
+          schedule_date: '2026-08-20',
+          request_reason_id: 1,
+          request_other_reason: null,
+          latitude: -0.9,
+          longitude: 119.87,
+          description: 'Lokasi klien',
+          notes: '  Pertemuan project  '
+        }
+      },
+      res,
+      jest.fn()
+    );
+
+    expect(mocks.mockBookingCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        suitability_score: null,
+        suitability_label: null,
+        wfa_scoring_snapshot: null
+      }),
+      { transaction }
+    );
+    expect(res.json.mock.calls[0][0].data).toEqual(
+      expect.objectContaining({
+        suitability_score: null,
+        suitability_label: null,
+        suitability_status: 'insufficient_facility_data'
+      })
+    );
+    expect(transaction.commit).toHaveBeenCalled();
   });
 });

--- a/tests/wfaDashboardAnalysisService.test.js
+++ b/tests/wfaDashboardAnalysisService.test.js
@@ -224,6 +224,7 @@ describe('WFA dashboard ranking aggregation', () => {
     );
     expect(ranking).toEqual([
       expect.objectContaining({
+        location_key: 'wfa-cluster:location:10:booking:a',
         location_label: 'Cafe Merdeka',
         score: 86.43,
         label: 'Sangat Tinggi',
@@ -236,6 +237,40 @@ describe('WFA dashboard ranking aggregation', () => {
         }
       })
     ]);
+  });
+
+  test('uses the immutable cluster anchor to build a stable backend-authored location key', async () => {
+    const weights = {
+      location_type: 0.5,
+      distance_factor: 0.3,
+      facility_score: 0.2,
+      consistency_ratio: 0,
+      weighting_method: 'row_geometric_mean_fallback',
+      version: METHODOLOGY_VERSION
+    };
+    const scoreCalculator = jest.fn().mockResolvedValue({ score: 86.43, label: 'Sangat Tinggi' });
+    const rows = [
+      row({ bookingId: 'later-row', locationId: 99, description: 'Cafe Stable', latitude: 20 }),
+      row({ bookingId: 'anchor-row', locationId: 42, description: 'Cafe Stable', latitude: 0 })
+    ];
+    const reversedRows = [...rows].reverse();
+
+    const forwardRanking = await buildWfaDashboardRanking(
+      clusterWfaDashboardRows(rows, { distanceCalculator: distanceByLatitude }),
+      { weights, scoreCalculator }
+    );
+    const reversedRanking = await buildWfaDashboardRanking(
+      clusterWfaDashboardRows(reversedRows, { distanceCalculator: distanceByLatitude }),
+      { weights, scoreCalculator }
+    );
+
+    expect(forwardRanking[0]).toEqual(
+      expect.objectContaining({
+        location_key: 'wfa-cluster:location:42:booking:anchor-row',
+        location_label: 'Cafe Stable'
+      })
+    );
+    expect(reversedRanking[0].location_key).toBe(forwardRanking[0].location_key);
   });
 
   test('sorts deterministically and returns only the top five ranked locations', async () => {
@@ -423,6 +458,7 @@ describe('WFA dashboard analysis service facade', () => {
     expect(result.ranking_preview.items).toHaveLength(2);
     expect(result.ranking_preview.items[0]).toEqual(
       expect.objectContaining({
+        location_key: expect.stringMatching(/^wfa-cluster:location:/),
         location_label: expect.any(String),
         approved_booking_count: expect.any(Number),
         analyzable_booking_count: expect.any(Number)

--- a/tests/wfaDashboardAnalysisService.test.js
+++ b/tests/wfaDashboardAnalysisService.test.js
@@ -1,7 +1,9 @@
 import { jest } from '@jest/globals';
+import { Op } from 'sequelize';
 
 import {
   buildWfaDashboardRanking,
+  createWfaDashboardAnalysisService,
   clusterWfaDashboardRows,
   normalizeWfaDashboardDescription,
   validateWfaScoringSnapshot
@@ -282,5 +284,189 @@ describe('WFA dashboard ranking aggregation', () => {
       'Echo'
     ]);
     expect(ranking).toHaveLength(5);
+  });
+});
+
+describe('WFA dashboard analysis service facade', () => {
+  const weights = {
+    location_type: 0.41,
+    distance_factor: 0.34,
+    facility_score: 0.25,
+    consistency_ratio: 0.07,
+    weighting_method: 'mocked-engine-method',
+    version: METHODOLOGY_VERSION
+  };
+
+  const createService = ({
+    rows = [],
+    scoreResult = { score: 91.25, label: 'Sangat Tinggi' }
+  } = {}) => {
+    const bookingModel = {
+      findAll: jest.fn().mockResolvedValue(rows)
+    };
+    const engine = {
+      getWfaAhpWeights: jest.fn(() => weights),
+      calculateWfaScore: jest.fn().mockResolvedValue(scoreResult)
+    };
+    const service = createWfaDashboardAnalysisService({
+      Booking: bookingModel,
+      fuzzyEngine: engine,
+      distanceCalculator: distanceByLatitude
+    });
+
+    return { bookingModel, engine, service };
+  };
+
+  test('queries only Approved WFA bookings in the inclusive schedule-date range with required location', async () => {
+    const { bookingModel, service } = createService();
+
+    await service.buildAnalysis({ from: '2026-08-01', to: '2026-08-15' });
+
+    expect(bookingModel.findAll).toHaveBeenCalledWith({
+      where: {
+        status: 1,
+        schedule_date: { [Op.between]: ['2026-08-01', '2026-08-15'] }
+      },
+      include: [
+        {
+          association: 'location',
+          required: true
+        }
+      ]
+    });
+  });
+
+  test('returns empty state with zeroed evidence and no fabricated ranking when no Approved bookings exist', async () => {
+    const { service } = createService({ rows: [] });
+
+    const result = await service.buildAnalysis({ from: '2026-08-01', to: '2026-08-15' });
+
+    expect(result.status).toBe('empty');
+    expect(result.ranking_preview).toEqual({ top_n: 5, items: [] });
+    expect(result.evidence).toEqual({
+      approved_booking_count: 0,
+      analyzable_booking_count: 0,
+      excluded_missing_snapshot_count: 0,
+      excluded_incompatible_snapshot_count: 0,
+      unique_location_count: 0,
+      ranked_location_count: 0
+    });
+  });
+
+  test('returns needs_data when Approved bookings have no compatible snapshots', async () => {
+    const rows = [
+      row({ bookingId: 'legacy', description: 'Legacy Cafe', scoringSnapshot: null }),
+      row({
+        bookingId: 'old-method',
+        description: 'Old Method Cafe',
+        latitude: 100,
+        scoringSnapshot: snapshot({ version: 'wfa_fahp_v0' })
+      })
+    ];
+    const { engine, service } = createService({ rows });
+
+    const result = await service.buildAnalysis({ from: '2026-08-01', to: '2026-08-15' });
+
+    expect(engine.calculateWfaScore).not.toHaveBeenCalled();
+    expect(result.status).toBe('needs_data');
+    expect(result.ranking_preview.items).toEqual([]);
+    expect(result.evidence).toEqual({
+      approved_booking_count: 2,
+      analyzable_booking_count: 0,
+      excluded_missing_snapshot_count: 1,
+      excluded_incompatible_snapshot_count: 1,
+      unique_location_count: 2,
+      ranked_location_count: 0
+    });
+  });
+
+  test('returns ready state, exact evidence counters, and keeps partial valid evidence analyzable', async () => {
+    const rows = [
+      row({
+        bookingId: 'valid-a',
+        description: 'Cafe Merdeka',
+        latitude: 0,
+        scoringSnapshot: snapshot({ locationType: 80, distance: 60, facility: 90 })
+      }),
+      row({
+        bookingId: 'missing-same-cluster',
+        description: 'Cafe Merdeka',
+        latitude: 1,
+        scoringSnapshot: null
+      }),
+      row({
+        bookingId: 'valid-b',
+        description: 'Library',
+        latitude: 100,
+        scoringSnapshot: snapshot({ locationType: 70, distance: 65, facility: 75 })
+      }),
+      row({
+        bookingId: 'old-method',
+        description: 'Old Method Cafe',
+        latitude: 200,
+        scoringSnapshot: snapshot({ version: 'wfa_fahp_v0' })
+      })
+    ];
+    const { service } = createService({ rows });
+
+    const result = await service.buildAnalysis({ from: '2026-08-01', to: '2026-08-15' });
+
+    expect(result.status).toBe('ready');
+    expect(result.evidence).toEqual({
+      approved_booking_count: 4,
+      analyzable_booking_count: 2,
+      excluded_missing_snapshot_count: 1,
+      excluded_incompatible_snapshot_count: 1,
+      unique_location_count: 3,
+      ranked_location_count: 2
+    });
+    expect(result.ranking_preview.items).toHaveLength(2);
+    expect(result.ranking_preview.items[0]).toEqual(
+      expect.objectContaining({
+        location_label: expect.any(String),
+        approved_booking_count: expect.any(Number),
+        analyzable_booking_count: expect.any(Number)
+      })
+    );
+  });
+
+  test('returns criteria weights, consistency, and methodology exclusively from the engine weights', async () => {
+    const rows = [
+      row({
+        bookingId: 'snapshot-with-different-method-metadata',
+        scoringSnapshot: {
+          ...snapshot(),
+          methodology: {
+            weights: {
+              location_type: 0.99,
+              distance_factor: 0,
+              facility_score: 0.01
+            },
+            consistency_ratio: 0.99,
+            weighting_method: 'snapshot-method'
+          }
+        }
+      })
+    ];
+    const { engine, service } = createService({ rows });
+
+    const result = await service.buildAnalysis({ from: '2026-08-01', to: '2026-08-15' });
+
+    expect(engine.getWfaAhpWeights).toHaveBeenCalledTimes(1);
+    expect(result.criteria_weights).toEqual([
+      { key: 'location_type', display_label: 'Tipe Lokasi', value: 0.41 },
+      { key: 'distance_factor', display_label: 'Faktor Jarak', value: 0.34 },
+      { key: 'facility_score', display_label: 'Skor Fasilitas', value: 0.25 }
+    ]);
+    expect(result.consistency).toEqual({
+      CR: 0.07,
+      threshold: 0.1,
+      is_consistent: true,
+      summary_label: 'Konsistensi dapat diterima'
+    });
+    expect(result.methodology).toEqual({
+      version: METHODOLOGY_VERSION,
+      weighting_method: 'mocked-engine-method'
+    });
   });
 });

--- a/tests/wfaDashboardAnalysisService.test.js
+++ b/tests/wfaDashboardAnalysisService.test.js
@@ -68,10 +68,11 @@ describe('WFA dashboard snapshot validation', () => {
   test.each([
     ['missing snapshot', null, 'MISSING_SNAPSHOT'],
     ['incompatible methodology', snapshot({ version: 'wfa_fahp_v0' }), 'INCOMPATIBLE_METHODOLOGY'],
+    ['unsupported snapshot schema', { ...snapshot(), schema_version: 2 }, 'UNSUPPORTED_SNAPSHOT_SCHEMA'],
     ['non-finite criterion', snapshot({ locationType: Number.NaN }), 'INVALID_CRITERIA'],
     ['criterion above range', snapshot({ distance: 101 }), 'INVALID_CRITERIA'],
     ['criterion below range', snapshot({ facility: -1 }), 'INVALID_CRITERIA'],
-    ['malformed criteria object', { methodology_version: METHODOLOGY_VERSION, criteria: null }, 'INVALID_CRITERIA']
+    ['malformed criteria object', { schema_version: 1, methodology_version: METHODOLOGY_VERSION, criteria: null }, 'INVALID_CRITERIA']
   ])('rejects %s with explicit reason code', (_caseName, value, reason) => {
     expect(validateWfaScoringSnapshot(value, METHODOLOGY_VERSION)).toEqual({
       valid: false,
@@ -273,7 +274,7 @@ describe('WFA dashboard ranking aggregation', () => {
     expect(reversedRanking[0].location_key).toBe(forwardRanking[0].location_key);
   });
 
-  test('sorts deterministically and returns only the top five ranked locations', async () => {
+  test('sorts deterministically, assigns one-based ranks, and keeps the full ranked set before preview projection', async () => {
     const weights = {
       location_type: 0.5,
       distance_factor: 0.3,
@@ -316,9 +317,11 @@ describe('WFA dashboard ranking aggregation', () => {
       'Charlie',
       'Alpha',
       'Bravo',
-      'Echo'
+      'Echo',
+      'Foxtrot'
     ]);
-    expect(ranking).toHaveLength(5);
+    expect(ranking.map((item) => item.rank)).toEqual([1, 2, 3, 4, 5, 6]);
+    expect(ranking).toHaveLength(6);
   });
 });
 
@@ -464,6 +467,27 @@ describe('WFA dashboard analysis service facade', () => {
         analyzable_booking_count: expect.any(Number)
       })
     );
+  });
+
+  test('counts every ranked location while exposing only the top five in ranking_preview', async () => {
+    const rows = Array.from({ length: 6 }, (_, index) =>
+      row({
+        bookingId: `ranked-${index + 1}`,
+        locationId: index + 1,
+        description: `Location ${String.fromCharCode(65 + index)}`,
+        latitude: index * 100,
+        scoringSnapshot: snapshot({ locationType: 80 - index })
+      })
+    );
+    const { service } = createService({ rows });
+
+    const result = await service.buildAnalysis({ from: '2026-08-01', to: '2026-08-15' });
+
+    expect(result.status).toBe('ready');
+    expect(result.evidence.unique_location_count).toBe(6);
+    expect(result.evidence.ranked_location_count).toBe(6);
+    expect(result.ranking_preview.items).toHaveLength(5);
+    expect(result.ranking_preview.items.map((item) => item.rank)).toEqual([1, 2, 3, 4, 5]);
   });
 
   test('returns criteria weights, consistency, and methodology exclusively from the engine weights', async () => {

--- a/tests/wfaDashboardAnalysisService.test.js
+++ b/tests/wfaDashboardAnalysisService.test.js
@@ -1,0 +1,286 @@
+import { jest } from '@jest/globals';
+
+import {
+  buildWfaDashboardRanking,
+  clusterWfaDashboardRows,
+  normalizeWfaDashboardDescription,
+  validateWfaScoringSnapshot
+} from '../src/services/wfaDashboardAnalysis.service.js';
+
+const METHODOLOGY_VERSION = 'wfa_fahp_v1';
+
+const snapshot = ({
+  version = METHODOLOGY_VERSION,
+  locationType = 80,
+  distance = 70,
+  facility = 90
+} = {}) => ({
+  schema_version: 1,
+  methodology_version: version,
+  criteria: {
+    location_type_score: locationType,
+    distance_factor_score: distance,
+    facility_score: facility
+  }
+});
+
+const row = ({
+  bookingId,
+  locationId = bookingId,
+  description = 'Cafe Merdeka',
+  latitude = 0,
+  longitude = 0,
+  scoringSnapshot = snapshot()
+}) => ({
+  booking_id: bookingId,
+  location_id: locationId,
+  description,
+  latitude,
+  longitude,
+  wfa_scoring_snapshot: scoringSnapshot
+});
+
+const distanceByLatitude = (latA, _lonA, latB) => Math.abs(latA - latB);
+
+const clusterBookingIds = (clusters) =>
+  clusters.map((cluster) => cluster.rows.map((item) => item.bookingId));
+
+describe('WFA dashboard snapshot validation', () => {
+  test('normalizes descriptions with trimming, lower-casing, whitespace collapse, and blank-to-null behavior', () => {
+    expect(normalizeWfaDashboardDescription('  Cafe   Merdeka \n Palu  ')).toBe('cafe merdeka palu');
+    expect(normalizeWfaDashboardDescription('   ')).toBeNull();
+    expect(normalizeWfaDashboardDescription(null)).toBeNull();
+  });
+
+  test('accepts matching finite criteria in the 0..100 range', () => {
+    expect(validateWfaScoringSnapshot(snapshot(), METHODOLOGY_VERSION)).toEqual({
+      valid: true,
+      criteria: {
+        location_type_score: 80,
+        distance_factor_score: 70,
+        facility_score: 90
+      }
+    });
+  });
+
+  test.each([
+    ['missing snapshot', null, 'MISSING_SNAPSHOT'],
+    ['incompatible methodology', snapshot({ version: 'wfa_fahp_v0' }), 'INCOMPATIBLE_METHODOLOGY'],
+    ['non-finite criterion', snapshot({ locationType: Number.NaN }), 'INVALID_CRITERIA'],
+    ['criterion above range', snapshot({ distance: 101 }), 'INVALID_CRITERIA'],
+    ['criterion below range', snapshot({ facility: -1 }), 'INVALID_CRITERIA'],
+    ['malformed criteria object', { methodology_version: METHODOLOGY_VERSION, criteria: null }, 'INVALID_CRITERIA']
+  ])('rejects %s with explicit reason code', (_caseName, value, reason) => {
+    expect(validateWfaScoringSnapshot(value, METHODOLOGY_VERSION)).toEqual({
+      valid: false,
+      reason
+    });
+  });
+});
+
+describe('WFA dashboard physical clustering', () => {
+  test('groups the same normalized nonblank description only inside the immutable anchor 25m boundary', () => {
+    const clusters = clusterWfaDashboardRows(
+      [
+        row({ bookingId: 'near-anchor', description: '  Cafe   Merdeka ', latitude: 25 }),
+        row({ bookingId: 'anchor', description: 'cafe merdeka', latitude: 0 }),
+        row({ bookingId: 'beyond-anchor', description: 'CAFE MERDEKA', latitude: 25.01 })
+      ],
+      { distanceCalculator: distanceByLatitude }
+    );
+
+    expect(clusterBookingIds(clusters)).toEqual([
+      ['anchor', 'near-anchor'],
+      ['beyond-anchor']
+    ]);
+  });
+
+  test('keeps different nonblank descriptions separate even when they are nearby', () => {
+    const clusters = clusterWfaDashboardRows(
+      [
+        row({ bookingId: 'library', description: 'Library', latitude: 0 }),
+        row({ bookingId: 'cafe', description: 'Cafe', latitude: 1 })
+      ],
+      { distanceCalculator: distanceByLatitude }
+    );
+
+    expect(clusterBookingIds(clusters)).toEqual([['cafe'], ['library']]);
+  });
+
+  test('uses proximity fallback for blank descriptions', () => {
+    const clusters = clusterWfaDashboardRows(
+      [
+        row({ bookingId: 'blank-near', description: ' ', latitude: 20 }),
+        row({ bookingId: 'blank-anchor', description: null, latitude: 0 }),
+        row({ bookingId: 'blank-far', description: '', latitude: 30 })
+      ],
+      { distanceCalculator: distanceByLatitude }
+    );
+
+    expect(clusterBookingIds(clusters)).toEqual([
+      ['blank-anchor', 'blank-near'],
+      ['blank-far']
+    ]);
+  });
+
+  test('groups blank descriptions with a labeled anchor by proximity while keeping far blanks separate', () => {
+    const clusters = clusterWfaDashboardRows(
+      [
+        row({ bookingId: 'blank-near-label', description: '', latitude: 20 }),
+        row({ bookingId: 'labeled-anchor', description: 'Cafe Anchor', latitude: 0 }),
+        row({ bookingId: 'blank-far-label', description: ' ', latitude: 30 })
+      ],
+      { distanceCalculator: distanceByLatitude }
+    );
+
+    expect(clusterBookingIds(clusters)).toEqual([
+      ['labeled-anchor', 'blank-near-label'],
+      ['blank-far-label']
+    ]);
+  });
+
+  test('returns the same deterministic cluster membership when input order is reversed', () => {
+    const rows = [
+      row({ bookingId: 'cafe-b', description: 'Cafe Palu', latitude: 10 }),
+      row({ bookingId: 'blank-a', description: '', latitude: 0 }),
+      row({ bookingId: 'cafe-a', description: ' cafe   palu ', latitude: 0 }),
+      row({ bookingId: 'library-a', description: 'Library', latitude: 0 })
+    ];
+
+    const forward = clusterBookingIds(
+      clusterWfaDashboardRows(rows, { distanceCalculator: distanceByLatitude })
+    );
+    const reversed = clusterBookingIds(
+      clusterWfaDashboardRows([...rows].reverse(), { distanceCalculator: distanceByLatitude })
+    );
+
+    expect(reversed).toEqual(forward);
+    expect(forward).toEqual([['cafe-a', 'cafe-b', 'blank-a'], ['library-a']]);
+  });
+
+  test('does not transitively merge rows when the new row is more than 25m from the cluster anchor', () => {
+    const clusters = clusterWfaDashboardRows(
+      [
+        row({ bookingId: 'a', description: 'Cafe Transit', latitude: 0 }),
+        row({ bookingId: 'b', description: 'Cafe Transit', latitude: 20 }),
+        row({ bookingId: 'c', description: 'Cafe Transit', latitude: 40 })
+      ],
+      { distanceCalculator: distanceByLatitude }
+    );
+
+    expect(clusterBookingIds(clusters)).toEqual([
+      ['a', 'b'],
+      ['c']
+    ]);
+  });
+});
+
+describe('WFA dashboard ranking aggregation', () => {
+  test('averages valid criteria and calls the score calculator with canonical WFA arguments', async () => {
+    const weights = {
+      location_type: 0.5,
+      distance_factor: 0.3,
+      facility_score: 0.2,
+      consistency_ratio: 0,
+      weighting_method: 'row_geometric_mean_fallback',
+      version: METHODOLOGY_VERSION
+    };
+    const scoreCalculator = jest.fn().mockResolvedValue({ score: 86.43, label: 'Sangat Tinggi' });
+    const clusters = clusterWfaDashboardRows(
+      [
+        row({
+          bookingId: 'a',
+          locationId: 10,
+          description: 'Cafe Merdeka',
+          scoringSnapshot: snapshot({ locationType: 80, distance: 60, facility: 90 })
+        }),
+        row({
+          bookingId: 'b',
+          locationId: 10,
+          description: 'Cafe Merdeka',
+          scoringSnapshot: snapshot({ locationType: 100, distance: 80, facility: 70 })
+        }),
+        row({
+          bookingId: 'legacy',
+          locationId: 10,
+          description: 'Cafe Merdeka',
+          scoringSnapshot: null
+        })
+      ],
+      { distanceCalculator: distanceByLatitude }
+    );
+
+    const ranking = await buildWfaDashboardRanking(clusters, { weights, scoreCalculator });
+
+    expect(scoreCalculator).toHaveBeenCalledWith(
+      {
+        locationTypeScore: 90,
+        distanceScore: 70,
+        facilityScore: 80
+      },
+      weights
+    );
+    expect(ranking).toEqual([
+      expect.objectContaining({
+        location_label: 'Cafe Merdeka',
+        score: 86.43,
+        label: 'Sangat Tinggi',
+        approved_booking_count: 3,
+        analyzable_booking_count: 2,
+        criteria_summary: {
+          location_type_score: 90,
+          distance_factor_score: 70,
+          facility_score: 80
+        }
+      })
+    ]);
+  });
+
+  test('sorts deterministically and returns only the top five ranked locations', async () => {
+    const weights = {
+      location_type: 0.5,
+      distance_factor: 0.3,
+      facility_score: 0.2,
+      consistency_ratio: 0,
+      weighting_method: 'row_geometric_mean_fallback',
+      version: METHODOLOGY_VERSION
+    };
+    const scoresByLocationTypeScore = new Map([
+      [10, { score: 90, label: 'Sangat Tinggi' }],
+      [20, { score: 90, label: 'Sangat Tinggi' }],
+      [30, { score: 90, label: 'Sangat Tinggi' }],
+      [40, { score: 90, label: 'Sangat Tinggi' }],
+      [50, { score: 88, label: 'Tinggi' }],
+      [60, { score: 87, label: 'Tinggi' }]
+    ]);
+    const scoreCalculator = jest.fn(({ locationTypeScore }) =>
+      Promise.resolve(scoresByLocationTypeScore.get(locationTypeScore))
+    );
+    const rows = [
+      row({ bookingId: 'bravo-1', description: 'Bravo', latitude: 0, scoringSnapshot: snapshot({ locationType: 40 }) }),
+      row({ bookingId: 'alpha-1', description: 'Alpha', latitude: 100, scoringSnapshot: snapshot({ locationType: 30 }) }),
+      row({ bookingId: 'charlie-1', description: 'Charlie', latitude: 200, scoringSnapshot: snapshot({ locationType: 20 }) }),
+      row({ bookingId: 'charlie-2', description: 'Charlie', latitude: 201, scoringSnapshot: snapshot({ locationType: 20 }) }),
+      row({ bookingId: 'delta-1', description: 'Delta', latitude: 300, scoringSnapshot: snapshot({ locationType: 10 }) }),
+      row({ bookingId: 'delta-2', description: 'Delta', latitude: 301, scoringSnapshot: snapshot({ locationType: 10 }) }),
+      row({ bookingId: 'delta-legacy', description: 'Delta', latitude: 302, scoringSnapshot: null }),
+      row({ bookingId: 'echo-1', description: 'Echo', latitude: 400, scoringSnapshot: snapshot({ locationType: 50 }) }),
+      row({ bookingId: 'foxtrot-1', description: 'Foxtrot', latitude: 500, scoringSnapshot: snapshot({ locationType: 60 }) })
+    ];
+    const clusters = clusterWfaDashboardRows(rows, {
+      distanceCalculator: distanceByLatitude,
+      methodologyVersion: METHODOLOGY_VERSION
+    });
+
+    const ranking = await buildWfaDashboardRanking(clusters, { weights, scoreCalculator });
+
+    expect(ranking.map((item) => item.location_label)).toEqual([
+      'Delta',
+      'Charlie',
+      'Alpha',
+      'Bravo',
+      'Echo'
+    ]);
+    expect(ranking).toHaveLength(5);
+  });
+});

--- a/tests/wfaRecommendationService.test.js
+++ b/tests/wfaRecommendationService.test.js
@@ -1,7 +1,13 @@
 import { jest } from '@jest/globals';
 
 import { AppError } from '../src/shared/errors/AppError.js';
-import { createWfaRecommendationService } from '../src/services/wfaRecommendation.service.js';
+
+jest.unstable_mockModule('../src/services/wfaFacility.service.js', () => ({
+  readStrictWfaCheckinWindow: jest.fn(),
+  scoreFacilityEvidence: jest.fn()
+}));
+
+const { createWfaRecommendationService } = await import('../src/services/wfaRecommendation.service.js');
 
 const scheduleDate = '2099-08-03';
 const facilityMatrix = Object.freeze({
@@ -88,7 +94,9 @@ const createHarness = ({
     location_type: 0.5,
     distance_factor: 0.3,
     facility_score: 0.2,
-    consistency_ratio: 0
+    consistency_ratio: 0,
+    weighting_method: 'chang_extent',
+    version: 'wfa_fahp_v1'
   },
   calculateWfaScore = null,
   fetchPlaceDetails = null,
@@ -167,6 +175,10 @@ const createHarness = ({
     readSearchRadius
   };
 };
+
+afterEach(() => {
+  jest.useRealTimers();
+});
 
 test('shortlists only the top 30 candidates before Place Details enrichment', async () => {
   const features = Array.from({ length: 35 }, (_, index) =>
@@ -495,6 +507,7 @@ test('analysis validates the date without a duplicate check and honors its expli
 });
 
 test('booking scoring selects the nearest valid candidate and returns canonical ranked fields', async () => {
+  jest.useFakeTimers().setSystemTime(new Date('2026-08-15T01:02:03.000Z'));
   const harness = createHarness({
     features: [
       place({ id: 'preliminary-best', distance: 90, locationScore: 100 }),
@@ -520,6 +533,35 @@ test('booking scoring selects the nearest valid candidate and returns canonical 
     status: 'ranked',
     suitabilityScore: 82.4,
     suitabilityLabel: 'Sangat Baik',
+    scoringSnapshot: {
+      schema_version: 1,
+      methodology_version: 'wfa_fahp_v1',
+      captured_at: '2026-08-15T01:02:03.000Z',
+      criteria: {
+        location_type_score: 40,
+        distance_factor_score: 95,
+        facility_score: 75
+      },
+      methodology: {
+        weights: {
+          location_type: 0.5,
+          distance_factor: 0.3,
+          facility_score: 0.2
+        },
+        consistency_ratio: 0,
+        weighting_method: 'chang_extent'
+      },
+      evidence: {
+        place_id: 'nearest',
+        location_type: 'cafe',
+        distance_meters: 5,
+        facility_confidence: 80
+      },
+      result: {
+        score: 82.4,
+        label: 'Sangat Baik'
+      }
+    },
     candidate: expect.objectContaining({ place_id: 'nearest', status: 'ranked' })
   });
 });
@@ -537,6 +579,7 @@ test('booking scoring returns nullable suitability when discovery has no candida
     status: 'insufficient_facility_data',
     suitabilityScore: null,
     suitabilityLabel: null,
+    scoringSnapshot: null,
     candidate: null
   });
 
@@ -563,6 +606,7 @@ test('booking scoring returns nullable suitability when discovery has no candida
     status: 'insufficient_facility_data',
     suitabilityScore: null,
     suitabilityLabel: null,
+    scoringSnapshot: null,
     candidate: expect.objectContaining({
       place_id: 'insufficient',
       facility_score: 100,

--- a/tests/wfaScoringSnapshotMigration.test.js
+++ b/tests/wfaScoringSnapshotMigration.test.js
@@ -1,0 +1,64 @@
+import { createRequire } from 'node:module';
+
+import { jest } from '@jest/globals';
+import { DataTypes } from 'sequelize';
+
+import { WFA_MATRIX_VERSION } from '../src/analytics/config.fahp.js';
+import Booking from '../src/models/booking.model.js';
+import fuzzyEngine from '../src/utils/fuzzyAhpEngine.js';
+
+const require = createRequire(import.meta.url);
+let migration = null;
+
+try {
+  migration = require('../src/models/migrations/20260815010000-add-wfa-scoring-snapshot.cjs');
+} catch (error) {
+  if (error.code !== 'MODULE_NOT_FOUND') throw error;
+}
+
+const Sequelize = { ...DataTypes };
+
+describe('WFA scoring snapshot persistence contract', () => {
+  it('adds and removes exactly one nullable JSON booking snapshot column', async () => {
+    expect(migration).not.toBeNull();
+
+    const queryInterface = {
+      addColumn: jest.fn().mockResolvedValue(undefined),
+      removeColumn: jest.fn().mockResolvedValue(undefined)
+    };
+
+    await migration.up(queryInterface, Sequelize);
+    await migration.down(queryInterface, Sequelize);
+
+    expect(queryInterface.addColumn).toHaveBeenCalledTimes(1);
+    expect(queryInterface.addColumn).toHaveBeenCalledWith('bookings', 'wfa_scoring_snapshot', {
+      type: Sequelize.JSON,
+      allowNull: true
+    });
+    expect(queryInterface.removeColumn).toHaveBeenCalledTimes(1);
+    expect(queryInterface.removeColumn).toHaveBeenCalledWith('bookings', 'wfa_scoring_snapshot');
+  });
+
+  it('maps the snapshot column on Booking and keeps the canonical WFA matrix version on repeated reads', () => {
+    expect(Booking.rawAttributes).toHaveProperty('wfa_scoring_snapshot');
+    expect(Booking.rawAttributes.wfa_scoring_snapshot.allowNull).toBe(true);
+    expect(Booking.rawAttributes.wfa_scoring_snapshot.type.key).toBe('JSON');
+
+    const first = fuzzyEngine.getWfaAhpWeights();
+    const second = fuzzyEngine.getWfaAhpWeights();
+
+    expect(first).toMatchObject({
+      version: WFA_MATRIX_VERSION,
+      weighting_method: expect.any(String),
+      consistency_ratio: expect.any(Number)
+    });
+    expect(second).toMatchObject({
+      version: WFA_MATRIX_VERSION,
+      weighting_method: first.weighting_method,
+      consistency_ratio: first.consistency_ratio
+    });
+    expect(second.location_type).toBe(first.location_type);
+    expect(second.distance_factor).toBe(first.distance_factor);
+    expect(second.facility_score).toBe(first.facility_score);
+  });
+});


### PR DESCRIPTION
## Summary
- Persist server-authored reproducible WFA scoring snapshots with methodology/schema validation.
- Add Approved booking date-range analysis with deterministic physical-location grouping, criterion aggregation, canonical FAHP ranking, semantic states, evidence counters, and location_key.
- Reuse the existing dashboard endpoint with explicit from/to validation (max 31 days); preserve generic WFA 410 and live WFA contracts.
- Synchronize OpenAPI and runtime/contract tests.

## Verification
- Full non-integration Jest: 158 suites, 1,530 tests passed.
- Focused WFA/dashboard/API/OpenAPI coverage passed.
- npm run lint passed.
- git diff --check passed.

Closes #142ுடன்

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Restored WFA dashboard analysis with required `from` and `to` dates, supporting windows up to 31 days.
  * Added WFA rankings, methodology details, location information, booking counts, status indicators, and evidence metrics.
  * Added scoring snapshots to preserve booking-analysis evidence and methodology versions.

* **Bug Fixes**
  * WFA dashboard requests no longer return a migration error.
  * Added validation for missing, invalid, or overly long date ranges.

* **Documentation**
  * Updated the API contract to reflect WFA dashboard parameters and response fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->