### PR TITLE
[INF-282] Persist production image tag across restarts

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -143,6 +143,7 @@ jobs:
         run: |
           set -euo pipefail
           tar -czf - docker-compose.yml deploy/scripts/verify-droplet-api.sh \
+            deploy/scripts/persist-backend-image-tag.sh \
             | ssh -i "$HOME/.ssh/production.key" -o IdentitiesOnly=yes "$PRODUCTION_SSH_USER@$PRODUCTION_SSH_HOST" "
                 set -euo pipefail
                 mkdir -p '$PRODUCTION_DEPLOY_PATH/deploy/scripts'
@@ -155,8 +156,10 @@ jobs:
             set -euo pipefail
             cd '$PRODUCTION_DEPLOY_PATH'
             echo '${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}' | docker login registry.digitalocean.com -u doctl --password-stdin
+            chmod +x ./deploy/scripts/persist-backend-image-tag.sh
+            ./deploy/scripts/persist-backend-image-tag.sh .env "${GITHUB_SHA}"
+            grep -qx "BACKEND_IMAGE_TAG=${GITHUB_SHA}" .env
             export BACKEND_IMAGE="${DOCKER_IMAGE}"
-            export BACKEND_IMAGE_TAG="${GITHUB_SHA}"
             docker compose pull app
             docker compose up -d --force-recreate app
             docker compose exec -T app npm run migrate

--- a/deploy/scripts/persist-backend-image-tag.sh
+++ b/deploy/scripts/persist-backend-image-tag.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENV_FILE="${1:-}"
+IMAGE_TAG="${2:-}"
+
+if [[ -z "$ENV_FILE" || ! -f "$ENV_FILE" ]]; then
+  echo "Environment file does not exist: $ENV_FILE" >&2
+  exit 1
+fi
+
+if [[ ! "$IMAGE_TAG" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "Backend image tag must be a 40-character lowercase Git SHA." >&2
+  exit 1
+fi
+
+TEMP_FILE="$(mktemp "${ENV_FILE}.tmp.XXXXXX")"
+trap 'rm -f "$TEMP_FILE"' EXIT
+
+cp -p "$ENV_FILE" "$TEMP_FILE"
+awk -v image_tag="$IMAGE_TAG" '
+  BEGIN { persisted = 0 }
+  /^BACKEND_IMAGE_TAG=/ {
+    if (!persisted) {
+      print "BACKEND_IMAGE_TAG=" image_tag
+      persisted = 1
+    }
+    next
+  }
+  { print }
+  END {
+    if (!persisted) {
+      print "BACKEND_IMAGE_TAG=" image_tag
+    }
+  }
+' "$ENV_FILE" > "$TEMP_FILE"
+
+mv "$TEMP_FILE" "$ENV_FILE"
+trap - EXIT
+
+grep -qx "BACKEND_IMAGE_TAG=${IMAGE_TAG}" "$ENV_FILE"

--- a/tests/persistBackendImageTagScript.test.js
+++ b/tests/persistBackendImageTagScript.test.js
@@ -1,0 +1,68 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const scriptPath = path.join(repositoryRoot, 'deploy', 'scripts', 'persist-backend-image-tag.sh');
+
+const resolveBash = () => {
+  if (process.platform !== 'win32') {
+    return 'bash';
+  }
+
+  const candidates = [
+    'C:\\Program Files\\Git\\bin\\bash.exe',
+    'C:\\Program Files\\Git\\usr\\bin\\bash.exe',
+  ];
+
+  return candidates.find((candidate) => fs.existsSync(candidate)) ?? 'bash';
+};
+
+const toBashPath = (value) => {
+  if (process.platform !== 'win32') {
+    return value;
+  }
+
+  return value
+    .replace(/^([A-Za-z]):\\/, (_, drive) => `/${drive.toLowerCase()}/`)
+    .replaceAll('\\', '/');
+};
+
+test('persisted backend image tag survives a future Docker Compose restart', () => {
+  const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'backend-image-tag-'));
+  const environmentPath = path.join(temporaryDirectory, '.env');
+  const releaseSha = '555f9b2a160c93b5e535aaefb07445b9ae98b884';
+
+  fs.writeFileSync(
+    environmentPath,
+    [
+      'NODE_ENV=production',
+      'BACKEND_IMAGE_TAG=1b16d917f4fdaccc8ed4f053ce152b0dab0ef15f',
+      'CORS_ORIGIN=https://infinite-track.tech',
+      '',
+    ].join('\n'),
+  );
+
+  try {
+    const result = spawnSync(
+      resolveBash(),
+      [toBashPath(scriptPath), toBashPath(environmentPath), releaseSha],
+      { encoding: 'utf8' },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(fs.readFileSync(environmentPath, 'utf8')).toBe(
+      [
+        'NODE_ENV=production',
+        `BACKEND_IMAGE_TAG=${releaseSha}`,
+        'CORS_ORIGIN=https://infinite-track.tech',
+        '',
+      ].join('\n'),
+    );
+  } finally {
+    fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+});

--- a/tests/productionWorkflowImageTags.test.js
+++ b/tests/productionWorkflowImageTags.test.js
@@ -12,3 +12,16 @@ test('production image publication uses only the immutable commit tag', () => {
   expect(workflow).not.toMatch(/\$\{\{\s*env\.DOCKER_IMAGE\s*\}\}:latest/);
   expect(workflow).not.toContain('Published rolling tag');
 });
+
+test('production deployment persists the immutable tag before recreating the app', () => {
+  const workflow = fs.readFileSync(productionWorkflowPath, 'utf8');
+  const persistTagIndex = workflow.indexOf(
+    './deploy/scripts/persist-backend-image-tag.sh .env "${GITHUB_SHA}"',
+  );
+  const recreateAppIndex = workflow.indexOf('docker compose up -d --force-recreate app');
+
+  expect(persistTagIndex).toBeGreaterThan(-1);
+  expect(recreateAppIndex).toBeGreaterThan(persistTagIndex);
+  expect(workflow).toContain('grep -qx "BACKEND_IMAGE_TAG=${GITHUB_SHA}" .env');
+  expect(workflow).not.toContain('export BACKEND_IMAGE_TAG="${GITHUB_SHA}"');
+});


### PR DESCRIPTION
## Summary
- persist the selected immutable production image SHA in the Droplet `.env` before Docker Compose recreation
- replace the process-only `BACKEND_IMAGE_TAG` export with a validated, atomic persistence helper
- verify persistence in the deployment workflow and add regression coverage for restart durability

## Root cause
The production workflow exported `BACKEND_IMAGE_TAG=$GITHUB_SHA` only inside one SSH process. Docker Compose used the new image for that deployment, but `/opt/infinite-track/backend/.env` retained the previous tag, so a later restart could silently roll back.

## Verification
- `npm run lint`
- `bash -n deploy/scripts/persist-backend-image-tag.sh`
- focused Jest: 3/3 tests passed
- full Jest: 164/164 suites, 1551/1551 tests passed
- production run 32614098124 attempt 2 succeeded before this durability fix; independent verification exposed the stale persisted tag