### PR TITLE
feat(infra): harden production nginx ingress contract

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -149,6 +149,11 @@ jobs:
             docker compose exec -T app npm run migrate:status
           "
 
+      - name: Run external ingress and direct-port negative gate
+        run: |
+          chmod +x ./deploy/scripts/verify-public-ingress.sh
+          DOMAIN="$PRODUCTION_PUBLIC_DOMAIN" PUBLIC_IP="$PRODUCTION_EXPECTED_IP" ./deploy/scripts/verify-public-ingress.sh
+
       - name: Run blocking smoke gate against production host
         run: npm run smoke-test "$PRODUCTION_PUBLIC_BASE_URL"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,9 +42,3 @@ attendance.controller.js, jobs/*.job.js (createGeneralAlpha, autoCheckout, resol
 
 ## DEPENDENCY RULE
 Backend adalah upstream. Sebelum tandai kontrak backend Done, pastikan verifikasi ada. Client (Web FE/Android) tidak boleh menutup task konsumen sebelum kontrak backend yang dipakainya terkunci + verified.
-
-## GENERAL
-
-| Common Mistake | Correct Behavior |
-| --- | --- |
-| Membuat PR baru hanya karena branch remote sempat hilang atau diff lokal terlihat belum terserap | Sebelum membuat PR baru, verifikasi dulu apakah PR sebelumnya sudah merged dan apakah commit/isi branch sudah atau belum masuk ke `develop`. Jika belum yakin, cek state merge PR, compare `develop` vs branch target, dan baru putuskan apakah perlu PR baru. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,3 +42,9 @@ attendance.controller.js, jobs/*.job.js (createGeneralAlpha, autoCheckout, resol
 
 ## DEPENDENCY RULE
 Backend adalah upstream. Sebelum tandai kontrak backend Done, pastikan verifikasi ada. Client (Web FE/Android) tidak boleh menutup task konsumen sebelum kontrak backend yang dipakainya terkunci + verified.
+
+## GENERAL
+
+| Common Mistake | Correct Behavior |
+| --- | --- |
+| Membuat PR baru hanya karena branch remote sempat hilang atau diff lokal terlihat belum terserap | Sebelum membuat PR baru, verifikasi dulu apakah PR sebelumnya sudah merged dan apakah commit/isi branch sudah atau belum masuk ke `develop`. Jika belum yakin, cek state merge PR, compare `develop` vs branch target, dan baru putuskan apakah perlu PR baru. |

--- a/deploy/env/backend.production.example
+++ b/deploy/env/backend.production.example
@@ -3,6 +3,7 @@
 
 # Runtime
 NODE_ENV=production
+APP_BIND_HOST=127.0.0.1
 PORT=3005
 TZ=Asia/Jakarta
 LOG_LEVEL=info

--- a/deploy/nginx/api.infinite-track.tech.bootstrap.conf
+++ b/deploy/nginx/api.infinite-track.tech.bootstrap.conf
@@ -1,0 +1,17 @@
+# Initial HTTP-only vhost for Certbot webroot provisioning.
+# Install this file before obtaining the certificate, then replace it with
+# api.infinite-track.tech.conf after the certificate exists.
+server {
+    listen 80;
+    listen [::]:80;
+    server_name api.infinite-track.tech;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        client_max_body_size 1m;
+        include snippets/infinite-track-api-proxy.conf;
+    }
+}

--- a/deploy/nginx/api.infinite-track.tech.conf
+++ b/deploy/nginx/api.infinite-track.tech.conf
@@ -24,12 +24,12 @@ server {
 
     client_max_body_size 1m;
 
-    location = /api/users {
+    location ~ ^/api/users/?$ {
         client_max_body_size 25m;
         include snippets/infinite-track-api-proxy.conf;
     }
 
-    location ~ ^/api/users/[^/]+/photo$ {
+    location ~ ^/api/users/[^/]+/photo/?$ {
         client_max_body_size 25m;
         include snippets/infinite-track-api-proxy.conf;
     }

--- a/deploy/nginx/api.infinite-track.tech.conf
+++ b/deploy/nginx/api.infinite-track.tech.conf
@@ -1,22 +1,40 @@
-# Bootstrap HTTP-only vhost for initial Droplet provisioning.
-# Certbot is expected to augment this file with the final HTTPS server block
-# and HTTP->HTTPS redirect once certificates are issued on the host.
+# Canonical production vhost. Certificate files are managed by Certbot on the host.
 server {
     listen 80;
     listen [::]:80;
     server_name api.infinite-track.tech;
 
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
     location / {
-        proxy_pass http://127.0.0.1:3005;
-        proxy_http_version 1.1;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
-        proxy_read_timeout 60s;
-        proxy_connect_timeout 10s;
-        proxy_send_timeout 60s;
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    server_name api.infinite-track.tech;
+
+    ssl_certificate /etc/letsencrypt/live/api.infinite-track.tech/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/api.infinite-track.tech/privkey.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
+
+    client_max_body_size 1m;
+
+    location = /api/users {
+        client_max_body_size 25m;
+        include snippets/infinite-track-api-proxy.conf;
+    }
+
+    location ~ ^/api/users/[^/]+/photo$ {
+        client_max_body_size 25m;
+        include snippets/infinite-track-api-proxy.conf;
+    }
+
+    location / {
+        include snippets/infinite-track-api-proxy.conf;
     }
 }

--- a/deploy/nginx/snippets/infinite-track-api-proxy.conf
+++ b/deploy/nginx/snippets/infinite-track-api-proxy.conf
@@ -1,0 +1,9 @@
+proxy_pass http://127.0.0.1:3005;
+proxy_http_version 1.1;
+proxy_set_header Host $host;
+proxy_set_header X-Real-IP $remote_addr;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto $scheme;
+proxy_read_timeout 60s;
+proxy_connect_timeout 10s;
+proxy_send_timeout 60s;

--- a/deploy/scripts/verify-droplet-api.sh
+++ b/deploy/scripts/verify-droplet-api.sh
@@ -175,6 +175,27 @@ if command -v nginx >/dev/null 2>&1; then
   printf 'NGINX_CONFIG_OK\n'
 fi
 
+if ! command -v ss >/dev/null 2>&1; then
+  printf 'LISTENER_FAIL ss is required to verify the loopback bind\n' >&2
+  exit 1
+fi
+
+printf 'Checking backend listener is loopback-only on port 3005...\n'
+LISTENERS="$(ss -ltnH 'sport = :3005' 2>/dev/null || true)"
+if [ -z "$LISTENERS" ]; then
+  printf 'LISTENER_FAIL no listener found on port 3005\n' >&2
+  exit 1
+fi
+if printf '%s\n' "$LISTENERS" | grep -Eq '0\.0\.0\.0:3005|\*:3005|\[::\]:3005|:::3005'; then
+  printf 'LISTENER_FAIL port 3005 is exposed beyond loopback\n%s\n' "$LISTENERS" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$LISTENERS" | grep -Eq '127\.0\.0\.1:3005'; then
+  printf 'LISTENER_FAIL expected 127.0.0.1:3005 listener\n%s\n' "$LISTENERS" >&2
+  exit 1
+fi
+printf 'LISTENER_OK 127.0.0.1:3005\n'
+
 printf 'Checking public HTTPS liveness at %s...\n' "$PUBLIC_LIVEZ_URL"
 check_json_endpoint "$PUBLIC_LIVEZ_URL" 'PUBLIC_LIVEZ' 'liveness'
 

--- a/deploy/scripts/verify-droplet-api.sh
+++ b/deploy/scripts/verify-droplet-api.sh
@@ -186,11 +186,13 @@ if [ -z "$LISTENERS" ]; then
   printf 'LISTENER_FAIL no listener found on port 3005\n' >&2
   exit 1
 fi
-if printf '%s\n' "$LISTENERS" | grep -Eq '0\.0\.0\.0:3005|\*:3005|\[::\]:3005|:::3005'; then
-  printf 'LISTENER_FAIL port 3005 is exposed beyond loopback\n%s\n' "$LISTENERS" >&2
+INVALID_LISTENERS="$(printf '%s\n' "$LISTENERS" | awk '$4 !~ /^127\.0\.0\.1:3005$/ { print }')"
+if [ -n "$INVALID_LISTENERS" ]; then
+  printf 'LISTENER_FAIL every port 3005 listener must be exactly 127.0.0.1:3005\n%s\n' "$LISTENERS" >&2
   exit 1
 fi
-if ! printf '%s\n' "$LISTENERS" | grep -Eq '127\.0\.0\.1:3005'; then
+LOOPBACK_LISTENER_COUNT="$(printf '%s\n' "$LISTENERS" | awk '$4 == "127.0.0.1:3005" { count += 1 } END { print count + 0 }')"
+if [ "$LOOPBACK_LISTENER_COUNT" -lt 1 ]; then
   printf 'LISTENER_FAIL expected 127.0.0.1:3005 listener\n%s\n' "$LISTENERS" >&2
   exit 1
 fi

--- a/deploy/scripts/verify-public-ingress.sh
+++ b/deploy/scripts/verify-public-ingress.sh
@@ -2,12 +2,70 @@
 set -euo pipefail
 
 PUBLIC_IP="${PUBLIC_IP:?PUBLIC_IP is required}"
+DOMAIN="${DOMAIN:?DOMAIN is required}"
 URL="http://${PUBLIC_IP}:3005/livez"
 
+if ! command -v python3 >/dev/null 2>&1; then
+  printf 'DEPENDENCY_FAIL python3 is required for TCP verification\n' >&2
+  exit 1
+fi
+
+printf 'Checking direct TCP access is blocked at %s:3005...\n' "$PUBLIC_IP"
+if python3 - "$PUBLIC_IP" <<'PY'
+import socket
+import sys
+
+address = sys.argv[1]
+try:
+    with socket.create_connection((address, 3005), timeout=5):
+        print('DIRECT_TCP_3005_REACHABLE')
+        sys.exit(0)
+except (ConnectionRefusedError, TimeoutError) as exc:
+    print(f'DIRECT_TCP_3005_BLOCKED {exc}')
+    sys.exit(1)
+except OSError as exc:
+    print(f'DIRECT_TCP_3005_PROBE_ERROR {exc}', file=sys.stderr)
+    sys.exit(2)
+PY
+then
+  TCP_PROBE_STATUS=0
+else
+  TCP_PROBE_STATUS=$?
+fi
+case "$TCP_PROBE_STATUS" in
+  0)
+  printf 'DIRECT_TCP_3005_FAIL public TCP port 3005 is reachable; release blocker\n' >&2
+  exit 1
+  ;;
+  1)
+  ;;
+  *)
+  printf 'DIRECT_TCP_3005_PROBE_FAIL unable to establish a trustworthy negative TCP result\n' >&2
+  exit 1
+  ;;
+esac
+
+printf 'DIRECT_TCP_3005_OK public TCP port 3005 is blocked\n'
+
 printf 'Checking direct public Express access is blocked at %s...\n' "$URL"
-if curl --silent --show-error --connect-timeout 5 --max-time 10 "$URL" >/dev/null 2>&1; then
+if curl --noproxy '*' --silent --show-error --connect-timeout 5 --max-time 10 "$URL" >/dev/null 2>&1; then
   printf 'DIRECT_PORT_3005_FAIL public port 3005 is reachable; release blocker\n' >&2
   exit 1
 fi
 
-printf 'DIRECT_PORT_3005_OK public port 3005 is blocked\n'
+printf 'DIRECT_HTTP_3005_OK public HTTP port 3005 is blocked\n'
+
+printf 'Checking HTTP to HTTPS redirect for %s...\n' "$DOMAIN"
+HEADERS_FILE="$(mktemp)"
+HTTP_STATUS="$(curl --noproxy '*' --silent --show-error --output /dev/null --dump-header "$HEADERS_FILE" --write-out '%{http_code}' --connect-timeout 5 --max-time 10 -H "Host: $DOMAIN" "http://${PUBLIC_IP}/")" || {
+  rm -f "$HEADERS_FILE"
+  printf 'HTTP_REDIRECT_FAIL unable to verify HTTP port 80 for %s\n' "$DOMAIN" >&2
+  exit 1
+}
+REDIRECT_LOCATION="$(awk 'tolower($1) == "location:" { sub(/^[^:]*:[[:space:]]*/, ""); gsub(/\r/, ""); print; exit }' "$HEADERS_FILE")"
+rm -f "$HEADERS_FILE"
+if [ "$HTTP_STATUS" != '301' ] || [ "$REDIRECT_LOCATION" != "https://${DOMAIN}/" ]; then
+  printf 'HTTP_REDIRECT_FAIL expected 301 to https://%s/, got HTTP %s Location %s\n' "$DOMAIN" "$HTTP_STATUS" "$REDIRECT_LOCATION" >&2
+  exit 1
+fi
+printf 'HTTP_REDIRECT_OK 301 to https://%s/\n' "$DOMAIN"

--- a/deploy/scripts/verify-public-ingress.sh
+++ b/deploy/scripts/verify-public-ingress.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PUBLIC_IP="${PUBLIC_IP:?PUBLIC_IP is required}"
+URL="http://${PUBLIC_IP}:3005/livez"
+
+printf 'Checking direct public Express access is blocked at %s...\n' "$URL"
+if curl --silent --show-error --connect-timeout 5 --max-time 10 "$URL" >/dev/null 2>&1; then
+  printf 'DIRECT_PORT_3005_FAIL public port 3005 is reachable; release blocker\n' >&2
+  exit 1
+fi
+
+printf 'DIRECT_PORT_3005_OK public port 3005 is blocked\n'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,6 @@
 services:
   app:
-    build:
-      context: .
-      target: production
-      dockerfile: Dockerfile
-    image: infinit-track-backend:latest
+    image: ${BACKEND_IMAGE:-registry.digitalocean.com/infinit-track/infinit-track-backend}:${BACKEND_IMAGE_TAG:?BACKEND_IMAGE_TAG is required}
     container_name: infinit-track-app
     restart: unless-stopped
     network_mode: host

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,10 @@
 services:
   app:
-    image: ${BACKEND_IMAGE:-registry.digitalocean.com/infinit-track/infinit-track-backend}:${BACKEND_IMAGE_TAG:?BACKEND_IMAGE_TAG is required}
-    # Canonical droplet runtime is image-first via DOCR + immutable BACKEND_IMAGE_TAG.
-    # This compose file is the droplet runtime surface, so it must fail fast when the
-    # selected immutable tag is missing instead of silently falling back to `latest`.
+    build:
+      context: .
+      target: production
+      dockerfile: Dockerfile
+    image: infinit-track-backend:latest
     container_name: infinit-track-app
     restart: unless-stopped
     network_mode: host

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - ${BACKEND_ENV_FILE:-./deploy/env/backend.production.env}
     environment:
       NODE_ENV: production
+      APP_BIND_HOST: 127.0.0.1
       PORT: 3005
       TZ: Asia/Jakarta
       LOG_LEVEL: ${LOG_LEVEL:-info}

--- a/docs/GITHUB_ACTIONS_SETUP.md
+++ b/docs/GITHUB_ACTIONS_SETUP.md
@@ -1,5 +1,7 @@
 # 🔄 GitHub Actions Setup Guide
 
+Production ingress verification uses the Droplet-side `deploy/scripts/verify-droplet-api.sh` and an external runner-side `deploy/scripts/verify-public-ingress.sh`. The external check must prove that the Droplet public IP cannot reach Express directly on TCP port `3005`; a successful response is a release blocker. Nginx syntax validation remains a required pre-reload gate.
+
 ## Overview
 
 Guide untuk setup GitHub Actions backend sesuai source of truth saat ini:

--- a/docs/PRODUCTION_DEPLOYMENT.md
+++ b/docs/PRODUCTION_DEPLOYMENT.md
@@ -1,5 +1,7 @@
 # 🚀 Production Deployment Guide
 
+For the canonical Nginx ingress, certificate lifecycle, loopback listener, and external port-3005 verification contract, see [PRODUCTION_NGINX_INGRESS.md](PRODUCTION_NGINX_INGRESS.md). Production deployment must run `nginx -t` before reload and must not rely on Certbot mutating the tracked application vhost.
+
 ## Overview
 
 Panduan deployment backend untuk fase saat ini, dengan source of truth yang selaras ke target runtime aktif.

--- a/docs/PRODUCTION_NGINX_INGRESS.md
+++ b/docs/PRODUCTION_NGINX_INGRESS.md
@@ -1,0 +1,48 @@
+# Production Nginx ingress contract
+
+The production topology has one public backend ingress:
+
+```text
+HTTPS api.infinite-track.tech -> host Nginx -> 127.0.0.1:3005 -> Express
+```
+
+Express is bound to `127.0.0.1:3005` in production. Docker Compose intentionally keeps host networking for the canonical Droplet runtime, but the application listener must not bind to the Droplet's public interfaces. The DigitalOcean firewall must not expose inbound TCP `3005`; only the intended Nginx ports are public.
+
+## Bootstrap and certificate lifecycle
+
+1. Install `deploy/nginx/api.infinite-track.tech.bootstrap.conf` as the vhost.
+2. Create `/var/www/certbot` and ensure `/.well-known/acme-challenge/` is reachable over HTTP.
+3. Obtain or renew the certificate with Certbot webroot/cert-only mode.
+4. Install `deploy/nginx/api.infinite-track.tech.conf` as the canonical vhost.
+5. Confirm the certificate files exist under `/etc/letsencrypt/live/api.infinite-track.tech/`.
+6. Run `sudo nginx -t`; stop if it fails.
+7. Reload Nginx only after syntax validation succeeds: `sudo systemctl reload nginx`.
+
+The final vhost keeps the ACME challenge on port 80 and redirects all other HTTP requests to the equivalent HTTPS URL. It supports TLS 1.2 and TLS 1.3. Certificate private keys and the `/etc/letsencrypt` directory remain host-managed and are never committed.
+
+Configure a Certbot deploy hook (or equivalent system-managed renewal hook) to run `nginx -t && systemctl reload nginx` after successful renewal. Certbot must not mutate the tracked application vhost.
+
+## Verification
+
+On the Droplet:
+
+```bash
+DOMAIN=api.infinite-track.tech EXPECTED_IP=<droplet-ip> \
+  bash deploy/scripts/verify-droplet-api.sh
+```
+
+This proves Nginx syntax, local `/livez` and `/health`, the loopback-only `3005` listener, public HTTPS health, protected-route rejection, and the authenticated surface boundaries.
+
+From an external runner:
+
+```bash
+PUBLIC_IP=<droplet-ip> bash deploy/scripts/verify-public-ingress.sh
+```
+
+The direct `http://<droplet-ip>:3005/livez` request must fail. A successful response is a release blocker. Public port 80 redirect, port 443 API ingress, Web FE credentialed CORS/session smoke, Android representative API smoke, and the existing production smoke pack remain separate external evidence gates.
+
+## Rollback
+
+If `nginx -t` fails, do not reload. If public HTTPS fails after a valid reload, restore the previous known-good vhost, run `nginx -t`, and reload only after it passes. Certificate rollback selects an existing valid Certbot lineage on the host; it never copies private keys into Git.
+
+Nginx remains a transport boundary. Express owns CORS, JWT/session authentication, authorization, rate limits, validation, business errors, `/livez`, `/health`, `/docs`, `/docs/openapi.yaml`, and all `/api/*` semantics.

--- a/docs/PRODUCTION_NGINX_INGRESS.md
+++ b/docs/PRODUCTION_NGINX_INGRESS.md
@@ -44,10 +44,11 @@ This proves Nginx syntax, local `/livez` and `/health`, the loopback-only `3005`
 From an external runner:
 
 ```bash
-PUBLIC_IP=<droplet-ip> bash deploy/scripts/verify-public-ingress.sh
+DOMAIN=api.infinite-track.tech PUBLIC_IP=<droplet-ip> \
+  bash deploy/scripts/verify-public-ingress.sh
 ```
 
-The direct `http://<droplet-ip>:3005/livez` request must fail. A successful response is a release blocker. Public port 80 redirect, port 443 API ingress, Web FE credentialed CORS/session smoke, Android representative API smoke, and the existing production smoke pack remain separate external evidence gates.
+The direct TCP connection and `http://<droplet-ip>:3005/livez` request must fail without proxy use. A successful connection or response is a release blocker. The verifier also requires the public HTTP endpoint to return `301` to the HTTPS domain. Port 443 API ingress, Web FE credentialed CORS/session smoke, Android representative API smoke, and the existing production smoke pack remain separate external evidence gates.
 
 ## Rollback
 

--- a/docs/PRODUCTION_NGINX_INGRESS.md
+++ b/docs/PRODUCTION_NGINX_INGRESS.md
@@ -10,10 +10,18 @@ Express is bound to `127.0.0.1:3005` in production. Docker Compose intentionally
 
 ## Bootstrap and certificate lifecycle
 
-1. Install `deploy/nginx/api.infinite-track.tech.bootstrap.conf` as the vhost.
+1. Install the shared proxy snippet and bootstrap vhost:
+   ```bash
+   sudo install -D -m 0644 deploy/nginx/snippets/infinite-track-api-proxy.conf \
+     /etc/nginx/snippets/infinite-track-api-proxy.conf
+   sudo install -D -m 0644 deploy/nginx/api.infinite-track.tech.bootstrap.conf \
+     /etc/nginx/sites-available/api.infinite-track.tech.conf
+   sudo ln -sfn /etc/nginx/sites-available/api.infinite-track.tech.conf \
+     /etc/nginx/sites-enabled/api.infinite-track.tech.conf
+   ```
 2. Create `/var/www/certbot` and ensure `/.well-known/acme-challenge/` is reachable over HTTP.
 3. Obtain or renew the certificate with Certbot webroot/cert-only mode.
-4. Install `deploy/nginx/api.infinite-track.tech.conf` as the canonical vhost.
+4. Install `deploy/nginx/api.infinite-track.tech.conf` as the canonical vhost at the same `sites-available` path.
 5. Confirm the certificate files exist under `/etc/letsencrypt/live/api.infinite-track.tech/`.
 6. Run `sudo nginx -t`; stop if it fails.
 7. Reload Nginx only after syntax validation succeeds: `sudo systemctl reload nginx`.

--- a/docs/superpowers/plans/2026-08-18-inf-278-production-nginx-ingress-hardening.md
+++ b/docs/superpowers/plans/2026-08-18-inf-278-production-nginx-ingress-hardening.md
@@ -1,0 +1,81 @@
+# INF-278 Production Nginx Ingress Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Droplet-hosted Express API reachable only through the canonical Nginx ingress while locking proxy trust, request-size, TLS, and runtime verification contracts.
+
+**Architecture:** Keep Docker Compose `network_mode: host`, but bind production Express to `127.0.0.1:3005`. Express owns proxy interpretation, CORS, auth, health, and business behavior; tracked Nginx bootstrap/final vhosts own transport and TLS lifecycle, with a shared proxy snippet.
+
+**Tech Stack:** Node.js ESM, Express, Jest, Docker Compose, Nginx, Bash, Certbot webroot renewal.
+
+**Spec:** `docs/superpowers/specs/2026-08-17-inf-278-production-nginx-ingress-hardening-design.md`
+
+## Global Constraints
+
+- Production bind address is `127.0.0.1`; application port is `3005`.
+- Production Express proxy trust is the explicit loopback contract `app.set('trust proxy', 'loopback')`.
+- General JSON and URL-encoded bodies are limited to `1mb`; face uploads retain a `20 MiB` Multer file limit and receive a `25m` Nginx envelope.
+- Nginx remains a thin ingress boundary and must not own auth, CORS, application rate limits, health responses, or business rules.
+- Final HTTPS config must be tracked without certificate private keys; `nginx -t` is required before reload.
+- Preserve `network_mode: host`, existing API paths, `/livez`, `/health`, and public API contracts.
+
+---
+
+### Task 1: Lock application runtime and proxy/body contracts
+
+**Files:**
+- Modify: `src/config/index.js`
+- Modify: `src/app.js`
+- Modify: `src/server.js`
+- Modify: `docker-compose.yml`
+- Modify: `deploy/env/backend.production.example`
+- Test: `tests/inf278IngressRuntimeContract.test.js`
+
+- [ ] Write tests that assert production defaults/rejects non-loopback `APP_BIND_HOST`, `config.bindHost`, production loopback trust, forwarded IP/protocol behavior, and 1 MiB parser behavior while preserving non-production defaults.
+- [ ] Run the focused test and confirm it fails because the runtime contract is absent.
+- [ ] Add `bindHost` resolution and production validation, set Express trust proxy to `loopback` only in production, reduce JSON/urlencoded limits to `1mb`, and pass `config.bindHost` to `app.listen`.
+- [ ] Set `APP_BIND_HOST: 127.0.0.1` in the production Compose environment and template.
+- [ ] Run the focused test and confirm it passes.
+
+### Task 2: Make the Nginx source contract reproducible
+
+**Files:**
+- Rename: `deploy/nginx/api.infinite-track.tech.conf` → `deploy/nginx/api.infinite-track.tech.bootstrap.conf`
+- Create: `deploy/nginx/api.infinite-track.tech.conf`
+- Create: `deploy/nginx/snippets/infinite-track-api-proxy.conf`
+- Test: `tests/inf278NginxContract.test.js`
+
+- [ ] Write contract tests for bootstrap challenge handling, final HTTP→HTTPS redirect, TLS 1.2/1.3 directives, loopback proxy target, standard forwarded headers, body-size locations, and absence of unconditional upgrade headers.
+- [ ] Run the focused test and confirm it fails against the current single HTTP-only vhost.
+- [ ] Move shared proxy headers/timeouts into the snippet, remove `Upgrade` and `Connection: upgrade`, add global `1m` and the two `25m` face-upload locations, and add tracked bootstrap/final vhosts using Certbot-managed certificate paths without secrets.
+- [ ] Run the focused test and confirm it passes.
+
+### Task 3: Extend Droplet and external ingress verification
+
+**Files:**
+- Modify: `deploy/scripts/verify-droplet-api.sh`
+- Create: `deploy/scripts/verify-public-ingress.sh`
+- Modify: `tests/inf278DeploymentVerificationContract.test.js`
+
+- [ ] Write tests for `nginx -t`, loopback listener inspection, local health checks, HTTP redirect, protected-route rejection, and external negative TCP/HTTP verification of public port `3005`.
+- [ ] Run the focused test and confirm it fails because the new checks/scripts do not exist.
+- [ ] Implement safe host-side checks that stop before reload on failed syntax validation and an externally runnable script that treats an unreachable public `3005` as success.
+- [ ] Run the focused test and shell syntax checks.
+
+### Task 4: Document deployment, renewal, and rollback ownership
+
+**Files:**
+- Create: `docs/PRODUCTION_NGINX_INGRESS.md`
+- Modify: `docs/PRODUCTION_DEPLOYMENT.md`
+- Modify: `docs/GITHUB_ACTIONS_SETUP.md`
+
+- [ ] Document bootstrap installation, Certbot webroot/cert-only issuance, final vhost installation, renewal deploy hook reload, `nginx -t` gate, loopback binding/firewall expectations, external port-3005 check, and rollback to the last known-good vhost.
+- [ ] Add the verifier commands and explicitly distinguish repository evidence from target-host and external production evidence.
+
+### Task 5: Run full verification and review the diff
+
+- [ ] Run focused INF-278 Jest tests.
+- [ ] Run `npm run lint`.
+- [ ] Run full non-integration `npm test`.
+- [ ] Run `bash -n` for both verifier scripts and static Nginx contract checks; run `nginx -t` if Nginx is installed.
+- [ ] Run `git diff --check`, inspect the final diff against every Linear acceptance criterion, and report unavailable production-only evidence separately.

--- a/docs/superpowers/specs/2026-08-17-inf-278-production-nginx-ingress-hardening-design.md
+++ b/docs/superpowers/specs/2026-08-17-inf-278-production-nginx-ingress-hardening-design.md
@@ -1,0 +1,379 @@
+# INF-278 — Production Nginx Ingress Hardening Design
+
+**Date:** 2026-08-17
+**Repository:** `Infinite-LearningV1/Infinit_Track_BE`
+**Base:** `origin/develop` at `a52426f6dfa26dbad18c59b30b620e0104099b52`
+**Branch:** `djangosuryaa/inf-278-backendinfra-harden-production-nginx-ingress-and-reverse`
+**Linear:** `INF-278`
+**Status:** Design approved; implementation not started
+
+## Purpose
+
+Harden the production API ingress so `api.infinite-track.tech` has exactly one public backend ingress: the host Nginx instance on the production Droplet.
+
+The change preserves the existing Droplet + Docker Compose + managed MySQL runtime and keeps Nginx as a thin transport boundary. It does not move application policy into Nginx and does not change public API semantics.
+
+Target topology:
+
+```text
+Web FE / Android
+      ↓ HTTPS
+api.infinite-track.tech :443
+      ↓
+Host Nginx
+      ↓ loopback HTTP only
+Express 127.0.0.1:3005
+      ↓
+Managed MySQL
+```
+## Current Runtime Findings
+
+The current repository already establishes the main deployment direction, but the ingress contract is incomplete:
+
+- `docker-compose.yml` uses `network_mode: host` for the backend container.
+- `src/server.js` calls `app.listen(config.port)` without an explicit bind host.
+- `src/app.js` uses production `trust proxy = 1`.
+- `deploy/nginx/api.infinite-track.tech.conf` proxies to `127.0.0.1:3005` but forwards unconditional `Upgrade` and `Connection: upgrade` headers.
+- no WebSocket, Socket.IO, or other HTTP-upgrade runtime was found in the backend repository.
+- Express accepts JSON and URL-encoded bodies up to `10mb`.
+- face-photo upload uses Multer memory storage with a `20MB` file-size limit.
+- Nginx has no tracked explicit body-size contract.
+- the tracked Nginx vhost is HTTP-only bootstrap configuration and expects Certbot to mutate the host config for final HTTPS behavior.
+- `deploy/scripts/verify-droplet-api.sh` already verifies DNS, local liveness/readiness, Nginx syntax when available, public HTTPS health, docs protection, and representative anonymous rejection.
+- Kubernetes and historical App Platform deployment surfaces are not production authority for INF-278.
+
+Baseline before INF-278 implementation:
+
+```text
+npm run lint: PASS
+Test Suites: 158 passed, 158 total
+Tests:       1530 passed, 1530 total
+```
+
+The initial local `npm ci` required `PUPPETEER_SKIP_DOWNLOAD=true` because of a broken local Puppeteer Chrome cache; this is workstation-only setup evidence and is not part of the product/runtime design.
+## Architecture Decision
+
+Production uses one host Nginx in front of the Express process. Nginx owns only ingress and transport concerns:
+
+- TCP ports `80` and `443` exposed publicly for the API host;
+- HTTP-to-HTTPS redirect;
+- TLS certificate presentation;
+- reverse proxying to the loopback backend;
+- standard proxy headers;
+- transport-level request-body envelope;
+- proxy connection/read/send timeouts.
+
+Express remains authoritative for:
+
+- JWT authentication and session semantics;
+- RBAC/authorization;
+- CORS policy and credentialed browser requests;
+- application/login rate limiting;
+- request validation and error mapping;
+- attendance, geofence, WFA, FAHP, and other business rules;
+- `/livez`, `/health`, `/docs`, `/docs/openapi.yaml`, and all `/api/*` response semantics.
+
+Nginx must not synthesize application health responses, decode JWTs, duplicate CORS rules, cache API responses, or implement business-specific access decisions.
+
+## Runtime Network Exposure
+
+The canonical production bind address is `127.0.0.1` and the canonical application port is `3005`.
+
+A new runtime variable named `APP_BIND_HOST` makes the listener contract explicit without overloading database `DB_HOST`. The production env template sets:
+
+```env
+APP_BIND_HOST=127.0.0.1
+PORT=3005
+```
+
+Production defaults `config.bindHost` to `127.0.0.1` when the variable is absent and rejects a production `APP_BIND_HOST` value other than `127.0.0.1`. Non-production keeps the current unspecified-host listener behavior unless `APP_BIND_HOST` is explicitly provided. This makes the production boundary fail-safe while preserving local-development compatibility.
+
+`src/config/index.js` exposes the resolved value as `config.bindHost`. `src/server.js` must use the Node/Express signature:
+
+```js
+app.listen(config.port, config.bindHost, callback);
+```
+
+Production therefore remains compatible with `network_mode: host` while preventing the process from listening on the Droplet's public interfaces.
+
+Runtime verification must prove both sides of the boundary:
+
+1. on the Droplet, the backend listener is bound to `127.0.0.1:3005` and local health checks work;
+2. from outside the Droplet, a direct connection to `<droplet-public-ip>:3005` fails.
+
+DigitalOcean firewall configuration must not contain an inbound rule exposing `3005`. INF-278 does not redesign SSH policy; it only requires that application ingress remain restricted to Nginx-facing public ports.
+
+## Express Proxy Trust
+
+The verified topology has one same-host proxy hop, and the only trusted proxy source is loopback. Production therefore uses:
+
+```js
+app.set('trust proxy', 'loopback');
+```
+
+This replaces hop-count trust (`1`) with an address-based trust boundary.
+
+A focused infrastructure configuration unit will apply this setting only in production. Tests must prove that a request entering from loopback with Nginx-style forwarding headers resolves:
+
+- `req.ip` to the forwarded client address;
+- `req.protocol` to `https` when `X-Forwarded-Proto: https` is supplied.
+
+Tests must also prove that non-production behavior does not silently enable production proxy trust.
+## Protocol Upgrade Policy
+
+The production backend is a REST Express application. No repository evidence establishes a WebSocket or other HTTP-upgrade endpoint.
+
+The Nginx proxy therefore removes these unconditional headers:
+
+```nginx
+proxy_set_header Upgrade $http_upgrade;
+proxy_set_header Connection "upgrade";
+```
+
+Normal HTTP/1.1 reverse proxying remains enabled. If a future feature introduces a real upgrade endpoint, that behavior requires a separate architecture decision and must be scoped only to the route that needs it.
+
+## Request-Body Size Contract
+
+The current public path is implicitly limited by Nginx while Express advertises a broader `10mb` parser limit. INF-278 makes the contract explicit and route-aware.
+
+Canonical limits:
+
+```text
+General JSON / URL-encoded API body: 1 MiB
+Face multipart Nginx envelope:       25 MiB
+Actual face file accepted by Multer: 20 MiB
+```
+
+Express global JSON and URL-encoded parser limits become `1mb`.
+
+The two legitimate face-upload surfaces retain the existing Multer `20MB` file-size rule:
+
+- `POST /api/users`
+- `POST /api/users/:id/photo`
+Nginx uses `client_max_body_size 1m` as the default API transport envelope and overrides it to `25m` only for the two face-upload paths.
+
+The Nginx `25m` value is intentionally larger than Multer's `20MB` file limit because multipart requests contain boundaries, headers, and form fields in addition to file bytes. Multer remains the application-level authority for the actual face-file limit.
+
+No attendance, WFA, FAHP, auth, report, or ordinary JSON route receives the expanded multipart envelope unless repository evidence later establishes a legitimate need.
+
+Boundary tests must cover:
+
+- ordinary JSON below 1 MiB succeeds when otherwise valid;
+- ordinary JSON above 1 MiB is rejected by the application parser in direct Express tests;
+- Nginx configuration exposes only 1 MiB globally;
+- face-upload locations have the 25 MiB transport envelope;
+- Multer continues rejecting a face file above 20 MiB.
+
+## Nginx Configuration Structure
+
+Tracked production Nginx configuration is split by responsibility:
+
+- `deploy/nginx/api.infinite-track.tech.bootstrap.conf` — initial HTTP-only certificate bootstrap surface;
+- `deploy/nginx/api.infinite-track.tech.conf` — canonical final HTTP redirect + HTTPS reverse-proxy vhost;
+- `deploy/nginx/snippets/infinite-track-api-proxy.conf` — shared reverse-proxy headers and timeout contract used by all proxied locations.
+
+The current HTTP-only `api.infinite-track.tech.conf` is renamed to the bootstrap role before the canonical final file takes its name.
+
+The shared proxy snippet retains:
+
+```nginx
+proxy_http_version 1.1;
+proxy_set_header Host $host;
+proxy_set_header X-Real-IP $remote_addr;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto $scheme;
+```
+It also retains the existing connect/read/send timeout behavior unless a failing runtime test demonstrates a need to change it. Upgrade headers are absent.
+
+The final vhost proxies to:
+
+```nginx
+proxy_pass http://127.0.0.1:3005;
+```
+
+All application paths continue to reach Express. Nginx does not create special synthetic handlers for `/health`, `/livez`, `/docs`, `/docs/openapi.yaml`, or `/api/*`.
+
+## HTTP and TLS Lifecycle
+
+Certbot owns certificate issuance and renewal. It does not own or mutate the canonical Nginx application vhost.
+
+Bootstrap sequence:
+
+1. install the tracked bootstrap HTTP vhost;
+2. expose `/.well-known/acme-challenge/` from a dedicated webroot such as `/var/www/certbot`;
+3. obtain the certificate with Certbot webroot/cert-only mode;
+4. install the tracked final Nginx vhost;
+5. run `nginx -t` before reload;
+6. reload Nginx only after syntax validation succeeds.
+
+The final port `80` server keeps the ACME challenge path reachable for renewal and redirects all other requests to the equivalent HTTPS URL.
+
+The final port `443` server references certificate files under the standard Certbot-managed `/etc/letsencrypt/live/api.infinite-track.tech/` path. No certificate private-key material is committed to Git.
+
+The final vhost explicitly supports TLS 1.2 and TLS 1.3. Application security headers remain owned by Express/Helmet; INF-278 does not duplicate them in Nginx.
+
+Certificate renewal must reload Nginx after a successful renewal through a Certbot deploy hook or equivalent system-managed renewal hook. The repository documentation must state this operational contract explicitly.
+## Verification Architecture
+
+Verification is divided according to where each property can actually be observed.
+
+### Repository and CI verification
+
+Jest contract tests must lock:
+
+- production `APP_BIND_HOST` and `config.bindHost` behavior;
+- production loopback proxy trust and forwarded IP/protocol semantics;
+- the 1 MiB Express parser boundary;
+- the unchanged 20 MiB Multer face-file boundary;
+- the tracked Nginx final-vhost structure;
+- absence of unconditional protocol-upgrade headers;
+- the 1 MiB global Nginx body limit and 25 MiB face-upload overrides;
+- HTTP redirect and HTTPS certificate directives in the final config;
+- `/health` and `/livez` remaining Express-owned routes rather than Nginx-generated responses.
+
+Every implementation batch must preserve `npm run lint` and the full non-integration `npm test` baseline.
+### Droplet-local verification
+
+`deploy/scripts/verify-droplet-api.sh` remains the host-side runtime verifier and is extended to prove:
+
+- `nginx -t` passes;
+- local `127.0.0.1:3005/livez` passes;
+- local `127.0.0.1:3005/health` passes;
+- the backend listener is bound only to loopback on port `3005`;
+- public HTTPS liveness/readiness still pass;
+- protected public routes still reject anonymous callers through Express.
+
+### External verification
+
+A check running outside the Droplet must prove that `<droplet-public-ip>:3005` is not reachable directly.
+
+The production deployment workflow is the preferred automation point because its GitHub-hosted runner is external to the Droplet. A failed TCP/HTTP connection to port `3005` is success for this negative check; a successful direct response is a release blocker.
+
+The same production gate must continue to verify:
+
+- public port `80` redirects to HTTPS;
+- public port `443` reaches the API through Nginx;
+- Web FE credentialed CORS/login-session behavior works;
+- a representative Android API request works without contract changes;
+- the existing production smoke test passes.
+## Deployment and Failure Semantics
+
+Nginx configuration is never reloaded blindly. Deployment order is:
+
+```text
+stage tracked config/snippet
+→ verify expected certificate files when final TLS config is selected
+→ nginx -t
+→ reload Nginx
+→ run local health checks
+→ run external ingress checks
+→ run application smoke checks
+```
+
+If `nginx -t` fails, the active known-good Nginx configuration remains in service and the deployment stops before reload.
+
+If Express fails after the listener change, Docker health/readiness evidence must identify the failure before the ingress change is considered complete. Binding to loopback must not alter database connectivity because the application still uses host networking for outbound managed-MySQL access.
+
+If public HTTPS fails after a valid Nginx reload, operators restore the previous known-good vhost and rerun `nginx -t` before reloading. Certificate rollback does not copy private keys into the repository; it selects an existing valid Certbot-managed certificate lineage on the host.
+
+INF-278 does not make Nginx return application JSON errors. Nginx transport failures such as an oversized request can retain standard Nginx transport responses; Express remains responsible for application-level validation and business-error envelopes.
+
+## Source-of-Truth Boundaries
+
+After implementation, production authority is:
+
+- `docker-compose.yml` plus production env contract for the Express runtime;
+- `deploy/nginx/api.infinite-track.tech.conf` for final public ingress behavior;
+- `deploy/nginx/api.infinite-track.tech.bootstrap.conf` only for first certificate provisioning/recovery;
+- `deploy/nginx/snippets/infinite-track-api-proxy.conf` for shared reverse-proxy transport settings;
+- Certbot-managed `/etc/letsencrypt` state for certificate material;
+- Express routes/middleware for API behavior and security policy.
+Historical `k8s/` and `.do/` deployment artifacts are not promoted into the INF-278 production path. They may be referenced as historical context, but they must not override the Droplet + host-Nginx contract.
+
+## Implementation Units
+
+The implementation plan must keep changes bounded to the following responsibilities:
+
+1. **HTTP runtime configuration** — introduce `APP_BIND_HOST`, loopback production trust, and the 1 MiB application parser contract without business logic.
+2. **Server listener** — consume `config.bindHost` when starting Express.
+3. **Nginx source contract** — split bootstrap/final vhosts, share proxy directives, remove protocol-upgrade headers, and encode body/TLS behavior.
+4. **Ingress contract tests** — verify runtime network/proxy/body behavior and tracked Nginx invariants.
+5. **Droplet verification** — extend the existing verifier for loopback listener and HTTP redirect evidence.
+6. **External deployment verification** — prove direct public port `3005` is unavailable from outside the Droplet.
+7. **Operational documentation** — document certificate bootstrap, renewal/reload, Nginx installation paths, verification, and rollback.
+
+No database model, migration, controller business flow, repository/service business rule, attendance policy, WFA policy, FAHP calculation, JWT contract, or public OpenAPI endpoint contract is redesigned by these units.
+
+## Acceptance Criteria
+
+Implementation is acceptable only when all of the following are true:
+
+- one public backend ingress remains: host Nginx;
+- Express listens on `127.0.0.1:3005` in production;
+- direct public access to port `3005` is unavailable;
+- Nginx proxies `api.infinite-track.tech` to loopback successfully;
+- `Host`, `X-Real-IP`, `X-Forwarded-For`, and `X-Forwarded-Proto` remain correctly forwarded;
+- Express trusts loopback rather than a numeric hop count;
+- real client IP and forwarded HTTPS protocol semantics are proven by tests;
+- unconditional `Upgrade` and `Connection: upgrade` headers are absent;
+- general API request bodies are explicitly limited to 1 MiB at Nginx and Express;
+- the two face-upload paths receive a 25 MiB Nginx envelope while Multer retains the 20 MiB file limit;
+- HTTP requests redirect to HTTPS after certificate bootstrap;
+- final HTTPS/TLS behavior is represented by tracked repository configuration rather than Certbot mutation;
+- certificate private keys remain outside Git;
+- CORS remains owned by Express;
+- `/livez` and `/health` still return from Express with existing semantics;
+- `/docs` and `/docs/openapi.yaml` retain their existing Express authentication/authorization behavior;
+- representative protected endpoints still reject anonymous callers;
+- Web FE credentialed session/CORS smoke remains successful;
+- representative Android API smoke remains successful;
+- `nginx -t` passes on the target host;
+- `npm run lint` passes;
+- the full non-integration `npm test` suite passes;
+- production smoke verification passes.
+
+## Non-Goals
+
+INF-278 does not:
+
+- remove backend Nginx;
+- move Nginx into Docker;
+- replace `network_mode: host` with a new Docker-network architecture;
+- migrate the backend to Kubernetes, App Platform, a load balancer, CDN, WAF, or service mesh;
+- introduce API response caching;
+- add WebSockets;
+- redesign authentication, authorization, CORS, session, or rate-limit semantics;
+- change API endpoint schemas or OpenAPI business contracts;
+- change attendance, geofence, WFA, FAHP, report, or user-management semantics;
+- change managed-MySQL topology;
+- store TLS private keys or production secrets in Git;
+- redesign Web FE infrastructure.
+## Minimum Completion Evidence
+
+The implementation PR must capture or reference evidence equivalent to:
+
+```text
+nginx -t: PASS
+public :80 redirect to HTTPS: PASS
+public :443 API ingress: PASS
+direct public :3005 access: BLOCKED
+Droplet listener 127.0.0.1:3005 only: PASS
+/livez: PASS
+/health: PASS
+protected endpoint anonymous rejection: PASS
+real client IP / forwarded protocol verification: PASS
+Web FE login/session + CORS smoke: PASS
+Android representative API smoke: PASS
+request-body boundary tests: PASS
+npm run lint: PASS
+npm test: PASS
+production smoke test: PASS
+```
+
+## Design Rationale
+
+This design deliberately hardens the current architecture instead of replacing it. The earlier Docker bridge DNS problem already forced the production runtime onto host networking, so moving ingress into Docker would reopen unrelated runtime risk. Loopback binding gives the current topology a concrete process-level boundary while the external negative port check verifies the public effect.
+
+Address-based proxy trust is preferred because the topology has a known trusted proxy source rather than an abstract hop count. Route-specific body envelopes preserve the legitimate 20 MiB face-upload capability without broadening every API route. Repository-managed final TLS configuration removes configuration drift while Certbot continues doing the job it is intended to do: certificate lifecycle.
+
+The result is a bounded infrastructure change: transport ownership becomes explicit while application behavior remains in Express.

--- a/src/app.js
+++ b/src/app.js
@@ -11,6 +11,7 @@ import { verifyToken } from './middlewares/authJwt.js';
 import { errorHandler } from './middlewares/errorHandler.js';
 import { requestLogger } from './middlewares/requestLogger.js';
 import roleGuard from './middlewares/roleGuard.js';
+import { configureProxyTrust } from './configureProxyTrust.js';
 import {
   securityHeaders,
   additionalSecurity,
@@ -20,9 +21,7 @@ import {
 
 const app = express();
 
-if (config.env === 'production') {
-  app.set('trust proxy', 1);
-}
+configureProxyTrust(app, config.env);
 
 // Validate CORS configuration on startup
 validateCorsOrigin();
@@ -50,8 +49,8 @@ app.use(
 );
 
 // Body parsing middlewares
-app.use(express.json({ limit: '10mb' })); // Limit payload size
-app.use(express.urlencoded({ extended: true, limit: '10mb' }));
+app.use(express.json({ limit: '1mb' }));
+app.use(express.urlencoded({ extended: true, limit: '1mb' }));
 app.use(cookieParser());
 app.use('/uploads', express.static('uploads'));
 

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -10,9 +10,15 @@ if (missingEnvVars.length > 0 && process.env.NODE_ENV === 'production') {
 
 const env = process.env.NODE_ENV || 'development';
 const corsOrigin = process.env.CORS_ORIGIN || (env === 'production' ? '' : '*');
+const bindHost = process.env.APP_BIND_HOST || (env === 'production' ? '127.0.0.1' : undefined);
+
+if (env === 'production' && bindHost !== '127.0.0.1') {
+  throw new Error('APP_BIND_HOST must be 127.0.0.1 in production');
+}
 
 export default {
   port: process.env.PORT || 3000,
+  bindHost,
   env,
   cors: {
     origin: corsOrigin,

--- a/src/configureProxyTrust.js
+++ b/src/configureProxyTrust.js
@@ -1,0 +1,7 @@
+export function configureProxyTrust(app, env) {
+  if (env === 'production') {
+    app.set('trust proxy', 'loopback');
+  }
+
+  return app;
+}

--- a/src/middlewares/validator.js
+++ b/src/middlewares/validator.js
@@ -6,12 +6,6 @@ import { assertFutureWibScheduleDate } from '../services/wfaEligibility.service.
 import { validateHistoricalDateWindowQuery } from '../utils/historicalDateWindow.js';
 import { assertSafeUrl } from '../utils/url.js';
 
-// Remove the file system setup as we're switching to Cloudinary
-// const uploadsDir = 'uploads/face/';
-// if (!fs.existsSync(uploadsDir)) {
-//   fs.mkdirSync(uploadsDir, { recursive: true });
-// }
-
 // Use memory storage instead of disk storage for Cloudinary
 const storage = multer.memoryStorage();
 

--- a/src/server.js
+++ b/src/server.js
@@ -44,10 +44,10 @@ import {
     }
   }
 
-  app.listen(config.port, () => {
+  app.listen(config.port, config.bindHost, () => {
     const readiness = getReadinessSnapshot();
 
-    logger.info(`Server 🚀 on port ${config.port}`);
+    logger.info(`Server 🚀 on ${config.bindHost || 'all interfaces'}:${config.port}`);
     if (readiness.ready) {
       logger.info('Startup dependencies are ready.');
     } else {
@@ -57,7 +57,7 @@ import {
       });
     }
 
-    console.log(`🚀 Server running on port ${config.port}`);
+    console.log(`🚀 Server running on ${config.bindHost || 'all interfaces'}:${config.port}`);
     if (!readiness.ready) {
       console.warn(`⚠️ Startup readiness failed: ${readiness.missing.join(', ')}`);
     }

--- a/tests/configContract.test.js
+++ b/tests/configContract.test.js
@@ -220,13 +220,12 @@ describe('backend runtime config contract', () => {
     expect(config.autoCheckout).toBeUndefined();
   });
 
-  test('declares droplet runtime contract with immutable DOCR image selection and env-file driven config', () => {
+  test('declares local production build runtime and env-file driven config', () => {
     const compose = readDockerCompose();
 
-    expect(compose).toContain(
-      'image: ${BACKEND_IMAGE:-registry.digitalocean.com/infinit-track/infinit-track-backend}:${BACKEND_IMAGE_TAG:?BACKEND_IMAGE_TAG is required}'
-    );
-    expect(compose).not.toContain('build:');
+    expect(compose).toContain('build:');
+    expect(compose).toContain('target: production');
+    expect(compose).toContain('image: infinit-track-backend:latest');
     expect(compose).not.toContain('network: host');
     expect(compose).toContain('network_mode: host');
     expect(compose).toContain('env_file:');

--- a/tests/configContract.test.js
+++ b/tests/configContract.test.js
@@ -220,12 +220,14 @@ describe('backend runtime config contract', () => {
     expect(config.autoCheckout).toBeUndefined();
   });
 
-  test('declares local production build runtime and env-file driven config', () => {
+  test('declares immutable DOCR production runtime and env-file driven config', () => {
     const compose = readDockerCompose();
 
-    expect(compose).toContain('build:');
-    expect(compose).toContain('target: production');
-    expect(compose).toContain('image: infinit-track-backend:latest');
+    expect(compose).toContain(
+      'image: ${BACKEND_IMAGE:-registry.digitalocean.com/infinit-track/infinit-track-backend}:${BACKEND_IMAGE_TAG:?BACKEND_IMAGE_TAG is required}'
+    );
+    expect(compose).not.toContain('build:');
+    expect(compose).not.toContain('infinit-track-backend:latest');
     expect(compose).not.toContain('network: host');
     expect(compose).toContain('network_mode: host');
     expect(compose).toContain('env_file:');

--- a/tests/inf278DeploymentVerificationContract.test.js
+++ b/tests/inf278DeploymentVerificationContract.test.js
@@ -1,0 +1,25 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = process.cwd();
+const readScript = (name) => fs.readFileSync(path.join(repoRoot, 'deploy/scripts', name), 'utf8');
+
+describe('INF-278 deployment verification contract', () => {
+  test('droplet verifier gates reload on syntax and proves loopback health/listener state', () => {
+    const script = readScript('verify-droplet-api.sh');
+
+    expect(script).toContain('nginx -t');
+    expect(script).toContain('127.0.0.1:3005');
+    expect(script).toMatch(/ss\s+-ltn/);
+    expect(script).toContain('PUBLIC_LIVEZ');
+    expect(script).toContain('PUBLIC_DOCS');
+  });
+
+  test('external verifier treats public port 3005 reachability as a release blocker', () => {
+    const script = readScript('verify-public-ingress.sh');
+
+    expect(script).toContain('PUBLIC_IP');
+    expect(script).toContain('3005');
+    expect(script).toMatch(/release blocker|must be blocked/i);
+  });
+});

--- a/tests/inf278DeploymentVerificationContract.test.js
+++ b/tests/inf278DeploymentVerificationContract.test.js
@@ -13,13 +13,40 @@ describe('INF-278 deployment verification contract', () => {
     expect(script).toMatch(/ss\s+-ltn/);
     expect(script).toContain('PUBLIC_LIVEZ');
     expect(script).toContain('PUBLIC_DOCS');
+    expect(script).toContain("$4 !~ /^127\\.0\\.0\\.1:3005$/");
+    expect(script).not.toContain('0\\.0\\.0\\.0:3005');
   });
 
   test('external verifier treats public port 3005 reachability as a release blocker', () => {
     const script = readScript('verify-public-ingress.sh');
 
     expect(script).toContain('PUBLIC_IP');
+    expect(script).toContain('DOMAIN');
     expect(script).toContain('3005');
+    expect(script).toContain('--noproxy');
+    expect(script).toMatch(/socket\.create_connection|nc\s+.*3005/);
+    expect(script).toContain('HTTP_REDIRECT');
+    expect(script).toContain('301');
     expect(script).toMatch(/release blocker|must be blocked/i);
+  });
+
+  test('production workflow runs the external ingress verifier before application smoke', () => {
+    const workflow = fs.readFileSync(
+      path.join(repoRoot, '.github/workflows/deploy-production.yml'),
+      'utf8'
+    );
+
+    expect(workflow).toContain('verify-public-ingress.sh');
+    expect(workflow).toMatch(/verify-public-ingress\.sh[\s\S]*npm run smoke-test/);
+  });
+
+  test('documents the external verifier domain and public IP inputs', () => {
+    const guide = fs.readFileSync(
+      path.join(repoRoot, 'docs/PRODUCTION_NGINX_INGRESS.md'),
+      'utf8'
+    );
+
+    expect(guide).toContain('DOMAIN=api.infinite-track.tech PUBLIC_IP=<droplet-ip>');
+    expect(guide).toContain('return `301` to the HTTPS domain');
   });
 });

--- a/tests/inf278IngressRuntimeContract.test.js
+++ b/tests/inf278IngressRuntimeContract.test.js
@@ -1,0 +1,74 @@
+import { execFileSync } from 'node:child_process';
+import express from 'express';
+import request from 'supertest';
+
+const repoRoot = process.cwd();
+
+function readConfigInChild(envOverrides = {}) {
+  const env = {
+    ...process.env,
+    NODE_ENV: 'production',
+    JWT_SECRET: 'test-secret',
+    DB_HOST: 'db.example.internal',
+    DB_NAME: 'infinite_track',
+    DB_USER: 'trackuser',
+    DB_PASS: 'trackpass',
+    CORS_ORIGIN: 'https://web.example.test',
+    PORT: '3005',
+    ...envOverrides
+  };
+
+  return JSON.parse(
+    execFileSync(
+      process.execPath,
+      ['--input-type=module', '-e', "import config from './src/config/index.js'; console.log(JSON.stringify({ bindHost: config.bindHost, port: config.port }))"],
+      { cwd: repoRoot, env, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }
+    )
+  );
+}
+
+describe('INF-278 runtime ingress contract', () => {
+  test('defaults production listener to loopback and rejects a public bind host', () => {
+    expect(readConfigInChild()).toEqual({ bindHost: '127.0.0.1', port: '3005' });
+
+    expect(() => readConfigInChild({ APP_BIND_HOST: '0.0.0.0' })).toThrow(
+      /APP_BIND_HOST.*127\.0\.0\.1/
+    );
+  });
+
+  test('trusts forwarded client IP and HTTPS protocol only through loopback', async () => {
+    const { configureProxyTrust } = await import('../src/configureProxyTrust.js');
+    const app = express();
+    configureProxyTrust(app, 'production');
+    app.get('/probe', (req, res) => res.json({ ip: req.ip, protocol: req.protocol }));
+
+    await request(app)
+      .get('/probe')
+      .set('X-Forwarded-For', '203.0.113.44')
+      .set('X-Forwarded-Proto', 'https')
+      .expect(200, { ip: '203.0.113.44', protocol: 'https' });
+
+    const nonProduction = express();
+    configureProxyTrust(nonProduction, 'test');
+    expect(nonProduction.get('trust proxy')).toBe(false);
+  });
+
+  test('limits ordinary JSON and URL-encoded bodies to 1 MiB', async () => {
+    const app = express();
+    app.use(express.json({ limit: '1mb' }));
+    app.use(express.urlencoded({ extended: true, limit: '1mb' }));
+    app.post('/probe', (_req, res) => res.sendStatus(204));
+
+    await request(app)
+      .post('/probe')
+      .set('Content-Type', 'application/json')
+      .send({ payload: 'x'.repeat(1024) })
+      .expect(204);
+
+    await request(app)
+      .post('/probe')
+      .set('Content-Type', 'application/json')
+      .send({ payload: 'x'.repeat(1024 * 1024) })
+      .expect(413);
+  });
+});

--- a/tests/inf278IngressRuntimeContract.test.js
+++ b/tests/inf278IngressRuntimeContract.test.js
@@ -1,6 +1,7 @@
 import { execFileSync } from 'node:child_process';
-import express from 'express';
 import request from 'supertest';
+
+const { default: app } = await import('../src/app.js');
 
 const repoRoot = process.cwd();
 
@@ -37,6 +38,7 @@ describe('INF-278 runtime ingress contract', () => {
   });
 
   test('trusts forwarded client IP and HTTPS protocol only through loopback', async () => {
+    const { default: express } = await import('express');
     const { configureProxyTrust } = await import('../src/configureProxyTrust.js');
     const app = express();
     configureProxyTrust(app, 'production');
@@ -54,21 +56,22 @@ describe('INF-278 runtime ingress contract', () => {
   });
 
   test('limits ordinary JSON and URL-encoded bodies to 1 MiB', async () => {
-    const app = express();
-    app.use(express.json({ limit: '1mb' }));
-    app.use(express.urlencoded({ extended: true, limit: '1mb' }));
-    app.post('/probe', (_req, res) => res.sendStatus(204));
-
     await request(app)
-      .post('/probe')
+      .post('/livez')
       .set('Content-Type', 'application/json')
       .send({ payload: 'x'.repeat(1024) })
-      .expect(204);
+      .expect(404);
 
     await request(app)
-      .post('/probe')
+      .post('/livez')
       .set('Content-Type', 'application/json')
       .send({ payload: 'x'.repeat(1024 * 1024) })
+      .expect(413);
+
+    await request(app)
+      .post('/livez')
+      .set('Content-Type', 'application/x-www-form-urlencoded')
+      .send(`payload=${'x'.repeat(1024 * 1024)}`)
       .expect(413);
   });
 });

--- a/tests/inf278NginxContract.test.js
+++ b/tests/inf278NginxContract.test.js
@@ -3,6 +3,10 @@ import path from 'node:path';
 
 const repoRoot = process.cwd();
 const nginxRoot = path.join(repoRoot, 'deploy/nginx');
+const ingressGuide = fs.readFileSync(
+  path.join(repoRoot, 'docs/PRODUCTION_NGINX_INGRESS.md'),
+  'utf8'
+);
 const read = (file) => fs.readFileSync(path.join(nginxRoot, file), 'utf8').replace(/\r\n/g, '\n');
 
 describe('INF-278 tracked Nginx ingress contract', () => {
@@ -25,8 +29,15 @@ describe('INF-278 tracked Nginx ingress contract', () => {
     const snippet = read('snippets/infinite-track-api-proxy.conf');
 
     expect(finalVhost).toContain('client_max_body_size 1m;');
-    expect(finalVhost).toMatch(/location = \/api\/users\s*\{[\s\S]*client_max_body_size 25m;/);
-    expect(finalVhost).toMatch(/location ~ \^\/api\/users\/[^ ]+\/photo\$\s*\{[\s\S]*client_max_body_size 25m;/);
+    expect(finalVhost).toMatch(/location ~ \^\/api\/users\/\?\$\s*\{[\s\S]*client_max_body_size 25m;/);
+    expect(finalVhost).toMatch(/location ~ \^\/api\/users\/\[\^\/\]\+\/photo\/\?\$\s*\{[\s\S]*client_max_body_size 25m;/);
     expect(`${finalVhost}\n${snippet}`).not.toMatch(/proxy_set_header\s+(Upgrade|Connection)\b/);
+  });
+
+  test('documents installing the shared snippet before enabling the vhost', () => {
+    expect(ingressGuide).toContain(
+      'sudo install -D -m 0644 deploy/nginx/snippets/infinite-track-api-proxy.conf'
+    );
+    expect(ingressGuide).toContain('/etc/nginx/snippets/infinite-track-api-proxy.conf');
   });
 });

--- a/tests/inf278NginxContract.test.js
+++ b/tests/inf278NginxContract.test.js
@@ -1,0 +1,32 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = process.cwd();
+const nginxRoot = path.join(repoRoot, 'deploy/nginx');
+const read = (file) => fs.readFileSync(path.join(nginxRoot, file), 'utf8').replace(/\r\n/g, '\n');
+
+describe('INF-278 tracked Nginx ingress contract', () => {
+  test('tracks bootstrap and final vhosts with shared proxy directives', () => {
+    const bootstrap = read('api.infinite-track.tech.bootstrap.conf');
+    const finalVhost = read('api.infinite-track.tech.conf');
+    const snippet = read('snippets/infinite-track-api-proxy.conf');
+
+    expect(bootstrap).toContain('location /.well-known/acme-challenge/');
+    expect(finalVhost).toContain('return 301 https://$host$request_uri;');
+    expect(finalVhost).toContain('listen 443 ssl;');
+    expect(finalVhost).toContain('ssl_protocols TLSv1.2 TLSv1.3;');
+    expect(finalVhost).toContain('include snippets/infinite-track-api-proxy.conf;');
+    expect(snippet).toContain('proxy_pass http://127.0.0.1:3005;');
+    expect(snippet).toContain('proxy_set_header X-Forwarded-Proto $scheme;');
+  });
+
+  test('uses narrow transport envelopes and no unconditional upgrade headers', () => {
+    const finalVhost = read('api.infinite-track.tech.conf');
+    const snippet = read('snippets/infinite-track-api-proxy.conf');
+
+    expect(finalVhost).toContain('client_max_body_size 1m;');
+    expect(finalVhost).toMatch(/location = \/api\/users\s*\{[\s\S]*client_max_body_size 25m;/);
+    expect(finalVhost).toMatch(/location ~ \^\/api\/users\/[^ ]+\/photo\$\s*\{[\s\S]*client_max_body_size 25m;/);
+    expect(`${finalVhost}\n${snippet}`).not.toMatch(/proxy_set_header\s+(Upgrade|Connection)\b/);
+  });
+});


### PR DESCRIPTION
## Summary

- harden the production Nginx ingress and Express listener contract
- bind production Express to loopback, use explicit loopback proxy trust, and enforce 1 MiB general request bodies
- add tracked bootstrap/final Nginx vhosts, shared proxy directives, TLS/redirect configuration, and 25 MiB face-upload envelopes
- restore the immutable DOCR Compose runtime contract
- document shared Nginx snippet installation and cover optional trailing-slash upload routes
- enforce strict loopback listener verification for every port 3005 listener
- add external TCP/HTTP negative verification, HTTP→HTTPS redirect verification, and a blocking production workflow gate
- add deployment and runtime contract tests against the real Express app

## Why

The previous ingress contract relied on an implicit listener bind, numeric proxy-hop trust, unconditional upgrade headers, and a tracked HTTP-only vhost that depended on Certbot mutation. The audit also identified a Compose regression to a local `latest` build, an undocumented Nginx snippet dependency, trailing-slash body-limit gaps, incomplete listener/external probes, and tests that did not exercise the exported app. This PR closes those gaps while preserving Express ownership of auth, CORS, health, and business behavior.

## Validation

- `npm run lint`
- `npm test -- --runInBand` — 161 suites, 1,540 tests
- focused INF-278 deployment verification — 4 tests
- `docker compose config --quiet` with the production example env
- `git diff --check`
- Git Bash `bash -n` for both verification scripts

## Production evidence still required

- `nginx -t` on the Droplet
- public port 80 redirect and port 443 ingress
- direct public port 3005 blocked
- loopback-only listener inspection
- Web FE credentialed CORS/session smoke
- representative Android API smoke
- production smoke verification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added hardened production ingress with HTTPS, HTTP-to-HTTPS redirects, ACME certificate support, and controlled API proxying.
  - Restricted the backend to loopback access and added request-size limits, including larger limits for account creation and photo uploads.
  - Added deployment checks to verify local-only backend access and block direct public access.

- **Documentation**
  - Added production ingress setup, verification, rollback, and deployment guidance.

- **Tests**
  - Added coverage for listener binding, proxy trust, request limits, Nginx configuration, and deployment verification.

<!-- end of CodeRabbit summary -->