### PR TITLE
[INF-282] Stop publishing rolling DOCR tag in production

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -83,7 +83,6 @@ jobs:
           context: .
           push: true
           tags: |
-            ${{ env.DOCKER_IMAGE }}:latest
             ${{ env.DOCKER_IMAGE }}:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/tests/productionWorkflowImageTags.test.js
+++ b/tests/productionWorkflowImageTags.test.js
@@ -1,0 +1,14 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const productionWorkflowPath = path.join(repositoryRoot, '.github', 'workflows', 'deploy-production.yml');
+
+test('production image publication uses only the immutable commit tag', () => {
+  const workflow = fs.readFileSync(productionWorkflowPath, 'utf8');
+
+  expect(workflow).toContain('${{ env.DOCKER_IMAGE }}:${{ github.sha }}');
+  expect(workflow).not.toMatch(/\$\{\{\s*env\.DOCKER_IMAGE\s*\}\}:latest/);
+  expect(workflow).not.toContain('Published rolling tag');
+});


### PR DESCRIPTION
## Linear
INF-282 — Production deploy CI fix

## Root cause
Production `Build & Push Docker Image` reached Docker build successfully but DOCR rejected the rolling `:latest` push with `denied: quota exceeded` in run 32594784253. The droplet deployment already selects the immutable `${GITHUB_SHA}` tag through `BACKEND_IMAGE_TAG`, so the rolling tag was unnecessary.

## Fix
- Remove the `:latest` tag from `.github/workflows/deploy-production.yml`.
- Keep only `registry.digitalocean.com/infinit-track/infinit-track-backend:${GITHUB_SHA}`.
- Add a regression contract test preventing production from reintroducing the rolling tag.

## Verification
- TDD regression: red before workflow change, green after.
- `npm run lint`: PASS
- focused workflow/runtime/deployment contracts: 12/12 PASS
- `git diff --check`: PASS

Base is merged INF-282 master commit `7ff3b71c81f9e674cb7a78bcd5a45c996ab5cbe6`. Production deployment should remain blocked until this PR's required checks and review pass.
